### PR TITLE
Add note to README specifying Java dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ To install PolyFile from source, in the same directory as this README, run:
 pip3 install -e .
 ```
 
+Important: Before installing from source, make sure Java is installed. Java is used to
+run the Kaitai Struct compiler, which compiles the file format definitions.
+
 This will automatically install the `polyfile` and `polymerge` executables in your path.
 
 ## Usage


### PR DESCRIPTION
While installing polyfile from source for the first time, I ran into an issue: after running `pip install -e .`, running `polyfile` would result in an error.

When running `pip install -e .` for the first time, `setup.py` would try to recompile all the KSY definitions. Since I didn't have Java installed on my system, the `kaitai-struct-compiler` would fail on every invocation and that would result in an empty `polyfile/kaitai/parsers/manifest.json`, which lead to the error seen when running `polyfile`.

This adds a note to the README to clarify that.
