### PR TITLE
Fix the matching hang on small text files

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -2725,7 +2725,7 @@ class Match:
         return len(self._results)
 
     def __getitem__(self, index: int) -> TestResult:
-        while self._result_iter is not None and index <= len(self._results):
+        while self._result_iter is not None and index >= len(self._results):
             # we have not yet finished collecting the results
             try:
                 result = next(self._result_iter)

--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -1305,7 +1305,12 @@ class StringWildcard(StringTest):
         return False
 
     def search(self, data: bytes) -> DataTypeMatch:
-        return self.matches(data)
+        # `num_bytes` bounds the start offsets a search tries, not the extent of the value it
+        # yields, so a search always reads up to the first null byte
+        first_null = data.find(b"\0")
+        if first_null >= 0:
+            return self.post_process(data[:first_null])
+        return self.post_process(data)
 
     def __str__(self):
         return "null-terminated string"
@@ -1484,9 +1489,13 @@ class StringMatch(StringTest):
         return DataTypeMatch.INVALID
 
     def search(self, data: bytes) -> DataTypeMatch:
-        if self.num_bytes is not None:
-            data = data[:self.num_bytes]
-        m = self.pattern.search(data)
+        if self.num_bytes is None:
+            end_pos = len(data)
+        else:
+            # libmagic tries `num_bytes` successive start offsets, so the window it reads is that
+            # many bytes plus the length of the string it is looking for
+            end_pos = min(len(data), self.num_bytes + len(self.string))
+        m = self.pattern.search(data, 0, end_pos)
         if m:
             return self.post_process(bytes(m.group(0)), initial_offset=m.start())
         return DataTypeMatch.INVALID
@@ -1600,7 +1609,7 @@ class SearchType(StringType):
             full_word_match=full_word_match,
             trim=trim
         )
-        self.repetitions: Optional[int] = repetitions
+        self.num_bytes = repetitions
         if repetitions is None:
             rep_str = ""
         else:
@@ -1613,6 +1622,16 @@ class SearchType(StringType):
                 self.name = f"search{rep_str}/s"
             else:
                 self.name = f"{self.name}s"
+
+    @property
+    def repetitions(self) -> Optional[int]:
+        """The number of start offsets libmagic tries, from the ``search/N`` declaration.
+
+        Returns:
+            The value of ``N``, or ``None`` if the declaration omitted it, in which case the
+            whole buffer is searched.
+        """
+        return self.num_bytes
 
     def is_text(self, value: StringTest) -> bool:
         return value.is_always_text()

--- a/polyfile/magic_defs/c-lang
+++ b/polyfile/magic_defs/c-lang
@@ -75,7 +75,7 @@
 !:mime	text/x-c++
 # But class alone is reduced to avoid beating php (Jens Schleusener)
 0	search/8192	class
->0	regex	\^[[:space:]]*class[[:space:]]+[[:digit:][:alpha:]:_]+[[:space:]]*\\{(.*[\n]*)*\\}(;)?$		C++ source text
+>0	regex	\^[[:space:]]*class[[:space:]]+[[:digit:][:alpha:]:_]+[[:space:]]*\\{(.|[\n])*\\}(;)?$		C++ source text
 !:strength + 13
 !:mime	text/x-c++
 0	search/8192	public

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1,5 +1,9 @@
+import subprocess
+import sys
+import time
 from pathlib import Path
-from typing import Callable, Optional
+from tempfile import TemporaryDirectory
+from typing import Callable, Optional, Set
 from unittest import TestCase
 
 # from polyfile import logger
@@ -191,3 +195,96 @@ class MagicTest(TestCase):
                                 self.assertTrue(any(m.endswith(expected) for m in matches))
                             else:
                                 self.assertIn(expected, matches)
