### PR TITLE
Locate ZIP records relative to the start of the archive

### DIFF
--- a/polyfile/zipmatcher.py
+++ b/polyfile/zipmatcher.py
@@ -98,9 +98,23 @@ class CentralDirectory(PolyFileStruct):
     extra_field: ByteField["extra_field_length"]
     file_comment: ByteField["file_comment_length"]
 
+    archive_offset: int = 0
+    """Byte offset at which the containing archive starts within the file."""
+
     def local_file_header(self, stream: FileStream) -> LocalFileHeader:
+        """Reads the local file header that this central directory record points to.
+
+        The record stores the header offset relative to the start of the archive, so
+        :attr:`archive_offset` is added to locate the header inside ``stream``.
+
+        Args:
+            stream: The stream containing the whole file, not only the archive.
+
+        Returns:
+            The local file header for this record.
+        """
         with stream.save_pos():
-            stream.seek(self.file_header_offset)
+            stream.seek(self.archive_offset + self.file_header_offset)
             return LocalFileHeader.read(stream)
 
 
@@ -117,14 +131,41 @@ class EndOfCentralDirectory(PolyFileStruct):
     comment_length: UInt16
     comment: ByteField["comment_length"]
 
+    @property
+    def archive_offset(self) -> int:
+        """Byte offset at which the archive starts within the file.
+
+        ZIP records store offsets relative to the start of the archive, but an archive can
+        be appended to other data, as in a polyglot or a self-extracting executable. The
+        end of central directory record sits immediately after the central directory, so
+        subtracting the central directory size and its recorded offset from the position of
+        the record itself yields the length of whatever precedes the archive.
+
+        Returns:
+            The number of bytes that precede the archive, or 0 if the record is malformed.
+        """
+        offset = self.start_offset - self.central_directory_bytes - self.central_directory_offset
+        return max(offset, 0)
+
     def central_directories(self, file_stream: FileStream) -> Iterator[CentralDirectory]:
+        """Iterates over the central directory records of this archive.
+
+        Args:
+            file_stream: The stream containing the whole file, not only the archive.
+
+        Yields:
+            Each central directory record, with :attr:`CentralDirectory.archive_offset` set
+            so that its local file header can be located.
+        """
+        archive_offset = self.archive_offset
         with file_stream.save_pos() as f:
-            cdo = self.central_directory_offset
+            cdo = archive_offset + self.central_directory_offset
             while cdo < self.start_offset:
                 f.seek(cdo)
                 cd = CentralDirectory.read(f)
                 if cd is None:
                     break
+                cd.archive_offset = archive_offset
                 yield cd
                 cdo += cd.num_bytes
 

