### PR TITLE
Fix AttributeError when writing to sbud or json

### DIFF
--- a/polyfile/__main__.py
+++ b/polyfile/__main__.py
@@ -376,7 +376,7 @@ equivalent to `--format mime`"""))
                     assert needs_sbud
                     json.dump(sbud, output)
                     if not output_format.output_to_stdout:
-                        log.info(f"Saved {output_format.upper()} output to {output_format.output_path}")
+                        log.info(f"Saved {output_format.output_format.upper()} output to {output_format.output_path}")
                 elif output_format.output_format == "html":
                     assert needs_sbud
                     output.write(html.generate(file_path, sbud))


### PR DESCRIPTION
It appears that during the changes made in this commit https://github.com/trailofbits/polyfile/commit/e950930e3d54a251c065ccf0ea3220dc7e97b457 the regression was introduced.

Essentially, the type of `output_format` changed from a `str` to an `argparse.Namespace` type (because the argparse flow was changed) - meaning that the string value was now contained in `output_format.output_format`. It would appear that this one was overlooked.

For reference, see the git-blame before-and-after here:

* https://github.com/trailofbits/polyfile/blame/71cc742a5195c8b659fe10413dfc66b8eafbffc8/polyfile/__main__.py#L263
* https://github.com/trailofbits/polyfile/blame/438628fea2d32ee97b9f23a7aef7ffa3fdc80a0a/polyfile/__main__.py#L379