+
+
+MATCH_TIMEOUT_SECONDS: int = 60
+
+MATCH_SCRIPT: str = """
+import sys
+from polyfile.magic import MagicMatcher
+with open(sys.argv[1], "rb") as f:
+    data = f.read()
+for match in MagicMatcher.DEFAULT_INSTANCE.match(data):
+    _ = set(match.mimetypes)
+"""
+
+
+class MagicMatchingRegressionTest(TestCase):
+    """Regression tests for the matching hang reported in issue #3411."""
+
+    # This header uses CRLF line endings, so the `}` that closes the class is never the last
+    # character on a line and the `c-lang` C++ class test can never succeed. Reduced from the
+    # file attached to issue #3411.
+    CRLF_CPP_HEADER: bytes = b"\r\n".join((
+        b"#ifndef MEMBLOCK_HDR",
+        b"#define MEMBLOCK_HDR",
+        b"",
+        b"class MemBlock",
+        b"{",
+        b"public :",
+        b"\tint len;",
+        b"\tconst char *data;",
+        b"\tMemBlock() : len(0), data(0) {}",
+        b"\tchar operator[](int i) const { return data[i]; }",
+        b"};",
+        b"",
+        b"#endif",
+        b"",
+    ))
+
+    @staticmethod
+    def mimetypes(matcher: MagicMatcher, data: bytes) -> Set[str]:
+        """Collects every MIME type that `matcher` reports for `data`.
+
+        Args:
+            matcher: The matcher to run.
+            data: The bytes to classify.
+
+        Returns:
+            The union of the MIME types of every match.
+        """
+        found: Set[str] = set()
+        for match in matcher.match(data):
+            found |= set(match.mimetypes)
+        return found
+
+    def match_in_subprocess(self, data: bytes, timeout: int = MATCH_TIMEOUT_SECONDS) -> float:
+        """Matches `data` in a subprocess, so that a hang fails the test instead of stalling CI.
+
+        Args:
+            data: The bytes to hand to the default matcher.
+            timeout: The number of seconds to wait before failing the test.
+
+        Returns:
+            The wall-clock seconds the subprocess took.
+        """
+        with TemporaryDirectory() as tmp_dir:
+            input_path = Path(tmp_dir) / "input"
+            input_path.write_bytes(data)
+            command = [sys.executable, "-c", MATCH_SCRIPT, str(input_path)]
+            started = time.monotonic()
+            try:
+                subprocess.run(command, capture_output=True, check=True, timeout=timeout)
+            except subprocess.TimeoutExpired:
+                self.fail(f"Matching {len(data)} bytes took longer than {timeout} seconds")
+            except subprocess.CalledProcessError as e:
+                error = e.stderr.decode("utf-8", "replace")
+                self.fail(f"Matching {len(data)} bytes failed: {error}")
+            return time.monotonic() - started
+
+    def test_cpp_class_test_terminates(self):
+        """Matching a C++ header used to backtrack exponentially in the `c-lang` class test."""
+        elapsed = self.match_in_subprocess(self.CRLF_CPP_HEADER)
+        print(f"Matched {len(self.CRLF_CPP_HEADER)} bytes in {elapsed:.3f} seconds")
+
+    def test_cpp_class_test_semantics(self):
+        """The rewritten `c-lang` class test accepts and rejects the same sources as before."""
+        for magic_def in MAGIC_DEFS:
+            if magic_def.name == "c-lang":
+                break
+        else:
+            self.fail("Could not find the c-lang definitions")
+        matcher = MagicMatcher.parse(magic_def)
+        source = b"class Foo {\n\tint x;\n};\n"
+        self.assertIn("text/x-c++", self.mimetypes(matcher, source))
+        self.assertNotIn("text/x-c++", self.mimetypes(matcher, source.replace(b"\n", b"\r\n")))

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 
 # from polyfile import logger
 import polyfile.magic
-from polyfile.magic import MagicMatcher, MAGIC_DEFS, Match, MatchContext, TestResult
+from polyfile.magic import MagicMatcher, MAGIC_DEFS, Match, MatchContext, SearchType, TestResult
 
 
 # logger.setLevel(logger.TRACE)
@@ -328,3 +328,12 @@ class MagicMatchingRegressionTest(TestCase):
         match, produced = self.counting_match(result, 8)
         self.assertTrue(match)
         self.assertEqual(1, len(produced))