--- a/tests/test_zipmatcher.py
+++ b/tests/test_zipmatcher.py
@@ -1,0 +1,91 @@
+from io import BytesIO
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Dict, List
+from unittest import TestCase
+import zipfile
+
+from polyfile.fileutils import FileStream
+from polyfile.polyfile import Match, Matcher
+from polyfile.zipmatcher import EndOfCentralDirectory, parse_zip
+
+MEMBERS: Dict[str, bytes] = {
+    "first.txt": b"the first member of the archive\n",
+    "nested/second.txt": b"the second member of the archive\n",
+}
+
+# A minimal but valid PNG, so the prepended data is a real file type rather than filler:
+PNG = (
+    b"\x89PNG\r\n\x1a\n"
+    b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+    b"\x00\x00\x00\nIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01\r\n-\xb4"
+    b"\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+def build_zip(prefix: bytes = b"") -> bytes:
+    """Builds a ZIP archive, optionally appended to unrelated leading data.
+
+    Args:
+        prefix: Bytes to place before the archive, as in a polyglot file.
+
+    Returns:
+        The contents of the resulting file.
+    """
+    buffer = BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name, content in MEMBERS.items():
+            archive.writestr(name, content)
+    return prefix + buffer.getvalue()
+
+
+class TestZipMatcher(TestCase):
+    def member_names(self, data: bytes) -> List[bytes]:
+        with FileStream(data) as stream:
+            eocd = EndOfCentralDirectory.load(stream)
+            self.assertIsNotNone(eocd)
+            return [
+                cd.local_file_header(stream).file_name for cd in eocd.central_directories(stream)
+            ]
+
+    def test_archive_offset(self):
+        with FileStream(build_zip()) as stream:
+            self.assertEqual(0, EndOfCentralDirectory.load(stream).archive_offset)
+        with FileStream(build_zip(PNG)) as stream:
+            self.assertEqual(len(PNG), EndOfCentralDirectory.load(stream).archive_offset)
+
+    def test_members_at_offset_zero(self):
+        expected = [name.encode("utf-8") for name in MEMBERS]
+        self.assertEqual(expected, self.member_names(build_zip()))
+
+    def test_members_with_prepended_data(self):
+        """Regression test for #3364.
+
+        Before the fix, the offsets recorded in the central directory were used as absolute
+        file offsets, so every read landed inside the prepended PNG and raised a StructError.
+        """
+        expected = [name.encode("utf-8") for name in MEMBERS]
+        self.assertEqual(expected, self.member_names(build_zip(PNG)))
+
+    def parsed_names(self, data: bytes) -> List[str]:
+        parent = Match("application/zip", None, 0, length=len(data), matcher=Matcher(parse=False))
+        with NamedTemporaryFile("wb", suffix=".bin", delete=False) as f:
+            f.write(data)
+            path = Path(f.name)
+        try:
+            with FileStream(str(path)) as stream:
+                return [match.name for match in parse_zip(stream, parent)]
+        finally:
+            path.unlink()
+
+    def test_parse_zip_with_prepended_data(self):
+        names = self.parsed_names(build_zip(PNG))
+        self.assertEqual(len(MEMBERS), names.count("LocalFileHeader"))
+        self.assertEqual(len(MEMBERS), names.count("CentralDirectory"))
+        self.assertEqual(1, names.count("EndOfCentralDirectory"))
+
+    def test_parse_zip_at_offset_zero(self):
+        names = self.parsed_names(build_zip())
+        self.assertEqual(len(MEMBERS), names.count("LocalFileHeader"))
+        self.assertEqual(len(MEMBERS), names.count("CentralDirectory"))
+        self.assertEqual(1, names.count("EndOfCentralDirectory"))

--- a/tests/test_zipmatcher.py
+++ b/tests/test_zipmatcher.py
@@ -1,11 +1,13 @@
+from contextlib import contextmanager
 from io import BytesIO
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Dict, List
+from typing import Dict, Iterator, List, Optional, Set
 from unittest import TestCase
 import zipfile
 
 from polyfile.fileutils import FileStream
+from polyfile.magic import MagicMatcher, MatchContext
 from polyfile.polyfile import Match, Matcher
 from polyfile.zipmatcher import EndOfCentralDirectory, parse_zip
 
@@ -13,6 +15,8 @@ MEMBERS: Dict[str, bytes] = {
     "first.txt": b"the first member of the archive\n",
     "nested/second.txt": b"the second member of the archive\n",
 }
+
+MANIFEST: Dict[str, bytes] = {"META-INF/MANIFEST.MF": b"Manifest-Version: 1.0\n\n"}
 
 # A minimal but valid PNG, so the prepended data is a real file type rather than filler:
 PNG = (
@@ -23,35 +27,71 @@ PNG = (
 )
 
 
-def build_zip(prefix: bytes = b"") -> bytes:
+def build_zip(prefix: bytes = b"", members: Optional[Dict[str, bytes]] = None) -> bytes:
     """Builds a ZIP archive, optionally appended to unrelated leading data.
 
     Args:
         prefix: Bytes to place before the archive, as in a polyglot file.
+        members: The archive members to write, defaulting to :data:`MEMBERS`.
 
     Returns:
         The contents of the resulting file.
     """
+    if members is None:
+        members = MEMBERS
     buffer = BytesIO()
     with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
-        for name, content in MEMBERS.items():
+        for name, content in members.items():
             archive.writestr(name, content)
     return prefix + buffer.getvalue()
 
 
+@contextmanager
+def temporary_file(data: bytes) -> Iterator[Path]:
+    """Writes bytes to a temporary file that is removed when the context exits."""
+    with NamedTemporaryFile("wb", suffix=".bin", delete=False) as f:
+        f.write(data)
+        path = Path(f.name)
+    try:
+        yield path
+    finally:
+        path.unlink()
+
+
 class TestZipMatcher(TestCase):
     def member_names(self, data: bytes) -> List[bytes]:
-        with FileStream(data) as stream:
+        with temporary_file(data) as path, FileStream(str(path)) as stream:
             eocd = EndOfCentralDirectory.load(stream)
             self.assertIsNotNone(eocd)
             return [
                 cd.local_file_header(stream).file_name for cd in eocd.central_directories(stream)
             ]
 
+    def parsed_names(self, data: bytes) -> List[str]:
+        parent = Match("application/zip", None, 0, length=len(data), matcher=Matcher(parse=False))
+        with temporary_file(data) as path, FileStream(str(path)) as stream:
+            return [match.name for match in parse_zip(stream, parent)]
+
+    def matched_mime_types(self, data: bytes) -> Set[str]:
+        with temporary_file(data) as path, FileStream(str(path)) as stream:
+            context = MatchContext.load(stream, only_match_mime=True)
+            return {
+                result.test.mime.resolve(context)
+                for match in MagicMatcher.DEFAULT_INSTANCE.match(context)
+                for result in match
+                if result.test.mime is not None
+            }
+
+    def assert_structure_parsed(self, data: bytes):
+        names = self.parsed_names(data)
+        self.assertEqual(len(MEMBERS), names.count("LocalFileHeader"))
+        self.assertEqual(len(MEMBERS), names.count("CentralDirectory"))
+        self.assertEqual(1, names.count("EndOfCentralDirectory"))
+
     def test_archive_offset(self):
-        with FileStream(build_zip()) as stream:
+        with temporary_file(build_zip()) as path, FileStream(str(path)) as stream:
             self.assertEqual(0, EndOfCentralDirectory.load(stream).archive_offset)
-        with FileStream(build_zip(PNG)) as stream:
+        with temporary_file(build_zip(PNG)) as path, FileStream(str(path)) as stream:
             self.assertEqual(len(PNG), EndOfCentralDirectory.load(stream).archive_offset)
 
     def test_members_at_offset_zero(self):
@@ -61,31 +101,22 @@ class TestZipMatcher(TestCase):
     def test_members_with_prepended_data(self):
         """Regression test for #3364.
 
-        Before the fix, the offsets recorded in the central directory were used as absolute
-        file offsets, so every read landed inside the prepended PNG and raised a StructError.
+        Before the fix, offsets recorded in the central directory were used as absolute file
+        offsets, so every read landed inside the prepended PNG and raised a StructError.
         """
         expected = [name.encode("utf-8") for name in MEMBERS]
         self.assertEqual(expected, self.member_names(build_zip(PNG)))
 
-    def parsed_names(self, data: bytes) -> List[str]:
-        parent = Match("application/zip", None, 0, length=len(data), matcher=Matcher(parse=False))
-        with NamedTemporaryFile("wb", suffix=".bin", delete=False) as f:
-            f.write(data)
-            path = Path(f.name)
-        try:
-            with FileStream(str(path)) as stream:
-                return [match.name for match in parse_zip(stream, parent)]
-        finally:
-            path.unlink()
+    def test_parse_zip_at_offset_zero(self):
+        self.assert_structure_parsed(build_zip())
 
     def test_parse_zip_with_prepended_data(self):
-        names = self.parsed_names(build_zip(PNG))
-        self.assertEqual(len(MEMBERS), names.count("LocalFileHeader"))
-        self.assertEqual(len(MEMBERS), names.count("CentralDirectory"))
-        self.assertEqual(1, names.count("EndOfCentralDirectory"))
+        self.assert_structure_parsed(build_zip(PNG))
 
-    def test_parse_zip_at_offset_zero(self):
-        names = self.parsed_names(build_zip())
-        self.assertEqual(len(MEMBERS), names.count("LocalFileHeader"))
-        self.assertEqual(len(MEMBERS), names.count("CentralDirectory"))
-        self.assertEqual(1, names.count("EndOfCentralDirectory"))
+    def test_jar_with_prepended_data(self):
+        """RelaxedJarMatcher reads local file headers, so it needs the archive offset too."""
+        members = dict(MEMBERS)
+        members.update(MANIFEST)
+        mime_types = self.matched_mime_types(build_zip(PNG, members))
+        self.assertIn("application/java-archive", mime_types)
+        self.assertIn("image/png", mime_types)


### PR DESCRIPTION
## Problem

PolyFile detects a ZIP archive that is appended to other data, but it cannot parse one. On a
PNG/ZIP polyglot, `parse_zip` raises a `StructError` and yields no structure at all, so the output
tree contains only the PNG:

```
$ polyfile --debug --format sbud png-zip-polyglot.bin
Parser parse_zip for MIME type application/zip raised an exception while parsing
Zip archive, with extra data prepended in png-zip-polyglot.bin: Expected b'PK\x01\x02'
but instead found b'{\xff{j' while parsing CentralDirectory.magic
```

```
image/png @0 +6019 children=1
application/zip @0 +6019 children=0
```

## Cause

A ZIP record stores the central directory offset and each local file header offset relative to the
start of the archive, not relative to the start of the file. `zipmatcher` used both as absolute
file offsets, so when anything precedes the archive, every seek landed in that leading data.

## Fix

Derive the start of the archive from the end of central directory record. That record sits
immediately after the central directory, so subtracting the central directory size and its recorded
offset from the position of the record itself gives the length of whatever precedes the archive.
`EndOfCentralDirectory.central_directories` and `CentralDirectory.local_file_header` add that value
to the recorded offsets.

For an archive that starts at offset zero the derived value is zero, so ordinary archives behave
exactly as before. A malformed record that yields a negative value is clamped to zero.

## Result

```
$ polyfile --debug --format sbud png-zip-polyglot.bin
```

No parser warning, and the ZIP structure is present:

```
application/zip @0 +6019
  LocalFileHeader @5877 +65
    magic @5877 +4
    ...
    file_name @5907 +9
    compressed_data @5916 +26
      text/plain @5916 +26
  CentralDirectory @5942 +55
    ...
  EndOfCentralDirectory @5997 +22
image/png @0 +6019
  Png @0 +6019
```

The relaxed JAR matcher walks the same records to look for a manifest, so it benefits too. A JAR
appended to a PNG now reports `application/java-archive`, which it did not before.

## Tests

`tests/test_zipmatcher.py` builds an archive twice, once at offset zero and once appended to a PNG,
and checks the member names, the parsed structure, and JAR detection. Against the unmodified
`master` implementation of `zipmatcher`, four of the six tests fail and the two offset-zero tests
pass:

```
FAILED tests/test_zipmatcher.py::TestZipMatcher::test_archive_offset
FAILED tests/test_zipmatcher.py::TestZipMatcher::test_jar_with_prepended_data
FAILED tests/test_zipmatcher.py::TestZipMatcher::test_members_with_prepended_data
FAILED tests/test_zipmatcher.py::TestZipMatcher::test_parse_zip_with_prepended_data
4 failed, 2 passed
```

With the fix, all six pass. `pytest tests` reports `1 failed, 947 passed, 8 skipped`; the failure is
`tests/test_corkami.py::CorkamiDifferentialTests::test_imports_iatindesc_asm`, which also fails on
`master` and is unrelated to this change.

## Out of scope

The report also mentions a PDF that PolyFile does not detect. Its header appears too far into the
file, which needs offset scanning; that is tracked in #3465. Every top-level match is still reported
at offset 0 spanning the whole file, which is tracked in #3466 and is not needed for this fix.

Closes #3364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VS8hTTRQeG8ZCmCZ9KLHiV
