### PR TITLE
Decode .i and .I indirect offsets as ID3 synchsafe integers

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -427,56 +427,85 @@ class RelativeOffset(Offset):
         return f"&{self.relative_to}"
 
 
+def decode_id3_synchsafe(value: int) -> int:
+    """Decodes a 32-bit ID3v2 synchsafe integer.
+
+    An ID3v2 tag stores its size with only seven significant bits per byte so that the encoded
+    size can never be mistaken for an MPEG frame sync. This mirrors `cvt_id3` in libmagic's
+    `src/softmagic.c`, which libmagic applies to the `i` and `I` indirect offset types before
+    any offset arithmetic.
+
+    Args:
+        value: The four size bytes, already interpreted in the field's byte order.
+
+    Returns:
+        The decoded 28-bit integer.
+    """
+    return ((value & 0x7F)
+            | ((value >> 8 & 0x7F) << 7)
+            | ((value >> 16 & 0x7F) << 14)
+            | ((value >> 24 & 0x7F) << 21))
+
+
 class IndirectOffset(Offset):
     OctalIndirectOffset = -1
 
+    STRUCT_FORMATS: Dict[int, str] = {1: "B", 2: "H", 4: "I", 8: "Q"}
+
+    TYPE_NUM_BYTES: Dict[str, int] = {
+        "b": 1, "c": 1,
+        "h": 2, "s": 2,
+        "i": 4, "l": 4,
+        "e": 8, "f": 8, "g": 8, "q": 8,
+        "o": OctalIndirectOffset,
+    }
+
     def __init__(self, offset: Offset, num_bytes: int, endianness: Endianness, signed: bool,
-                 post_process: Callable[[int], int] = lambda n: n):
+                 post_process: Callable[[int], int] = lambda n: n, *, is_id3: bool = False):
         self.offset: Offset = offset
         self.num_bytes: int = num_bytes
         self.endianness: Endianness = endianness
         self.signed: bool = signed
         self.post_process: Callable[[int], int] = post_process
+        self.is_id3: bool = is_id3
         if self.endianness != Endianness.LITTLE and self.endianness != endianness.BIG:
             raise ValueError(f"Invalid endianness: {endianness!r}")
         elif num_bytes not in (1, 2, 4, 8, IndirectOffset.OctalIndirectOffset):
             raise ValueError(f"Invalid number of bytes: {num_bytes}")
+        elif is_id3 and num_bytes != 4:
+            raise ValueError(f"An ID3 indirect offset must be four bytes, not {num_bytes}")
 
-    def to_absolute(self, data: bytes, last_match: Optional[TestResult], allow_invalid: bool = False) -> int:
-        if self.num_bytes == IndirectOffset.OctalIndirectOffset:
-            # Special case: This is for the new octal type used here:
-            # https://github.com/file/file/blob/7a4e60a8f56ed45f76f28d2812a88d82efdc4bb8/magic/Magdir/gentoo#L81
-            offset = self.offset.to_absolute(data, last_match)
-            octal_string_end = offset
-            while octal_string_end < len(data) and ord('0') <= data[octal_string_end] <= ord('7'):
-                octal_string_end += 1
-            value: Optional[int] = None
-            if octal_string_end > offset:
-                try:
-                    value = int(data[:octal_string_end], 8)
-                except ValueError:
-                    pass
-            if value is None:
-                if allow_invalid:
-                    value = 0
-                else:
-                    return len(data)
-                    # raise ValueError(f"Invalid octal string expected for {self} at file offset {offset}")
-            return self.post_process(value)
-        elif self.num_bytes == 1:
-            fmt = "B"
-        elif self.num_bytes == 2:
-            fmt = "H"
-        elif self.num_bytes == 8:
-            fmt = "Q"
-        else:
-            fmt = "I"
+    def _octal_to_absolute(self, data: bytes, last_match: Optional[TestResult],
+                           allow_invalid: bool) -> int:
+        # This is for the octal type used here:
+        # https://github.com/file/file/blob/7a4e60a8f56ed45f76f28d2812a88d82efdc4bb8/magic/Magdir/gentoo#L81
+        offset = self.offset.to_absolute(data, last_match)
+        octal_string_end = offset
+        while octal_string_end < len(data) and ord('0') <= data[octal_string_end] <= ord('7'):
+            octal_string_end += 1
+        value: Optional[int] = None
+        if octal_string_end > offset:
+            try:
+                value = int(data[:octal_string_end], 8)
+            except ValueError:
+                pass
+        if value is None:
+            if not allow_invalid:
+                return len(data)
+            value = 0
+        return self.post_process(value)
+
+    def _struct_format(self) -> str:
+        fmt = IndirectOffset.STRUCT_FORMATS[self.num_bytes]
         if self.signed:
             fmt = fmt.lower()
         if self.endianness == Endianness.LITTLE:
