### PR TITLE
Mark undescribed bytes in the HTML hex viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Found a file of type application/zip at byte offset 0
 Found a file of type application/java-archive at byte offset 0
 Saved HTML output to output.html
 ```
+The viewer renders any byte that no match describes in gray on a diagonal hatch, and reports how many
+such bytes the file has above the hex dump.
 
 Run `polyfile --help` for full usage instructions.
 

--- a/polyfile/html.py
+++ b/polyfile/html.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import math
 import mimetypes
 import os
@@ -24,6 +25,54 @@ def assign_ids(sbud):
     return matches
 
 
+def _leaf_extents(matches, length):
+    """Yields the ``(start, end)`` byte extent of every match that has no children.
+
+    A match with children spans all of them, so it says nothing about the bytes its children
+    skip. Only childless matches describe bytes.
+
+    Args:
+        matches: The top-level SBUD matches to walk.
+        length: The length of the analyzed file, in bytes. Extents are clamped to it.
+
+    Yields:
+        A ``(start, end)`` pair for each childless match that covers at least one byte.
+    """
+    stack = list(matches)
+    while stack:
+        match = stack.pop()
+        children = match.get('subEls')
+        if children:
+            stack.extend(children)
+            continue
+        start = min(max(match['offset'], 0), length)
+        end = min(max(start + match['size'], start), length)
+        if end > start:
+            yield start, end
+
+
+def undescribed_regions(matches, length):
+    """Finds the byte ranges of a file that no match describes.
+
+    Args:
+        matches: The top-level SBUD matches, each with ``offset``, ``size``, and ``subEls`` keys.
+        length: The length of the analyzed file, in bytes.
+
+    Returns:
+        A list of ``(offset, size)`` pairs, in ascending order of offset, one for each maximal
+        run of bytes that no childless match covers.
+    """
+    regions = []
+    position = 0
+    for start, end in sorted(_leaf_extents(matches, length)):
+        if start > position:
+            regions.append((position, start - position))
+        position = max(position, end)
+    if position < length:
+        regions.append((position, length - position))
+    return regions
+
+
 def generate(file_path, sbud):
     global TEMPLATE, jinja2
     if jinja2 is None:
@@ -37,6 +86,8 @@ def generate(file_path, sbud):
     matches = assign_ids(sbud)
 
     input_bytes = sbud['length']
+    regions = undescribed_regions(matches, input_bytes)
+    undescribed_bytes = sum(size for _, size in regions)
     with open(file_path, 'rb') as input_file:
         class ReadUnicode():
             def __init__(self):
@@ -123,12 +174,14 @@ def generate(file_path, sbud):
             math=math,
             read_unicode=ReadUnicode(),
             mime_type=mime_type,
-            decoded_matches=decoded_matches
+            decoded_matches=decoded_matches,
+            undescribed_regions=json.dumps(regions, separators=(',', ':')),
+            undescribed_bytes=undescribed_bytes,
+            undescribed_percent=undescribed_bytes * 100.0 / max(input_bytes, 1)
         )
 
 
 if __name__ == '__main__':
-    import json
     import sys
 
     with open(sys.argv[2], 'r') as f:

--- a/polyfile/templates/hexdump.css
+++ b/polyfile/templates/hexdump.css
@@ -173,18 +173,41 @@ label.tree_label:after { border-bottom: 0; }
   color: gray;
 }
 
+.undescribed {
+  color: #6a6a6a;
+  background-image: repeating-linear-gradient(
+    45deg, transparent, transparent 2px, #dcdcdc 2px, #dcdcdc 4px);
+}
+
+.coverage {
+  margin: 1em 0 0.5em 0;
+  font-size: 0.9em;
+}
+
+.coverage .swatch {
+  display: inline-block;
+  width: 2.5em;
+  height: 1em;
+  vertical-align: -0.15em;
+  margin-right: 0.5em;
+  border: 1px solid #999;
+}
+
 .highlighted {
   background-color: #42bff5;
+  background-image: none;
   color: white;
 }
 
 .manually-focused {
   background-color: #FF0000;
+  background-image: none;
   color: white;
 }
 
 .cursor {
   background-color: #0000FF;
+  background-image: none;
   color: white;
   cursor: none;
 }
@@ -219,6 +242,7 @@ label.tree_label:after { border-bottom: 0; }
     -moz-box-shadow: 0 0 20px #FFFF00;
     box-shadow:0 0 20px #FFFF00;
     background-color:#FFFF00;
+    background-image: none;
 }
 
 .overlay {

--- a/polyfile/templates/hexdump.js
+++ b/polyfile/templates/hexdump.js
@@ -1,5 +1,6 @@
 const rawBytes = atob("{{ encoded }}");
 const ROWS = Math.max(Math.ceil(rawBytes.length / 16), 1);
+const UNDESCRIBED_REGIONS = {{ undescribed_regions }};
 let BYTE_HEIGHT;
 let ROW_OFFSET = 0;
 let VISIBLE_ROWS = 0;
@@ -9,6 +10,18 @@ let LINE_DIGITS = 1;
 let $bytes = [];
 let $ascii = [];
 let $rbytes = [];
+
+function buildUndescribedMap() {
+    const map = new Uint8Array(rawBytes.length);
+    for(let i=0; i<UNDESCRIBED_REGIONS.length; ++i) {
+        const region = UNDESCRIBED_REGIONS[i];
+        map.fill(1, region[0], region[0] + region[1]);
+    }
+    return map;
+}
+
+/* Expanded once at load so that rendering a row costs one array read per byte. */
+const undescribedMap = buildUndescribedMap();
 
 function getByte(index) {
     if(index < $bytes.length && index >= 0) {
@@ -398,12 +411,26 @@ function updateRendering() {
         } else {
             html += '<span id="rbyte'
                 + (i - startOffset)
+                + (undescribedMap[i] === 1 ? '" class="undescribed' : '')
                 + '" onmouseover="mouseOverByte(' + i + ')">'
                 + formatChar(rawBytes[i], false) + "</span>";
         }
     }
 
     $('.readablebytes').html(html).scrollTop(0);
+}
+
+function renderByteCells(startOffset) {
+    for(let i=startOffset; i < startOffset + VISIBLE_ROWS * 16; ++i) {
+        const present = i < rawBytes.length;
+        const undescribed = present && undescribedMap[i] === 1;
+        getByte(i - startOffset)
+            .text(present ? rawBytes.charCodeAt(i).toString(16).padStart(2, '0') : '')
+            .toggleClass('undescribed', undescribed);
+        getAscii(i - startOffset)
+            .html(present ? formatChar(rawBytes[i]) : '')
+            .toggleClass('undescribed', undescribed);
+    }
 }
 
 function scrollToRow(row) {
@@ -418,20 +445,7 @@ function scrollToRow(row) {
     }
     $byteLabelCache.clear();
     ROW_OFFSET = row;
-    const startOffset = ROW_OFFSET * 16;
-    for(let i=startOffset; i < startOffset + VISIBLE_ROWS * 16; ++i) {
-        let bytecode;
-        let bytestring;
-        if(i >= rawBytes.length) {
-            bytecode = '';
-            bytestring = '';
-        } else {
-            bytecode = rawBytes.charCodeAt(i).toString(16).padStart(2, '0');
-            bytestring = formatChar(rawBytes[i]);
-        }
-        getByte(i - startOffset).text(bytecode);
-        getAscii(i - startOffset).html(bytestring);
-    }
+    renderByteCells(ROW_OFFSET * 16);
     /* update the row labels */
     const requiredDigits = Math.ceil(Math.log(rawBytes.length) / Math.log(16));
     for(let i=0; i<VISIBLE_ROWS; ++i) {

--- a/polyfile/templates/template.html
+++ b/polyfile/templates/template.html
@@ -29,7 +29,14 @@
     <input type="button" value="⬇" id="searchdown" onclick="searchDown()" />
 </span>
 <span style="display:none;" id="clickinfo">Double-click to jump to an address</span>
-<br />
+
+<div class="coverage">
+{% if undescribed_bytes %}<span class="swatch undescribed"></span>Hatched, gray bytes are undescribed:
+    no match covers them. {{ '{:,}'.format(undescribed_bytes) }} of
+    {{ '{:,}'.format(input_bytes) }} bytes ({{ '%.1f' % undescribed_percent }}%) are
+    undescribed.{% else %}Every one of the {{ '{:,}'.format(input_bytes) }} bytes is described by
+    a match.{% endif %}
+</div>
 
 {% macro render_match_name(match, first) -%}
 <a href="#" class="download" title="download" onclick="downloadFile({{ match['offset'] }}, {{ match['size'] }}, '{{ match['type'] }}', '{{ match['extension'] }}')">⇩</a>

--- a/tests/unit/test_html.py
+++ b/tests/unit/test_html.py
@@ -1,0 +1,111 @@
+import base64
+import json
+import re
+from unittest import TestCase
+
+from polyfile.fileutils import Tempfile
+from polyfile.html import generate, undescribed_regions
+
+
+def match(offset, size, sub_els=()):
+    return {
+        'offset': offset,
+        'relative_offset': offset,
+        'size': size,
+        'type': 'application/octet-stream',
+        'name': f'match@{offset}',
+        'value': '',
+        'subEls': list(sub_els)
+    }
+
+
+def sbud(contents, struc):
+    return {
+        'MD5': '',
+        'SHA1': '',
+        'SHA256': '',
+        'b64contents': base64.b64encode(contents).decode('utf-8'),
+        'fileName': 'test.bin',
+        'length': len(contents),
+        'versions': [],
+        'struc': struc
+    }
+
+
+class UndescribedRegionTests(TestCase):
+    """Test that undescribed_regions finds every byte that no childless match covers.
+
+    These tests prevent a regression to the behavior reported in
+    https://github.com/trailofbits/polyfile/issues/8, where the hex viewer had no way to tell
+    a reader which bytes the analysis failed to describe.
+    """
+
+    def test_no_matches_leaves_the_whole_file_undescribed(self):
+        self.assertEqual([(0, 16)], undescribed_regions([], 16))
+
+    def test_full_coverage_reports_nothing(self):
+        self.assertEqual([], undescribed_regions([match(0, 16)], 16))
+
+    def test_a_gap_between_two_matches(self):
+        regions = undescribed_regions([match(0, 4), match(10, 6)], 16)
+        self.assertEqual([(4, 6)], regions)
+
+    def test_a_gap_before_the_first_match(self):
+        self.assertEqual([(0, 3)], undescribed_regions([match(3, 13)], 16))
+
+    def test_a_gap_after_the_last_match(self):
+        self.assertEqual([(12, 4)], undescribed_regions([match(0, 12)], 16))
+
+    def test_only_childless_matches_describe_bytes(self):
+        parent = match(0, 16, [match(0, 4), match(12, 4)])
+        self.assertEqual([(4, 8)], undescribed_regions([parent], 16))
+
+    def test_overlapping_matches_do_not_create_gaps(self):
+        regions = undescribed_regions([match(0, 10), match(4, 6), match(2, 3)], 16)
+        self.assertEqual([(10, 6)], regions)
+
+    def test_a_match_nested_out_of_order_is_still_counted(self):
+        parent = match(0, 16, [match(8, 8), match(0, 2)])
+        self.assertEqual([(2, 6)], undescribed_regions([parent], 16))
+
+    def test_zero_length_matches_describe_nothing(self):
+        self.assertEqual([(0, 16)], undescribed_regions([match(4, 0)], 16))
+
+    def test_a_match_running_past_the_end_is_clamped(self):
+        self.assertEqual([], undescribed_regions([match(0, 1024)], 16))
+
+
+class GeneratedHtmlTests(TestCase):
+    """Test that the generated hex viewer carries the data it needs to mark undescribed bytes."""
+
+    def render(self, contents, struc):
+        with Tempfile(contents) as file_path:
+            return generate(file_path, sbud(contents, struc))
+
+    def emitted_regions(self, html):
+        emitted = re.search(r'const UNDESCRIBED_REGIONS = (\[.*?]);', html)
+        self.assertIsNotNone(emitted, 'the viewer script declares no undescribed regions')
+        return [tuple(region) for region in json.loads(emitted.group(1))]
+
+    def legend(self, html):
+        found = re.search(r'<div class="coverage">(.*?)</div>', html, re.DOTALL)
+        self.assertIsNotNone(found, 'the viewer has no coverage legend')
+        return ' '.join(found.group(1).split())
+
+    def test_a_file_with_gaps_emits_them(self):
+        html = self.render(bytes(16), [match(0, 16, [match(0, 4), match(12, 4)])])
+        self.assertEqual([(4, 8)], self.emitted_regions(html))
+        self.assertIn('8 of 16 bytes (50.0%) are undescribed.', self.legend(html))
+        self.assertIn('class="swatch undescribed"', html)
+
+    def test_a_fully_described_file_emits_no_gaps(self):
+        html = self.render(bytes(16), [match(0, 16)])
+        self.assertEqual([], self.emitted_regions(html))
+        self.assertIn('Every one of the 16 bytes is described by a match.', self.legend(html))
+        self.assertNotIn('class="swatch undescribed"', html)
+
+    def test_the_style_the_viewer_applies_is_defined(self):
+        html = self.render(bytes(16), [match(0, 16)])
+        self.assertIn(".toggleClass('undescribed'", html)
+        self.assertIn('.undescribed {', html)
+        self.assertIn('repeating-linear-gradient', html)


### PR DESCRIPTION
## The problem

The standalone HTML hex viewer renders every byte the same way, so nothing tells you which bytes
PolyFile described and which it passed over. Issue #8 puts it as "shows binary data at the next
offsets even if no value is defined by the JSON there."

Half of that report is now stale. `yes.png`, the file the issue was filed against, parses
completely today: `polyfile/kaitaimatcher.py` maps `image/png` to the Kaitai `image/png.ksy`
grammar, which yields 757 leaf matches covering all 5,877 bytes. The original reproducer no longer
reproduces.

The behavior it identified is still there for other files. The numbers below count bytes covered by
a match with no children, measured on `ffdf476`. Counting every match instead gives a meaningless
100% for any file, because each top-level match spans the whole file at offset 0.

| file | size | described by a match | undescribed |
|---|---|---|---|
| `yes.png` (#8) | 5,877 | 100.0% | 0 |
| `6fb9cceb.pdf` (#15) | 76,078 | 95.9% | 3,125 |
| `000899.pdf` (#26) | 135,640 | 90.1% | 13,441 |
| `optician-with-annots.pdf` (#19) | 527,477 | 84.7% | 80,572 |
| `398129.pdf` (#23) | 547,955 | 82.3% | 96,882 |

Tens of kilobytes per file render exactly like parsed bytes, with nothing marking them as
undescribed.

## The change

`polyfile.html.undescribed_regions()` walks the childless matches, merges their extents, and
returns the complement as `(offset, size)` pairs. The template hands that list to the viewer, which
expands it into one flag per byte at load time, so rendering a row costs one typed-array read per
byte rather than a search through the match tree.

Undescribed bytes render gray on a diagonal hatch in all three panes, and a legend above the dump
reports how many the file has. Two independent cues carry the meaning, so the marking survives
grayscale printing and color vision deficiency. The existing highlight classes set
`background-image: none`, so hover, search, and click highlighting look exactly as they did.

Nothing is removed, the SBUD schema is unchanged, and `html.generate()` keeps its signature. The
generated page stays standalone: no new asset, and no new dependency.

## Verification

Rendered `yes.png` and `398129.pdf` and opened both in Chrome 154. `yes.png` shows "Every one of
the 5,877 bytes is described by a match." and no hatching anywhere. `398129.pdf` shows the swatch
and "96,882 of 547,955 bytes (17.7%) are undescribed", with the hatch matching the emitted regions
byte for byte: offsets 0-23 hatched, 24-27 plain, 28 hatched, and so on. A DOM dump of the rendered
page confirms 105 of the 736 visible hex cells carry the `undescribed` class, exactly the cells the
region list names. Highlighting still wins over the hatch: with a match selected and the cursor on
byte 40, the red, yellow, and blue highlights render solid and unhatched over undescribed bytes.

Performance on `398129.pdf` (548 KB, 11,535 leaf matches, 46 visible rows), Chrome headless,
averaged over 200 iterations per run:

| measurement | `origin/master` | this branch |
|---|---|---|
| generated HTML | 11,297,314 bytes | 11,422,312 bytes (+1.1%) |
| load to interactive | 585 ms | 565 ms |
| re-render all 46 visible rows | 18.5 ms | 18.7 ms |
| one `mouseOverByte()` | 9.6 ms | 9.1 ms |

Per run, re-rendering takes 17.4-19.6 ms on `origin/master` and 18.0-20.0 ms here, so the 0.2 ms
difference in the mean sits inside the run-to-run spread. The extra bytes are the region list:
11,146 runs for this file, which is 125 KB of the 11 MB page.

`tests/unit/test_html.py` covers the region arithmetic and the emitted markup. It fails on
`origin/master` and passes here.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
