### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/polyfile/kaitai/parsers/minecraft_nbt.py
+++ b/polyfile/kaitai/parsers/minecraft_nbt.py
@@ -13,14 +13,14 @@ if parse_version(kaitaistruct.__version__) < parse_version('0.9'):
 class MinecraftNbt(KaitaiStruct):
     """A structured binary format native to Minecraft for saving game data and transferring
     it over the network (in multiplayer), such as player data
-    ([`<player>.dat`](https://minecraft.fandom.com/wiki/Player.dat_format); contains
+    ([`<player>.dat`](https://minecraft.wiki/w/Player.dat_format); contains
     e.g. player's inventory and location), saved worlds
     ([`level.dat`](
-      https://minecraft.fandom.com/wiki/Java_Edition_level_format#level.dat_format
-    ) and [Chunk format](https://minecraft.fandom.com/wiki/Chunk_format#NBT_structure)),
+      https://minecraft.wiki/w/Java_Edition_level_format#level.dat_format
+    ) and [Chunk format](https://minecraft.wiki/w/Chunk_format#NBT_structure)),
     list of saved multiplayer servers
-    ([`servers.dat`](https://minecraft.fandom.com/wiki/Servers.dat_format)) and so on -
-    see <https://minecraft.fandom.com/wiki/NBT_format#Uses>.
+    ([`servers.dat`](https://minecraft.wiki/w/Servers.dat_format)) and so on -
+    see <https://minecraft.wiki/w/NBT_format#Uses>.
     
     The entire file should be _gzip_-compressed (in accordance with the original
     specification [NBT.txt](


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki