### PR TITLE
Load corpus sidecars and assert that known failures still fail

### DIFF
--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -41,6 +41,46 @@ def tag_length_value(tag: int, value: bytes) -> bytes:
     return bytes((tag, len(value))) + value
 
 
+def corpus_matcher(test: str) -> MagicMatcher:
+    """Builds the matcher for one libmagic corpus test.
+
+    Upstream's runner loads every `<stem>*.magic` sidecar, joined with the path separator, and
+    falls back to the compiled definitions when a test ships none (`file/tests/Makefile.am`).
+
+    Args:
+        test: The stem shared by the test's `.testfile`, `.result` and sidecar files.
+
+    Returns:
+        A matcher parsed from the test's sidecars, or the default matcher when it has none.
+    """
+    sidecars = sorted(FILE_TEST_DIR.glob(f"{test}*.magic"))
+    if not sidecars:
+        return MagicMatcher.DEFAULT_INSTANCE
+    print(f"\tParsing custom match scripts: {', '.join(s.name for s in sidecars)}")
+    return MagicMatcher.parse(*sidecars)
+
+
+def corpus_flags(test: str) -> str:
+    """Reads the libmagic flags that produced a corpus test's expected result.
+
+    Upstream's runner appends the contents of `<stem>.flags` to the flags it hands to
+    `magic_open` (`file/tests/Makefile.am` and `file/tests/test.c`). `k` is `MAGIC_CONTINUE`,
+    which makes `file` report every match instead of only the strongest one, joining them with
+    `\\012- `. PolyFile always reports every match and never builds that join (issue #3491), so
+    the harness only reports the flags rather than emulating them.
+
+    Args:
+        test: The stem shared by the test's `.testfile`, `.result` and `.flags` files.
+
+    Returns:
+        The flag letters, or the empty string when the test ships no `.flags` file.
+    """
+    flags = FILE_TEST_DIR / f"{test}.flags"
+    if not flags.exists():
+        return ""
+    return flags.read_text().strip()
+
+
 class MagicTest(TestCase):
     _old_local_date: Optional[Callable[[int], str]] = None
 
@@ -310,8 +350,6 @@ class MagicTest(TestCase):
         self.assertTrue(FILE_TEST_DIR.exists(), "Make sure to run `git submodule init && git submodule update` in the "
                                                 "root of this repository.")
 
-        default_matcher = MagicMatcher.DEFAULT_INSTANCE
-
         tests = sorted([
             f.stem for f in FILE_TEST_DIR.glob("*.testfile")
         ])
@@ -324,15 +362,12 @@ class MagicTest(TestCase):
                 if not testfile.exists() or not result.exists():
                     continue
 
-                magicfile = FILE_TEST_DIR / f"{test}.magic"
-
                 print(f"Testing: {test}")
 
-                if magicfile.exists():
-                    print(f"\tParsing custom match script: {magicfile.stem}")
-                    matcher = MagicMatcher.parse(magicfile)
-                else:
-                    matcher = default_matcher
+                matcher = corpus_matcher(test)
+                flags = corpus_flags(test)
+                if flags:
+                    print(f"\tlibmagic flags: -{flags}")
 
                 with open(result, "r") as f:
                     expected = f.read()

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -6,7 +6,7 @@ import time
 import zlib
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Callable, Iterator, List, Optional, Set, Tuple
+from typing import Callable, Dict, Iterator, List, Optional, Set, Tuple
 from unittest import TestCase
 from uuid import UUID
 
@@ -19,6 +19,30 @@ from polyfile.magic import MagicMatcher, MAGIC_DEFS, Match, MatchContext, Search
 # logger.setLevel(logger.TRACE)
 
 FILE_TEST_DIR: Path = Path(__file__).parent.parent / "file" / "tests"
+
+KNOWN_FAILURES: Dict[str, int] = {
+    # `test_file_corpus` asserts that each of these stems still fails, so fixing one of these bugs
+    # includes deleting its stems from this map in the same change. Each value is the first issue
+    # that has to be fixed for the stem to pass, and the trailing comment names what blocks it
+    # after that. Issue #3480 tracks the whole set.
+    "JW07022A.mp3": 3485,
+    "cmd1": 3483,           # then #3488 and #3490
+    "cmd2": 3483,           # then #3488 and #3490
+    "cmd3": 3483,
+    "cmd4": 3483,
+    "gedcom": 3483,         # then #3488
+    "jpeg-text": 3488,
+    "jsonlines1": 3486,
+    # Issue #3487 makes the harness load the two `multiple*.magic` sidecars, but the harness still
+    # cannot express the test's `k` flag, because PolyFile has no MAGIC_CONTINUE join.
+    "multiple": 3487,       # then #3491 and #3477
+    "osm": 3488,
+    "pnm1": 3482,           # then #3488
+    "pnm2": 3482,
+    "pnm3": 3482,           # then #3488
+    "utf16xmlsvg": 3484,    # then #3488 and #3489
+}
+"""Corpus stems that cannot pass yet, each mapped to the issue that has to be fixed first."""
 
 DER_CERTIFICATE: Path = Path(__file__).absolute().parent / "msjdbc.cer.gz"
 
@@ -79,6 +103,32 @@ def corpus_flags(test: str) -> str:
     if not flags.exists():
         return ""
     return flags.read_text().strip()
+
+
+def corpus_result_matches(expected: str, matches: Set[str]) -> bool:
+    """Reports whether PolyFile's matches include libmagic's expected description.
+
+    The comparison ignores case and trailing whitespace, and it works around two known
+    formatting differences between PolyFile and libmagic.
+
+    Args:
+        expected: The contents of the test's `.result` file.
+        matches: The description of every match PolyFile reported for the test file.
+
+    Returns:
+        True if one of `matches` corresponds to `expected`.
+    """
+    if expected == "ASCII text" and expected not in matches:
+        # PolyFile emits "ascii text" in lower case; part of issue #3488.
+        return expected.lower() in matches
+    expected = expected.rstrip().lower()
+    lowered = {match.rstrip().lower() for match in matches}
+    if "00000000" in expected and expected not in lowered:
+        # Technically correct, but PolyFile formats a zero as "0x000000"; part of issue #3488.
+        return expected.replace("00000000", "0x000000") in lowered
+    if expected.startswith("hancom hwp"):
+        return any(match.endswith(expected) for match in lowered)
+    return expected in lowered
 
 
 class MagicTest(TestCase):
@@ -350,52 +400,62 @@ class MagicTest(TestCase):
         self.assertTrue(FILE_TEST_DIR.exists(), "Make sure to run `git submodule init && git submodule update` in the "
                                                 "root of this repository.")
 
-        tests = sorted([
-            f.stem for f in FILE_TEST_DIR.glob("*.testfile")
-        ])
-
-        for test in tests:
+        for test in sorted(f.stem for f in FILE_TEST_DIR.glob("*.testfile")):
             with self.subTest(test=test):
-                testfile = FILE_TEST_DIR / f"{test}.testfile"
-                result = FILE_TEST_DIR / f"{test}.result"
+                self.check_corpus_test(test)
 
-                if not testfile.exists() or not result.exists():
-                    continue
+    def check_corpus_test(self, test: str):
+        """Runs one libmagic corpus test and asserts the verdict `KNOWN_FAILURES` calls for.
 
-                print(f"Testing: {test}")
+        Args:
+            test: The stem shared by the test's `.testfile`, `.result` and sidecar files.
+        """
+        testfile = FILE_TEST_DIR / f"{test}.testfile"
+        result = FILE_TEST_DIR / f"{test}.result"
 
-                matcher = corpus_matcher(test)
-                flags = corpus_flags(test)
-                if flags:
-                    print(f"\tlibmagic flags: -{flags}")
+        if not testfile.exists() or not result.exists():
+            return
 
-                with open(result, "r") as f:
-                    expected = f.read()
-                    print(f"\tExpected: {expected!r}")
+        print(f"Testing: {test}")
+        matcher = corpus_matcher(test)
+        flags = corpus_flags(test)
+        if flags:
+            print(f"\tlibmagic flags: -{flags}")
 
-                with open(testfile, "rb") as f:
-                    matches = set()
-                    for match in matcher.match(f.read()):
-                        actual = str(match)
-                        matches.add(actual)
-                        print(f"\tActual:   {actual!r}")
-                    if testfile.stem not in (
-                            "JW07022A.mp3", "gedcom", "cmd1", "cmd2", "cmd3", "cmd4", "jpeg-text", "jsonlines1",
-                            "multiple", "osm", "pnm1", "pnm2", "pnm3", "utf16xmlsvg"
-                    ):
-                        # The files we skip fail because there is a bug in our implementation that we have not yet fixed
-                        if expected == "ASCII text" and expected not in matches:
-                            self.assertIn(expected.lower(), matches)
-                        else:
-                            expected = expected.rstrip().lower()
-                            matches = [m.rstrip().lower() for m in matches]
-                            if "00000000" in expected and expected not in matches:
-                                # our output is technically correct but we output "0x000000" instead of "00000000"
-                                self.assertIn(expected.replace("00000000", "0x000000"), matches)
-                            elif expected.startswith("hancom hwp"):
-                                self.assertTrue(any(m.endswith(expected) for m in matches))
-                            else:
-                                self.assertIn(expected, matches)
+        expected = result.read_text()
+        print(f"\tExpected: {expected!r}")
+
+        with open(testfile, "rb") as f:
+            matches = {str(match) for match in matcher.match(f.read())}
+        for actual in sorted(matches):
+            print(f"\tActual:   {actual!r}")
+
+        self.assert_corpus_verdict(test, expected, matches, flags)
+
+    def assert_corpus_verdict(self, test: str, expected: str, matches: Set[str], flags: str):
+        """Asserts that a corpus test passes, or that it still fails if `KNOWN_FAILURES` maps it.
+
+        Args:
+            test: The stem of the corpus test.
+            expected: The contents of the test's `.result` file.
+            matches: The description of every match PolyFile reported for the test file.
+            flags: The libmagic flag letters from the test's `.flags` file, if it ships one.
+        """
+        matched = corpus_result_matches(expected, matches)
+        issue = KNOWN_FAILURES.get(test)
+        context = f" (libmagic ran with -{flags})" if flags else ""
+        if issue is None:
+            self.assertTrue(matched, (
+                f"{test} does not match libmagic{context}: expected {expected!r}, but PolyFile "
+                f"reported {sorted(matches)!r}. If this is a bug we have filed, add {test!r} to "
+                f"KNOWN_FAILURES in tests/test_magic.py, mapped to that issue number."
+            ))
+        else:
+            self.assertFalse(matched, (
+                f"{test} now matches libmagic{context}, so issue #{issue} looks fixed. Delete "
+                f"{test!r} from KNOWN_FAILURES in tests/test_magic.py so that this test keeps "
+                f"checking it, and close issue #{issue} if nothing else blocks it."
+            ))
 
 
 MATCH_TIMEOUT_SECONDS: int = 60


### PR DESCRIPTION
Closes #3487

`tests/test_magic.py::test_file_corpus` ignored the per-test sidecars that the libmagic corpus
ships, and hid 14 stems behind a blanket skip list that asserted nothing. This is a test-only
change; nothing under `polyfile/` is touched.

## Part 1: load every sidecar, and read `.flags`

The harness loaded a per-test magic script only when it was named exactly `<stem>.magic`. Upstream's
runner globs `${stem}*.magic` and joins the hits with the path separator
(`file/tests/Makefile.am:211-234`):