-            fmt = f"<{fmt}"
-        else:
-            fmt = f">{fmt}"
+            return f"<{fmt}"
+        return f">{fmt}"
+
+    def to_absolute(self, data: bytes, last_match: Optional[TestResult], allow_invalid: bool = False) -> int:
+        if self.num_bytes == IndirectOffset.OctalIndirectOffset:
+            return self._octal_to_absolute(data, last_match, allow_invalid)
         offset = self.offset.to_absolute(data, last_match)
         to_unpack = data[offset:offset + self.num_bytes]
         if len(to_unpack) < self.num_bytes:
@@ -484,7 +513,10 @@ class IndirectOffset(Offset):
                 return len(data)
             else:
                 raise InvalidOffsetError(offset=self)
-        return self.post_process(struct.unpack(fmt, to_unpack)[0])
+        value = struct.unpack(self._struct_format(), to_unpack)[0]
+        if self.is_id3:
+            value = decode_id3_synchsafe(value)
+        return self.post_process(value)
 
     NUMBER_PATTERN: str = r"(0[xX][\dA-Fa-f]+|\d+)L?"
     INDIRECT_OFFSET_PATTERN: Pattern[str] = re.compile(
@@ -495,14 +527,57 @@ class IndirectOffset(Offset):
         r"\)$"
     )
 
+    @staticmethod
+    def _parse_post_process(pp: Optional[str]) -> Callable[[int], int]:
+        if pp is None:
+            return lambda n: n
+        multiply = pp.startswith("*")
+        bitwise_and = pp.startswith("&")
+        divide = pp.startswith("/")
+        if multiply or bitwise_and or divide:
+            pp = pp[1:]
+        if pp.startswith("+"):
+            pp = pp[1:]
+        if pp.startswith("(") and pp.endswith(")"):
+            # some definition files like `msdos` have indirect offsets of the form: >>>(&0x0f.l+(-4))
+            # Handle those nested parenthesis around the `(-4)` here. This is an undocumented part of the DSL,
+            # so, TODO: confirm we are handling it properly and it's not something more complex like a nested
+            #           indirect offset
+            pp = pp[1:-1]
+        operand = parse_numeric(pp)
+        if multiply:
+            return lambda n: n * operand
+        elif bitwise_and:
+            return lambda n: n & operand
+        elif divide:
+            return lambda n: n // operand
+        return lambda n: n + operand
+
     @classmethod
     def parse(cls, offset: str) -> "IndirectOffset":
+        """Parses an indirect offset such as `(6.I+10)`.
+
+        The type character selects the width and byte order of the field to read, following
+        libmagic's `parse_type` in `src/apprentice.c`: `l`/`L` are four-byte integers, `i`/`I`
+        are four-byte ID3v2 synchsafe integers, and an absent type defaults to a four-byte
+        integer. A lowercase character means little endian and an uppercase one big endian.
+
+        Args:
+            offset: The parenthesized text of the offset, including its surrounding parentheses.
+
+        Returns:
+            The parsed offset.
+
+        Raises:
+            ValueError: If `offset` is not a valid indirect offset, or names an unsupported type.
+            NotImplementedError: If `offset` uses middle endianness.
+        """
         m = cls.INDIRECT_OFFSET_PATTERN.match(offset)
         if not m:
             raise ValueError(f"Invalid indirect offset: {offset!r}")
         t = m.group("type")
         if t is None:
-            t = "I"
+            t = "L"
         if t == "m":
             raise NotImplementedError("TODO: Add support for middle endianness")
         elif t.islower():
@@ -510,56 +585,21 @@ class IndirectOffset(Offset):
         else:
             endianness = Endianness.BIG
         t = t.lower()
