### PR TITLE
Detect text by character class instead of chardet confidence

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -2602,7 +2602,9 @@ _ISO_8859_BYTES: bytes = bytes(
     b for b in range(256) if TEXT_CHAR_CLASSES[b] in (TEXT_CHAR_ASCII, TEXT_CHAR_ISO_8859)
 )
 _TEXT_BYTES: bytes = bytes(b for b in range(256) if TEXT_CHAR_CLASSES[b] != TEXT_CHAR_NONE)
-_UTF8_SAFE_BYTES: bytes = bytes(b for b in range(256) if b >= 0x80 or TEXT_CHAR_CLASSES[b] == TEXT_CHAR_ASCII)
+_UTF8_SAFE_BYTES: bytes = bytes(
+    b for b in range(256) if b >= 0x80 or TEXT_CHAR_CLASSES[b] == TEXT_CHAR_ASCII
+)
 
 _UCS_BYTE_ORDER_MARKS: Tuple[Tuple[bytes, str, int], ...] = (
     (b"\xff\xfe\x00\x00", "utf-32le", 4),
@@ -2636,7 +2638,8 @@ def _looks_like_ucs(data: bytes) -> Optional[str]:
             decoded = body.decode(encoding)
         except UnicodeDecodeError:
             continue
-        if all(char >= "\x80" or TEXT_CHAR_CLASSES[ord(char)] == TEXT_CHAR_ASCII for char in decoded):
+        if all(char >= "\x80" or TEXT_CHAR_CLASSES[ord(char)] == TEXT_CHAR_ASCII
+               for char in decoded):
             return encoding
     return None
 
@@ -2732,7 +2735,8 @@ class PlainTextTest(MagicTest):
         except (UnicodeDecodeError, LookupError):
             value = content
         self.message = ConstantMessage(f"{encoding} text")
-        return MatchedTest(self, offset=absolute_offset, length=len(content), parent=parent_match, value=value)
+        return MatchedTest(self, offset=absolute_offset, length=len(content), parent=parent_match,
+                           value=value)
 
     def test_flip_endianness(
             self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]

--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -2571,6 +2571,111 @@ class DERTest(MagicTest):
         return self.test(data, absolute_offset, parent_match)
 
 
+TEXT_CHAR_NONE: int = 0
+TEXT_CHAR_ASCII: int = 1
+TEXT_CHAR_ISO_8859: int = 2
+TEXT_CHAR_EXTENDED: int = 3
+
+
+def _text_char_classes() -> bytes:
+    """Reproduces the ``text_chars`` table of libmagic's ``src/encoding.c``.
+
+    Returns:
+        A 256 byte table mapping each byte value to one of the ``TEXT_CHAR_*`` classes.
+    """
+    classes = bytearray(256)
+    for byte in range(0x20, 0x7F):
+        classes[byte] = TEXT_CHAR_ASCII
+    for byte in range(0x80, 0xA0):
+        classes[byte] = TEXT_CHAR_EXTENDED
+    for byte in range(0xA0, 0x100):
+        classes[byte] = TEXT_CHAR_ISO_8859
+    for byte in (0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x1A, 0x1B, 0x85):
+        classes[byte] = TEXT_CHAR_ASCII
+    return bytes(classes)
+
+
+TEXT_CHAR_CLASSES: bytes = _text_char_classes()
+
+_ASCII_BYTES: bytes = bytes(b for b in range(256) if TEXT_CHAR_CLASSES[b] == TEXT_CHAR_ASCII)
+_ISO_8859_BYTES: bytes = bytes(
+    b for b in range(256) if TEXT_CHAR_CLASSES[b] in (TEXT_CHAR_ASCII, TEXT_CHAR_ISO_8859)
+)
+_TEXT_BYTES: bytes = bytes(b for b in range(256) if TEXT_CHAR_CLASSES[b] != TEXT_CHAR_NONE)
+_UTF8_SAFE_BYTES: bytes = bytes(b for b in range(256) if b >= 0x80 or TEXT_CHAR_CLASSES[b] == TEXT_CHAR_ASCII)
+
+_UCS_BYTE_ORDER_MARKS: Tuple[Tuple[bytes, str, int], ...] = (
+    (b"\xff\xfe\x00\x00", "utf-32le", 4),
+    (b"\x00\x00\xfe\xff", "utf-32be", 4),
+    (b"\xff\xfe", "utf-16le", 2),
+    (b"\xfe\xff", "utf-16be", 2),
+)
+
+
+def _only_contains(data: bytes, allowed: bytes) -> bool:
+    return not data.translate(None, delete=allowed)
+
+
+def _looks_like_utf8(data: bytes) -> bool:
+    if not _only_contains(data, _UTF8_SAFE_BYTES):
+        return False
+    try:
+        data.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    return True
+
+
+def _looks_like_ucs(data: bytes) -> Optional[str]:
+    for bom, encoding, unit in _UCS_BYTE_ORDER_MARKS:
+        if not data.startswith(bom):
+            continue
+        body = data[len(bom):]
+        body = body[:len(body) - len(body) % unit]
+        try:
+            decoded = body.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+        if all(char >= "\x80" or TEXT_CHAR_CLASSES[ord(char)] == TEXT_CHAR_ASCII for char in decoded):
+            return encoding
+    return None
+
+
+def _eight_bit_encoding(data: bytes) -> Optional[str]:
+    if not _only_contains(data, _TEXT_BYTES):
+        return None
+    elif _only_contains(data, _ISO_8859_BYTES):
+        return "iso-8859-1"
+    else:
+        return "unknown-8bit"
+
+
+def detect_text_encoding(data: bytes) -> Optional[str]:
+    """Decides whether `data` is text, and names the character encoding family it belongs to.
+
+    This mirrors ``file_encoding`` in libmagic's ``src/encoding.c``: membership in a text
+    encoding is decided by character class alone, with no statistical inference. Every byte in
+    ``0xA0``-``0xFF`` is a printable ISO-8859 character, so a buffer of ASCII with a handful of
+    accented characters is text.
+
+    Args:
+        data: the bytes to classify.
+
+    Returns:
+        The name of the encoding family, or None if `data` belongs to no text character class.
+    """
+    if len(data) < 2:
+        return None
+    elif _only_contains(data, _ASCII_BYTES):
+        return "ascii"
+    elif _looks_like_utf8(data):
+        return "utf-8"
+    ucs_encoding = _looks_like_ucs(data)
+    if ucs_encoding is not None:
+        return ucs_encoding
+    return _eight_bit_encoding(data)
+
+
 class PlainTextTest(MagicTest):
     AUTO_REGISTER_TEST = False
 
@@ -2589,29 +2694,45 @@ class PlainTextTest(MagicTest):
     def subtest_type(self) -> TestType:
         return TestType.TEXT
 
-    def test(self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]) -> TestResult:
-        if not isinstance(self.message, ConstantMessage) or self.message.message:
-            raise ValueError(f"A new PlainTextTest must be constructed for each call to .test")
+    def encoding_name(self, data: bytes, fallback: str) -> str:
+        """Names the encoding of `data` for the human-readable match message.
+
+        Args:
+            data: the text whose encoding to name.
+            fallback: the name to use when chardet is not confident enough to name one itself.
+
+        Returns:
+            The chardet encoding name if its confidence reaches `minimum_encoding_confidence`,
+            and `fallback` otherwise.
+        """
         detector = UniversalDetector()