+
+    def test_search_honors_its_repetition_limit(self):
+        """libmagic's `search/N` tries `N` start offsets; PolyFile used to scan the whole buffer."""
+        search = SearchType.parse("search/8192")
+        self.assertEqual(8192, search.repetitions)
+        expected = search.parse_expected("needle")
+        self.assertEqual(8192, expected.num_bytes)
+        self.assertTrue(search.match(b"." * 8000 + b"needle", expected))
+        self.assertFalse(search.match(b"." * 9000 + b"needle", expected))

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -3,12 +3,12 @@ import sys
 import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Callable, Optional, Set
+from typing import Callable, Iterator, List, Optional, Set, Tuple
 from unittest import TestCase
 
 # from polyfile import logger
 import polyfile.magic
-from polyfile.magic import MagicMatcher, MAGIC_DEFS
+from polyfile.magic import MagicMatcher, MAGIC_DEFS, Match, MatchContext, TestResult
 
 
 # logger.setLevel(logger.TRACE)
@@ -248,6 +248,26 @@ class MagicMatchingRegressionTest(TestCase):
             found |= set(match.mimetypes)
         return found
 
+    @staticmethod
+    def counting_match(result: TestResult, count: int) -> Tuple[Match, List[TestResult]]:
+        """Builds a `Match` that records each result its iterator yields.
+
+        Args:
+            result: The test result to yield repeatedly.
+            count: The number of results the iterator yields before it is exhausted.
+
+        Returns:
+            The match, and the list that grows by one entry per result the match consumes.
+        """
+        produced: List[TestResult] = []
+
+        def results() -> Iterator[TestResult]:
+            for _ in range(count):
+                produced.append(result)
+                yield result
+
+        return Match(MagicMatcher.DEFAULT_INSTANCE, MatchContext(b""), results()), produced
+
     def match_in_subprocess(self, data: bytes, timeout: int = MATCH_TIMEOUT_SECONDS) -> float:
         """Matches `data` in a subprocess, so that a hang fails the test instead of stalling CI.
 
@@ -288,3 +308,23 @@ class MagicMatchingRegressionTest(TestCase):
         source = b"class Foo {\n\tint x;\n};\n"
         self.assertIn("text/x-c++", self.mimetypes(matcher, source))
         self.assertNotIn("text/x-c++", self.mimetypes(matcher, source.replace(b"\n", b"\r\n")))
+
+    def test_match_results_are_lazy(self):
+        """Reading one result used to drain the whole result iterator."""
+        data = b"#!/bin/sh\nexec cat \"$@\"\n"
+        result = next(iter(MagicMatcher.DEFAULT_INSTANCE.match(data)))[0]
+        match, produced = self.counting_match(result, 8)
+        self.assertIs(result, match[0])
+        self.assertEqual(1, len(produced))
+        self.assertIs(result, match[3])
+        self.assertEqual(4, len(produced))
+        self.assertEqual(8, len(match))
+        self.assertEqual(8, len(produced))
+
+    def test_match_truthiness_is_lazy(self):
+        """`bool(match)` used to match the whole subtree before it could answer."""
+        data = b"#!/bin/sh\nexec cat \"$@\"\n"
+        result = next(iter(MagicMatcher.DEFAULT_INSTANCE.match(data)))[0]
+        match, produced = self.counting_match(result, 8)
+        self.assertTrue(match)
+        self.assertEqual(1, len(produced))


### PR DESCRIPTION
Matching a small text file with `MagicMatcher.DEFAULT_INSTANCE.match()` could take longer than 10 minutes. The 1,399-byte file attached to #3411 did not finish within 600 seconds. This fixes the cause and two defects that made it worse.

## Catastrophic backtracking in the C++ class test

`polyfile/magic_defs/c-lang:78` contained the sub-pattern `(.*[\n]*)*`: a star over a group whose body is itself nullable. libmagic compiles its tests with a POSIX engine, but PolyFile compiles them with Python's `re`, which backtracks, so the number of ways to split a span of *n* characters across those two quantifiers is 2^(n-1). The test only runs when a line starts with `class`, and it only fails slowly when no line in the 8 KiB window ends in the closing brace it needs, which is why only some text files hang. Both files in the report use CRLF line endings, so no line ends in `}`.

Measured on the pattern alone, appending characters to a class body that never closes:

| Characters after `class Foo\n{\n` | Time |
| --- | --- |
| 16 | 0.0086 s |
| 20 | 0.14 s |
| 24 | 2.3 s |
| 28 | 35.9 s |

The pattern is now `(.|[\n])*`. Each repetition consumes exactly one character, so a span of *n* characters has exactly one decomposition instead of 2^(n-1), and the language both patterns accept is the same: every string. A differential check over 167,961 inputs (every string up to 6 characters over `a{};\n` and space, appended to three different matching prefixes, plus a set of realistic sources) found no input on which the two patterns disagree, in either whether they match or where the match ends.

### Why change the definition rather than `RegexType`

`polyfile/magic_defs/` is synced from upstream libmagic, so a change there is lost on the next sync. The alternative was to detect and rewrite the construct in `RegexType.parse_expected`, or to bound the time each search may take. Both were rejected:

- A general rewriter would run over all 366 regex tests in the definitions, and a bug in it would silently change detection for unrelated formats. The definition change is one token with a proof of language equivalence behind it.
- Bounding the search time would make detection depend on how loaded the machine is, and would leave the pathological pattern in place.

Upstream is not affected, because it does not use a backtracking engine, so there is nothing to send upstream and this belongs in PolyFile's copy. `test_cpp_class_test_terminates` runs the default matcher over a CRLF C++ header in a subprocess with a 60-second bound, so a sync that reintroduces the construct fails CI rather than hanging it, and `test_cpp_class_test_semantics` pins the accept and reject behavior the rewrite preserves.

## `Match.__getitem__` drained every result

```python
while self._result_iter is not None and index <= len(self._results):
```

For `index == 0` that holds at every list length, so reading the first result ran the whole result generator. So did `bool(match)`, `match.mimetypes`, and anything else that touches one element: `Match` was lazy in name only. The comparison is now `index >= len(self._results)`, which is the guard `LazyIterableSequence.__getitem__` already uses.

## `SearchType` ignored its repetition count

`SearchType.parse` recorded the `N` of a `search/N` declaration in `self.repetitions` and never passed it on, so every one of the 800 search tests in the definitions scanned the whole remaining buffer. libmagic reads at most `N` start offsets plus the length of the string it looks for (`softmagic.c`, `FILE_SEARCH`), which is both cheaper and stricter. The count is now stored as `num_bytes`, exposed through a `repetitions` property, and applied in `StringMatch.search`. Wildcard searches still read to the first null byte, because the count bounds the start offsets a search tries, not the extent of the value it yields.

## Results

Wall-clock time for the snippet in the report, on the two files attached to it:

| File | Before | After |
| --- | --- | --- |
| `memblock.txt` (1,399 bytes) | > 600 s (timed out) | 0.061 s |
| `WhisperCppTest.java` (6,236 bytes) | > 600 s (timed out) | 0.069 s |

Neither file is C++ as far as libmagic is concerned, and neither is as far as PolyFile is concerned now: `file` reports `c program text` for the first and `ASCII text` for the second, and PolyFile reports `text/x-c` and `application/x-brainfuck`. The time went into failing to match.

## Detection results

`tests/test_magic.py` runs the upstream libmagic corpus and passes unchanged. Comparing the full set of messages and MIME types for all 86 corpus files before and after, four files change, all from the `SearchType` fix and all in the same way: `HWP2016.hwpx.zip`, `escapevel`, `issue311docx`, and `issue359xlsx` no longer report a `Zip archive data, made by ...` message. Their central directory signature sits at offset 3,176 to 13,582, past the 1,024-byte window of the `>0 search/1024 PK\001\002` test, so `file` does not report it for them either. No MIME type changes for any corpus file.

`pytest tests` passes except for `tests/test_corkami.py::CorkamiDifferentialTests::test_imports_iatindesc_asm`, which fails the same way on unmodified `master` and is being fixed separately.

## Follow-up

The sweep that checked all 366 regex tests for other patterns of this kind turned up one more, unrelated to this fix and filed as #3473.

Closes #3411

🤖 Generated with [Claude Code](https://claude.com/claude-code)