-        if t in ("b", "c"):
-            num_bytes = 1
-        elif t in ("e", "f", "g", "q"):
-            num_bytes = 8
-        elif t in ("h", "s"):
-            num_bytes = 2
-        elif t in ("i", "l"):
-            # TODO: Confirm that "l" should really be here
-            num_bytes = 4
-        elif t in ("o",):
-            num_bytes = IndirectOffset.OctalIndirectOffset
-        else:
+        if t not in cls.TYPE_NUM_BYTES:
             raise ValueError(f"Unsupported indirect specifier type: {m.group('type')!r}")
-        pp = m.group("post_process")
-        if pp is None:
-            post_process = lambda n: n
-        else:
-            multiply = pp.startswith("*")
-            bitwise_and = pp.startswith("&")
-            divide = pp.startswith("/")
-            if multiply or bitwise_and or divide:
-                pp = pp[1:]
-            if pp.startswith("+"):
-                pp = pp[1:]
-            if pp.startswith("(") and pp.endswith(")"):
-                # some definition files like `msdos` have indirect offsets of the form: >>>(&0x0f.l+(-4))
-                # Handle those nested parenthesis around the `(-4)` here. This is an undocumented part of the DSL,
-                # so, TODO: confirm we are handling it properly and it's not something more complex like a nested
-                #           indirect offset
-                pp = pp[1:-1]
-            operand = parse_numeric(pp)
-            if multiply:
-                post_process = lambda n: n * operand
-            elif bitwise_and:
-                post_process = lambda n: n & operand
-            elif divide:
-                post_process = lambda n: n // operand
-            else:
-                post_process = lambda n: n + operand
         return IndirectOffset(
             offset=Offset.parse(m.group("offset")),
-            num_bytes=num_bytes,
+            num_bytes=cls.TYPE_NUM_BYTES[t],
             endianness=endianness,
             signed=m.group("signedness") == ",",
-            post_process=post_process
+            post_process=cls._parse_post_process(m.group("post_process")),
+            is_id3=t == "i"
         )
 
     def __repr__(self):
         return f"{self.__class__.__name__}(offset={self.offset!r}, num_bytes={self.num_bytes}, "\
-               f"endianness={self.endianness!r}, signed={self.signed}, post_process={self.post_process!r})"
+               f"endianness={self.endianness!r}, signed={self.signed}, "\
+               f"post_process={self.post_process!r}, is_id3={self.is_id3})"
 
     def __str__(self):
         if self.num_bytes == IndirectOffset.OctalIndirectOffset:

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -75,6 +75,56 @@ class MagicTest(TestCase):
                 self.assertIs(polyfile.magic.DataTypeMatch.INVALID,
                               data_type.match(data, UUID(int=0)))
 
