### PR TITLE
[temporary] CI baseline probe - do not merge

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "Pillow>=5.0.0",
         "pyreadline3;platform_system=='Windows'",
         "pyyaml>=3.13",
-        "setuptools>=65.5.1"
+        "setuptools>=83.0.0"
     ],
     extras_require={
         'demangle': ['cxxfilt'],


### PR DESCRIPTION
Temporary probe: master plus only the setuptools>=83.0.0 bump, to establish whether tests/test_corkami.py::CorkamiDifferentialTests::test_imports_iatindesc_asm already fails on master once pip-audit stops blocking the pytest step. Will be closed and the branch deleted as soon as the run finishes.