-        offset = absolute_offset
+        offset = 0
         while not detector.done and offset < min(len(data), 5000000):
             # feed 1kB at a time until we have high confidence in the classification
             # up to a maximum of 5MiB
             detector.feed(data[offset:offset+1024])
             offset += 1024
         detector.close()
-        if detector.result["confidence"] >= self.minimum_encoding_confidence and detector.result["encoding"] is not None:
-            encoding = detector.result["encoding"]
-            try:
-                value = data[absolute_offset:].decode(encoding)
-            except UnicodeDecodeError:
-                value = data[absolute_offset:]
-            self.message = ConstantMessage(f"{encoding} text")
-            return MatchedTest(self, offset=absolute_offset, length=len(data) - absolute_offset, parent=parent_match,
-                               value=value)
-        else:
+        if detector.result["encoding"] is None \
+                or detector.result["confidence"] < self.minimum_encoding_confidence:
+            return fallback
+        return detector.result["encoding"]
+
+    def test(self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]) -> TestResult:
+        if not isinstance(self.message, ConstantMessage) or self.message.message:
+            raise ValueError(f"A new PlainTextTest must be constructed for each call to .test")
+        content = data[absolute_offset:]
+        character_class = detect_text_encoding(content)
+        if character_class is None:
             return FailedTest(self, offset=absolute_offset, parent=parent_match, message="the data do not appear to "
                                                                                          "be encoded in a text format")