+    def test_id3_synchsafe_decode(self):
+        """Tests that `decode_id3_synchsafe` drops bit 7 of every byte and repacks the rest.
+
+        This is a regression test for trailofbits/polyfile#3485. An ID3v2 tag stores its size
+        with seven significant bits per byte, so a plain four-byte read overstates it: the size
+        field `00 00 10 24` is 2084, not 0x1024.
+        """
+        self.assertEqual(2084, polyfile.magic.decode_id3_synchsafe(0x00001024))
+        self.assertEqual(0x0FFFFFFF, polyfile.magic.decode_id3_synchsafe(0x7F7F7F7F))
+        self.assertEqual(0, polyfile.magic.decode_id3_synchsafe(0x80808080))
+        for shift, expected in ((0, 1), (8, 1 << 7), (16, 1 << 14), (24, 1 << 21)):
+            with self.subTest(shift=shift):
+                self.assertEqual(expected, polyfile.magic.decode_id3_synchsafe(1 << shift))
+
+    def test_id3_indirect_offset_byte_orders(self):
+        """Tests that `.i` and `.I` indirect offsets read their field as an ID3 synchsafe integer.
+
+        This is a regression test for trailofbits/polyfile#3485. libmagic maps the `i` and `I`
+        indirect types to FILE_LEID3 and FILE_BEID3 and applies `cvt_id3` before the offset
+        arithmetic, so `>(6.I+10)` in `magic_defs/audio` resolves to 2094 and not to 4142. The
+        `10 7a` case pins the decode ahead of the `+10`: decoding afterwards carries `0x7a + 10`
+        into bit 7 and yields 2052 instead of 2180.
+        """
+        for spec, size_field, endianness, expected in (
+                ("(6.I+10)", b"\x00\x00\x10\x24", polyfile.magic.Endianness.BIG, 2094),
+                ("(6.i+10)", b"\x24\x10\x00\x00", polyfile.magic.Endianness.LITTLE, 2094),
+                ("(6.I+10)", b"\x00\x00\x10\x7a", polyfile.magic.Endianness.BIG, 2180)):
+            with self.subTest(offset=spec, size_field=size_field):
+                offset = polyfile.magic.IndirectOffset.parse(spec)
+                self.assertTrue(offset.is_id3)
+                self.assertEqual(endianness, offset.endianness)
+                header = b"ID3\x02\x00\x00" + size_field
+                self.assertEqual(expected, offset.to_absolute(header, None))
+        for spec in ("(6.l+10)", "(6.L+10)", "(6+10)"):
+            with self.subTest(offset=spec):
+                self.assertFalse(polyfile.magic.IndirectOffset.parse(spec).is_id3)
+
+    def test_id3v2_tag_locates_its_audio_frames(self):
+        """Tests that an ID3v2 tag's indirect offset lands on the MPEG frame that follows it.
+
+        This is a regression test for trailofbits/polyfile#3485. `magic_defs/audio` reaches the
+        audio frames with `>(6.I+10) indirect`; without the synchsafe decode PolyFile read the
+        2084-byte tag size as 4132 and reported `contains: data`.
+        """
+        tag = b"ID3\x02\x00\x00\x00\x00\x10\x24"
+        data = tag + b"A" * (2094 - len(tag)) + b"\xff\xfb\x70\xc0" + b"\x55" * 380
+        matches = {str(match) for match in MagicMatcher.DEFAULT_INSTANCE.match(data)}
+        self.assertIn("Audio file with ID3 version 2.2.0, contains: MPEG ADTS, layer III, v1, "
+                      "96 kbps, 44.1 kHz, Monaural", matches)
+
     def test_text_tests(self):
         matcher = MagicMatcher.parse(*MAGIC_DEFS)
         self.assertEqual(len(matcher.text_tests & matcher.non_text_tests), 0)

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -395,7 +395,7 @@ class MagicTest(TestCase):
                         matches.add(actual)
                         print(f"\tActual:   {actual!r}")
                     if testfile.stem not in (
-                            "JW07022A.mp3", "gedcom", "cmd1", "cmd2", "cmd3", "cmd4", "jpeg-text", "jsonlines1",
+                            "gedcom", "cmd1", "cmd2", "cmd3", "cmd4", "jpeg-text", "jsonlines1",
                             "multiple", "osm", "pnm1", "pnm2", "pnm3", "utf16xmlsvg"
                     ):
                         # The files we skip fail because there is a bug in our implementation that we have not yet fixed


### PR DESCRIPTION
Closes #3485

## The problem

`polyfile/magic_defs/audio:322` reaches an MP3's audio frames through the ID3v2 tag size:

```
>(6.I+10)	indirect	x	\b, contains:
```

An ID3v2 size field is a *synchsafe* integer: it stores only the low seven bits of each byte, so
the encoded size can never contain a false MPEG frame sync. libmagic maps the `i` and `I` indirect
offset types to `FILE_LEID3` and `FILE_BEID3` (`file/src/apprentice.c:2198-2202`) and runs
`cvt_id3` (`file/src/softmagic.c:1015-1025`) on the four bytes *before* applying the offset
arithmetic (`file/src/softmagic.c:1803-1811`):

```c
lhs = BE32(p->hl);
if (in_type == FILE_BEID3)
	lhs = cvt_id3(ms, CAST(uint32_t, lhs));
if (do_ops(ms, m, &offset, SEXT(sgn,32,lhs), off))
	return 0;
```

PolyFile read the field as a plain four-byte integer. `IndirectOffset.parse` lumped `i` in with
`l` behind a `# TODO: Confirm that "l" should really be here`, and `IndirectOffset.to_absolute`
had no ID3 branch.

For `file/tests/JW07022A.mp3.testfile`, whose header is `49 44 33 02 00 00 00 00 10 24 …`:

| | value at bytes 6-9 | after `+10` |
| --- | --- | --- |
| libmagic (`cvt_id3`) | `(0<<21) \| (0<<14) \| (0x10<<7) \| 0x24` = 2084 | **2094** |
| PolyFile (`>I`) | `0x00001024` = 4132 | **4142** |

Byte 2094 is `ff fb 70 c0`, the MPEG frame sync. Byte 4142 is mid-frame. `file -d` confirms the
decoded value:

