### PR TITLE
fix(magic): handle null encoding to prevent decode TypeError

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -2600,7 +2600,7 @@ class PlainTextTest(MagicTest):
             detector.feed(data[offset:offset+1024])
             offset += 1024
         detector.close()
-        if detector.result["confidence"] >= self.minimum_encoding_confidence:
+        if detector.result["confidence"] >= self.minimum_encoding_confidence and detector.result["encoding"] is not None:
             encoding = detector.result["encoding"]
             try:
                 value = data[absolute_offset:].decode(encoding)


### PR DESCRIPTION
This PR fixes a `TypeError` that occurs when PolyFile processes certain binary files (specifically observed with PNG, JPG, and GIF images).

The Problem: In `polyfile/magic.py`, the `PlainTextTest.test` method uses `chardet.UniversalDetector` to guess the encoding of a file. In some cases, the detector returns a confidence score higher than the minimum threshold but sets the `encoding` result to `None`.

When this happens, the following line triggers a crash because `decode()` expects a string:

```python
value = data[absolute_offset:].decode(encoding)  # encoding is None
```

The Fix: Added a check to ensure `detector.result["encoding"]` is not `None` before attempting to use it for decoding. If it is `None`, the test correctly falls back to a `FailedTest`, allowing PolyFile to continue its analysis instead of exiting with a traceback.

Verification: Verified by running `polyfile` against several image files that previously triggered the crash. The analysis now completes successfully for all files.