+        encoding = self.encoding_name(content, character_class)
+        try:
+            value: Union[str, bytes] = content.decode(encoding)
+        except (UnicodeDecodeError, LookupError):
+            value = content
+        self.message = ConstantMessage(f"{encoding} text")
+        return MatchedTest(self, offset=absolute_offset, length=len(content), parent=parent_match, value=value)
 
     def test_flip_endianness(
             self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -139,8 +139,9 @@ class MagicTest(TestCase):
     def test_text_character_classes(self):
         """Tests that text membership follows libmagic's character classes, not chardet's guess."""
         self.assertEqual("ascii", polyfile.magic.detect_text_encoding(b"plain ASCII\n"))
-        self.assertEqual("utf-8", polyfile.magic.detect_text_encoding("héllo wörld".encode("utf-8")))
-        self.assertEqual("utf-16le", polyfile.magic.detect_text_encoding(b"\xff\xfe" + "hi".encode("utf-16-le")))
+        self.assertEqual("utf-8", polyfile.magic.detect_text_encoding("héllo wörld".encode()))
+        utf16 = b"\xff\xfe" + "hi".encode("utf-16-le")
+        self.assertEqual("utf-16le", polyfile.magic.detect_text_encoding(utf16))
         self.assertEqual("unknown-8bit", polyfile.magic.detect_text_encoding(b"text\x80\x9f"))
         self.assertIsNone(polyfile.magic.detect_text_encoding(b"text\x00\x01\x02"))
         self.assertIsNone(polyfile.magic.detect_text_encoding(b"a"))

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -136,6 +136,19 @@ class MagicTest(TestCase):
         self.assertIn("application/x-pie-executable", matcher.mimetypes)
         self.assertIn("application/x-sharedlib", matcher.mimetypes)
 
+    def test_text_char_class_boundaries(self):
+        """Tests the corners of the character class table against libmagic's `text_chars`."""
+        classes = polyfile.magic.TEXT_CHAR_CLASSES
+        self.assertEqual(256, len(classes))
+        for byte in (0x00, 0x06, 0x0E, 0x19, 0x1C, 0x7F):
+            self.assertEqual(polyfile.magic.TEXT_CHAR_NONE, classes[byte], f"byte {byte:#04x}")
+        for byte in (0x07, 0x0B, 0x0D, 0x1A, 0x1B, 0x20, 0x7E, 0x85):
+            self.assertEqual(polyfile.magic.TEXT_CHAR_ASCII, classes[byte], f"byte {byte:#04x}")
+        for byte in (0x80, 0x84, 0x86, 0x9F):
+            self.assertEqual(polyfile.magic.TEXT_CHAR_EXTENDED, classes[byte], f"byte {byte:#04x}")
+        for byte in (0xA0, 0xE9, 0xEA, 0xFF):
+            self.assertEqual(polyfile.magic.TEXT_CHAR_ISO_8859, classes[byte], f"byte {byte:#04x}")
+
     def test_text_character_classes(self):
         """Tests that text membership follows libmagic's character classes, not chardet's guess."""
         self.assertEqual("ascii", polyfile.magic.detect_text_encoding(b"plain ASCII\n"))

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -136,6 +136,39 @@ class MagicTest(TestCase):
         self.assertIn("application/x-pie-executable", matcher.mimetypes)
         self.assertIn("application/x-sharedlib", matcher.mimetypes)
 
+    def test_text_character_classes(self):
+        """Tests that text membership follows libmagic's character classes, not chardet's guess."""
+        self.assertEqual("ascii", polyfile.magic.detect_text_encoding(b"plain ASCII\n"))
+        self.assertEqual("utf-8", polyfile.magic.detect_text_encoding("héllo wörld".encode("utf-8")))
+        self.assertEqual("utf-16le", polyfile.magic.detect_text_encoding(b"\xff\xfe" + "hi".encode("utf-16-le")))
+        self.assertEqual("unknown-8bit", polyfile.magic.detect_text_encoding(b"text\x80\x9f"))
+        self.assertIsNone(polyfile.magic.detect_text_encoding(b"text\x00\x01\x02"))
+        self.assertIsNone(polyfile.magic.detect_text_encoding(b"a"))
+
+    def test_iso_8859_text_is_not_binary(self):
+        """Tests that mostly-ASCII data with a handful of ISO-8859-1 high bytes matches text/plain.
+
+        This is a regression test for trailofbits/polyfile#3468. chardet scores this data at a
+        confidence of 0.07 because five high bytes cannot distinguish ISO-8859-1 from its
+        siblings, so PolyFile used to report application/octet-stream where `file` reports
+        text/plain.
+        """
+        data = (
+            b"; imports with IAT inside descriptors\r\n"
+            b"; Ange Albertini, BSD LICENCE 2011-2013\r\n"
+            b"%include 'consts.inc'\r\n"
+            b"        ; Mais elle n'a pas r\xe9ussi a laminer tes rancoeurs dialectiques\r\n"
+            b"        ; et \xe9radiquer les tentacules de la d\xe9r\xe9liction...\r\n"
+            b"        ; ok, j'arr\xeate de boire...\r\n"
+        )
+        self.assertEqual("iso-8859-1", polyfile.magic.detect_text_encoding(data))
+        mimetypes = {
+            mimetype
+            for match in MagicMatcher.DEFAULT_INSTANCE.match(data)
+            for mimetype in match.mimetypes
+        }
+        self.assertIn("text/plain", mimetypes)
+
     def test_file_corpus(self):
         self.assertTrue(FILE_TEST_DIR.exists(), "Make sure to run `git submodule init && git submodule update` in the "
                                                 "root of this repository.")


### PR DESCRIPTION
This unblocks CI on `master`. `tests/test_corkami.py::CorkamiDifferentialTests::test_imports_iatindesc_asm`
is the only failing test there, and it fails on every Python version in the matrix.

## Problem

`PlainTextTest.test` decided whether data was text from chardet's confidence score alone:

```python
if detector.result["confidence"] >= self.minimum_encoding_confidence and detector.result["encoding"] is not None:
```

That score answers "which encoding is this?", not "is this text?". For
`corkami/pocs/PE/imports_iatindesc.asm` — 1,625 bytes of ASCII with CRLF plus five high bytes
(`0xE9` four times and `0xEA` once, `é` and `ê` in ISO-8859-1) — chardet returns:

```
{'encoding': 'ISO-8859-1', 'confidence': 0.0697, 'language': 'fr', 'mime_type': 'text/plain'}
```

The low score is chardet being unsure which 8-bit encoding it is looking at, which is fair:
five bytes cannot separate ISO-8859-1 from its siblings. chardet's own `mime_type` field says
`text/plain`. Because the two questions were conflated, any mostly-ASCII file with a few
accented characters came out as `application/octet-stream`.

## Fix

Decide text membership by character class, the way libmagic does, and keep chardet only for
naming the encoding in the human-readable match message.

`polyfile/magic.py` gains `detect_text_encoding()`, which mirrors `file_encoding()` in
libmagic's `src/encoding.c`:

- `TEXT_CHAR_CLASSES` reproduces libmagic's `text_chars` table byte for byte, and
  `test_text_char_class_boundaries` pins every boundary the ranges could drift across.
- Membership follows libmagic's order: ASCII, UTF-8, UTF-32 and UTF-16 by byte order mark, then
  ISO-8859 (`0xA0`-`0xFF` are printable), then non-ISO extended ASCII (`0x80`-`0x9F`).
- The three class checks use `bytes.translate`, so each is a single C-level pass over the buffer.

`PlainTextTest.encoding_name()` keeps chardet for the message text, still gated on
`minimum_encoding_confidence`, and falls back to the character-class name when chardet is not
confident. Every input that matched before keeps its exact message; the file in this issue now
reports `iso-8859-1 text` where it previously reported nothing at all.

Two deliberate departures from libmagic, both on the strict side: PolyFile examines the whole
buffer rather than libmagic's first 64 KiB, and it does not treat EBCDIC as text.

## Verification

`pytest tests`, which includes the 900-plus-case differential test against a locally built
`file` binary:

| | before | after |
|---|---|---|
| result | 1 failed, 942 passed, 8 skipped, 357 subtests passed | 946 passed, 8 skipped, 357 subtests passed |
| runtime | 92.16 s | 69.51 s |

The suite gets faster because chardet no longer runs on binary input, which is the common case.

The three new tests in `tests/test_magic.py` fail on `master` and pass here. Checking the
behavior on its own, with only `polyfile/magic.py` reverted to `origin/master`:

```
--- origin/master ---
mimetypes: {'application/octet-stream'} -> text/plain present: False
--- with fix ---
mimetypes: {'text/plain'} -> text/plain present: True
```

Widening text detection makes the `TestType.TEXT` tests run on more inputs, so the two corpora
are the safety net here, and both are green. As a separate check, comparing
`detect_text_encoding()` against `file --mime-encoding` over all 943 files in the corkami corpus
gives one disagreement: `mocks/elf.bin`, 4 bytes, which `file` reads as EBCDIC. That file is
already in `KNOWN_BAD_FILES` as a case where `file` is wrong and PolyFile is right.

One thing a reviewer may want to follow up on separately: five of the eight entries in
`KNOWN_BAD_FILES` (`arj.bin`, `dex035.bin`, `id3v2.bin`, `jpg.bin`, `png.bin`) now agree with
`file` and could be unskipped. This PR leaves that list alone.

Closes #3468

🤖 Generated with [Claude Code](https://claude.com/claude-code)