```
$ TZ=UTC file/src/file -d -m file/magic/magic.mgc file/tests/JW07022A.mp3.testfile 2>&1 | grep 'id3 offs'
id3 offs=2084
```

Before:

```
Audio file with ID3 version 2.2.0, contains: data
```

After:

```
Audio file with ID3 version 2.2.0, contains: MPEG ADTS, layer III, v1, 96 kbps, 44.1 kHz, Monaural
```

which is exactly `file/tests/JW07022A.mp3.result`.

## The change

- `decode_id3_synchsafe` mirrors `cvt_id3`, and `IndirectOffset.to_absolute` applies it after the
  `struct.unpack` and before `post_process`, matching libmagic's order. Order matters: the
  regression test uses a `10 7a` size field, where decoding after the `+10` carries `0x7a + 10`
  into bit 7 and yields 2052 instead of 2180. The corpus file's own `10 24` field cannot tell the
  two orders apart, because `0x24 + 10` stays inside seven bits.
- `IndirectOffset.parse` now dispatches through a type table. That resolves the `"l"` TODO: per
  `apprentice.c`, `.l` is `FILE_LELONG` and `.L` is `FILE_BELONG`, so four bytes is correct, and
  only `.i`/`.L`'s ID3 siblings need the decode.
- The default for an absent type changed from `I` to `L`. This is behavior-preserving (both are
  four bytes big-endian in PolyFile), but it keeps `t.lower() == "i"` from marking the 500-odd
  untyped indirect offsets in the definitions as ID3.
- `to_absolute` and `parse` were each over 50 lines and over the complexity limit before this
  change, so the octal case, the struct format, and the post-process parsing moved into helpers.
  flake8 findings drop from 189 to 182 (two `C901`, five `E731`); none are added.

## Scope

Exactly one ID3 indirect offset exists in the definitions. Walking all 25,017 parsed tests finds
`audio:322` and nothing else. The issue mentions `polyfile/magic_defs/audio:921` as a second
`indirect` reading the same field; that is not the case. Line 921 is
`>>>>>>&-4	indirect	x` inside the Garmin Voice Processing Module block, reached through
`(&-8.l)` — a plain little-endian long, not ID3. It is unaffected either way.

## The `tar archive (old)` match is expected

The same file also matches `tar archive (old), type 'C' ID3\x02, …`. That is not a defect. The
reference binary reports it too; it is simply weaker than the ID3 match, and PolyFile reports every
match rather than only the strongest one:

```
$ TZ=UTC file/src/file -b -k -m file/magic/magic.mgc file/tests/JW07022A.mp3.testfile
Audio file with ID3 version 2.2.0, contains: MPEG ADTS, layer III, v1, 96 kbps, 44.1 kHz, Monaural
- -  tar archive (old), type 'C' ID3\002, mode 0 00000, uid D0 0000, gid 000 000, size 5223 0000000,
seconds 0 000000D0 , linkname OM, comment: 0000000 00000000 00000000 00000000
- data
```

`test_file_corpus` asserts that the expected string is *among* the matches, so the extra match does
not affect the verdict.

## Verification

Corpus differential over the 88 stems of `file/tests`, using the same normalization as
`test_file_corpus`:

```
NEWLY PASSING (1): ['JW07022A.mp3']
STILL FAILING (13): ['cmd1', 'cmd2', 'cmd3', 'cmd4', 'gedcom', 'jpeg-text', 'jsonlines1', 'multiple', 'osm', 'pnm1', 'pnm2', 'pnm3', 'utf16xmlsvg']
REGRESSIONS   (0):
```

`pytest tests`:

| | before | after |
| --- | --- | --- |
| passed | 1007 | 1010 |
| skipped | 8 | 8 |
| subtests passed | 362 | 372 |
| failed | 0 | 0 |

The three new tests account for the three additional test cases and ten additional subtests.

Each new test was checked against a deliberately broken fix: a no-op decode, `parse` never setting
the ID3 flag, the decode applied after `post_process` instead of before, and the untyped default
reverted to `I`. Every break produced a failure in at least one of the new tests, and the tests
pass again once the fix is restored.

## Sequencing

#3487 converts `test_file_corpus`'s skip tuple into a `KNOWN_FAILURES` map. It should merge after
this PR, since this PR removes `JW07022A.mp3` from that tuple.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VS8hTTRQeG8ZCmCZ9KLHiV