```make
for j in $$(eval echo $${t}\*.magic); do \
    if [ -f "$$j" ]; then \
        if [ -z "$$m" ]; then m=$$j; else m=$$m${PATH_SEPARATOR}$$j; fi \
    fi \
done; \
```

`MagicMatcher.parse` already accepts several paths, so `corpus_matcher` now globs `<stem>*.magic`
and passes every hit. The `multiple` test is the one that needed it: it ships `multiple-A.magic` and
`multiple-B.magic`, and was previously matched against the default definitions.

The glob is safe for the rest of the corpus. There are exactly four sidecars, and each is picked up
only by the stem that owns it:

```
multiple    -> multiple-A.magic, multiple-B.magic
regex-eol   -> regex-eol.magic
searchbug   -> searchbug.magic
```

No other testfile stem is a prefix of any sidecar name, so no other test's matcher changes. With
`-s` the harness prints exactly those three lines.

The same runner appends `<stem>.flags` to the flags it hands to `magic_open`
(`file/tests/Makefile.am:227-229`, `file/tests/test.c:100-110`), where `k` is `MAGIC_CONTINUE`.
`multiple.flags` contains `k` and is the only `.flags` file in the corpus. `corpus_flags` reads it,
the harness reports it, and its failure messages say which flags produced the expected result. It
does not emulate the flag: `k` makes `file` report every match joined with `\012- `, and PolyFile
has no such join (#3491).

## What `multiple` looks like now

With both sidecars loaded, PolyFile finds all four names, but not the encoding trailer that
`file_ascmagic` appends to the last one:

```
expected: Viva File 2.0\012- RTF1.0\012- Test File 1.0\012- ABCD File, ASCII text, with no line terminators
actual:   ABCD File, RTF1.0, Test File 1.0, Viva File 2.0
```

So `multiple` still fails, and it stays in the map.

### Suggestion, not implemented here

The harness could split the expected result on `\012- ` and require every part to appear among the
matches. That would express `k` without a `MAGIC_CONTINUE` implementation, and it would affect no
other stem, since `multiple` is the only test with a `.flags` file. I left it out because it changes
what blocks `multiple`: with the split, the join (#3491) stops being a blocker and only the encoding
trailer (#3488) and the strength ordering (#3477) remain. That is a call for the reviewer, not
something to slip in under a harness fix.

## Part 2: `KNOWN_FAILURES` replaces the skip list

The old list was a tuple of stems that skipped the assertion entirely, so a stem that started
passing went unnoticed and the list never shrank:

```python
if testfile.stem not in (
        "JW07022A.mp3", "gedcom", "cmd1", "cmd2", "cmd3", "cmd4", "jpeg-text", "jsonlines1",
        "multiple", "osm", "pnm1", "pnm2", "pnm3", "utf16xmlsvg"
):
    # The files we skip fail because there is a bug in our implementation that we have not yet fixed
```

It is now a map from stem to the issue that has to be fixed first:

```python
KNOWN_FAILURES: Dict[str, int] = {
    # `test_file_corpus` asserts that each of these stems still fails, so fixing one of these bugs
    # includes deleting its stems from this map in the same change. Each value is the first issue
    # that has to be fixed for the stem to pass, and the trailing comment names what blocks it
    # after that. Issue #3480 tracks the whole set.
    "JW07022A.mp3": 3485,
    "cmd1": 3483,           # then #3488 and #3490
    "cmd2": 3483,           # then #3488 and #3490
    "cmd3": 3483,
    "cmd4": 3483,
    "gedcom": 3483,         # then #3488
    "jpeg-text": 3488,
    "jsonlines1": 3486,
    # Issue #3487 makes the harness load the two `multiple*.magic` sidecars, but the harness still
    # cannot express the test's `k` flag, because PolyFile has no MAGIC_CONTINUE join.
    "multiple": 3487,       # then #3491 and #3477
    "osm": 3488,
    "pnm1": 3482,           # then #3488
    "pnm2": 3482,
    "pnm3": 3482,           # then #3488
    "utf16xmlsvg": 3484,    # then #3488 and #3489
}
```

The assertion runs in both directions, still inside `self.subTest`, so one stem's verdict does not
hide another's:

```python
matched = corpus_result_matches(expected, matches)
issue = KNOWN_FAILURES.get(test)
if issue is None:
    self.assertTrue(matched, ...)   # an unmapped stem must pass, exactly as before
else:
    self.assertFalse(matched, ...)  # a mapped stem must still fail
```

A stem that is not mapped must pass. A stem that is mapped must fail; if it starts passing, the
test fails with a message naming the issue and telling the reader to delete the entry. Deleting a
stem from the map is now part of fixing its bug, so no fix can land silently and the list only
shrinks deliberately.

The comparison moved into `corpus_result_matches`, which returns one boolean, and
`test_file_corpus` was split into `check_corpus_test` and `assert_corpus_verdict` to stay within
the project's function-length limit. The two undocumented escape hatches now cite their issue:
lower-case `ascii text` and the `0x000000` zero formatting are both part of #3488.

Two observations about them, for a follow-up rather than this PR:

- The `expected == "ASCII text"` branch is unreachable against libmagic 5.48. `expected` is the raw
  contents of the `.result` file, and every `.result` file ends with a newline, so the comparison
  never holds. `json5` and `json7` reach the same outcome through the `rstrip().lower()` path.
- The `hancom hwp` branch accepts a suffix match rather than an exact one, and has no issue behind
  it. I left both as they were.

## Negative tests, proving the assertion works

Both were run against the committed code and then reverted.

Adding a stem that currently passes (`json5`) to the map:

```
AssertionError: True is not false : json5 now matches libmagic, so issue #3486 looks fixed.
Delete 'json5' from KNOWN_FAILURES in tests/test_magic.py so that this test keeps checking it,
and close issue #3486 if nothing else blocks it.
1 failed, 1 passed, 20 deselected, 87 subtests passed
```

Deleting a mapped stem (`pnm2`) from the map:

```
AssertionError: False is not true : pnm2 does not match libmagic: expected 'Netpbm image data,
size = 2 x 2, rawbits, greymap\n', but PolyFile reported [', rawbits, greymap']. If this is a bug
we have filed, add 'pnm2' to KNOWN_FAILURES in tests/test_magic.py, mapped to that issue number.
1 failed, 1 passed, 20 deselected, 87 subtests passed
```

## Verification

```
$ python -m pytest tests/test_magic.py -q
21 passed, 91 subtests passed

$ python -m pytest tests -q
1007 passed, 8 skipped, 362 subtests passed

$ python -m flake8 polyfile polymerge tests --max-complexity=10 --max-line-length=127 \
      --exclude=polyfile/kaitai/parsers
241    # unchanged from master; zero findings in tests/test_magic.py, zero in E9,F63,F7,F82
```

`test_file_corpus` contributes 88 subtests before and after, the same as on `master`. The
difference is that the 14 mapped stems are now asserted to fail instead of asserting nothing.

## Merge order

**This PR should merge last**, after the four sibling PRs, and it will need a rebase. Each sibling
fixes a bug and deletes its own entries from the map, so the map here is the full 14-stem set as it
stands on `master`:

| sibling | deletes from `KNOWN_FAILURES` |
| --- | --- |
| #3482 | `pnm2` |
| #3483 | `cmd3`, `cmd4` |
| #3485 (PR #3492) | `JW07022A.mp3` |
| #3486 | `jsonlines1` |

If a sibling merges after this PR instead, its stem will trip the "now matches libmagic" assertion,
which is the intended signal: the fix has to delete the entry.

Part of #3480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VS8hTTRQeG8ZCmCZ9KLHiV
