### PR TITLE
Detect newline-delimited JSON

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 PolyFile is a file analysis utility that identifies and maps the semantic and syntactic structure of files—including polyglots, chimeras, and "schizophrenic" files that are validly multiple types simultaneously.
 
 **Key capabilities:**
-- Pure-Python libmagic implementation (895 MIME types, from libmagic 5.48)
+- Pure-Python libmagic implementation (896 MIME types, from libmagic 5.48)
 - Recursive embedded file detection (like binwalk)
 - Parsers for PDF, ZIP, JPEG, iNES, and 183 Kaitai Struct formats
 - Interactive HTML hex viewer with structure mapping

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You can run PolyFile with the debugger enabled using the `-db` option.
 
 ### File Support
 
-PolyFile has a cleanroom, [pure Python implementation of the libmagic file classifier](#libmagic-implementation), and supports all 895 MIME types that it can identify.
+PolyFile has a cleanroom, [pure Python implementation of the libmagic file classifier](#libmagic-implementation), and supports all 896 MIME types that it can identify.
 
 It currently has support for parsing and semantically mapping the following formats:
 * PDF, using an instrumented version of [Didier Stevens' public domain, permissive, forensic parser](https://blog.didierstevens.com/programs/pdf-tools/)

--- a/docs/updating_libmagic_defs.md
+++ b/docs/updating_libmagic_defs.md
@@ -16,7 +16,7 @@ The directory holds a byte-for-byte copy of `file/magic/Magdir/`, plus five entr
 | `__init__.py` | Empty. Makes the directory an importable package, so `MAGIC_DEFS` can find it through `importlib.resources`. |
 | `COPYING` | A copy of `file/COPYING`, the license the definitions are distributed under. |
 | `csv` | Declares PolyFile's `csv` test type, which libmagic implements in C rather than in the DSL. |
-| `json` | Declares PolyFile's `json` test type, for the same reason. |
+| `json` | Declares PolyFile's `json` and `ndjson` test types, for the same reason. |
 | `polyfile_zip` | An extra backwards search for a ZIP end-of-central-directory record, which helps detect ZIP polyglots. |
 
 `MAGIC_DEFS` in [`polyfile/magic.py`](../polyfile/magic.py) globs this directory and skips only

--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -24,7 +24,8 @@ import struct
 import sys
 from time import gmtime, localtime, strftime
 from typing import (
-    Any, BinaryIO, Callable, Dict, Generic, Iterable, Iterator, List, Optional, Set, Tuple, Type, TypeVar, Union
+    Any, BinaryIO, Callable, Dict, Generic, Iterable, Iterator, List, NamedTuple, Optional, Set,
+    Tuple, Type, TypeVar, Union
 )
 from uuid import UUID
 
@@ -2529,19 +2530,90 @@ class UseTest(MagicTest):
         raise NotImplementedError("This function should never be called")
 
 
+JSON_WHITESPACE: str = " \t\n\r"
+"""The characters that libmagic's `json_skip_space` skips (`file/src/is_json.c`)."""
+
+
+class ParsedJSON(NamedTuple):
+    """A buffer that parsed as JSON under libmagic's rules."""
+
+    value: Any
+    """The first top-level JSON value in the buffer."""
+
+    newline_delimited: bool
+    """Whether a second top-level JSON value follows the first one."""
+
+
+def _skip_json_whitespace(text: str, offset: int) -> int:
+    while offset < len(text) and text[offset] in JSON_WHITESPACE:
+        offset += 1
+    return offset
+
+
+def parse_json(raw: bytes) -> ParsedJSON:
+    """Parses a buffer as JSON the way libmagic's `file_is_json` does.
+
+    libmagic implements JSON detection with a C parser rather than with the magic DSL, and its
+    rules are narrower than `json.loads`:
+
+    * The top-level value must be an object or an array, because libmagic only reports JSON when
+      `st[JSON_OBJECT]` or `st[JSON_ARRAYN]` is set (`file/src/is_json.c`). A bare scalar such as
+      `42` is therefore not JSON, even though `json.loads` accepts one.
+    * If more data follows the first value, it is newline-delimited JSON as long as the next byte
+      equals the first byte of the first value and a second value parses there. libmagic stops
+      after that second value, so trailing garbage does not disqualify the buffer.
+
+    Args:
+        raw: the bytes to parse, starting at the first byte of the candidate JSON value.
+
+    Returns:
+        The first top-level value, and whether a second top-level value follows it.
+
+    Raises:
+        json.JSONDecodeError: if the buffer is not JSON under libmagic's rules.
+        UnicodeDecodeError: if the buffer is not text in an encoding that JSON allows.
+    """
+    text = raw.decode(json.detect_encoding(raw), "surrogatepass")
+    decoder = json.JSONDecoder()
+    start = _skip_json_whitespace(text, 0)
+    value, offset = decoder.raw_decode(text, start)
+    if not isinstance(value, (dict, list)):
+        raise json.JSONDecodeError("the top-level JSON value is neither an object nor an array", text, start)
+    offset = _skip_json_whitespace(text, offset)
+    if offset >= len(text):
+        return ParsedJSON(value, False)
+    if text[offset] != text[start]:
+        raise json.JSONDecodeError("the data after the top-level JSON value does not start another one",
+                                   text, offset)
+    decoder.raw_decode(text, offset)
+    return ParsedJSON(value, True)
+
+
 class JSONTest(MagicTest):
-    def test(self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]) -> Optional[TestResult]:
+    """Matches a buffer that holds a single top-level JSON object or array.
+
+    `NEWLINE_DELIMITED` selects which of libmagic's two JSON verdicts this test accepts, so the
+    two messages come from two tests in `polyfile/magic_defs/json` rather than from reassigning
+    `MagicTest.message` at match time. Test objects are shared across calls to
+    `MagicMatcher.match`, so a message assigned during one match would leak into the next.
+    """
+
+    NEWLINE_DELIMITED: bool = False
+    """Whether this test matches newline-delimited JSON rather than a single JSON value."""
+
+    def test(self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]) -> TestResult:
         try:
-            parsed = json.loads(data[absolute_offset:])
-            return MatchedTest(self, offset=absolute_offset, length=len(data) - absolute_offset, value=parsed,
-                               parent=parent_match)
+            parsed = parse_json(data[absolute_offset:])
         except (json.JSONDecodeError, UnicodeDecodeError) as e:
-            return FailedTest(
-                test=self,
-                offset=absolute_offset,
-                parent=parent_match,
-                message=str(e)
-            )
+            return FailedTest(test=self, offset=absolute_offset, parent=parent_match, message=str(e))
+        if parsed.newline_delimited != self.NEWLINE_DELIMITED:
+            if parsed.newline_delimited:
+                reason = "the data holds more than one top-level JSON value"
+            else:
+                reason = "the data holds only one top-level JSON value"
+            return FailedTest(test=self, offset=absolute_offset, parent=parent_match, message=reason)
+        return MatchedTest(self, offset=absolute_offset, length=len(data) - absolute_offset, value=parsed.value,
+                           parent=parent_match)
 
     def subtest_type(self) -> TestType:
         return TestType.TEXT
@@ -2550,6 +2622,12 @@ class JSONTest(MagicTest):
             self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]
     ) -> TestResult:
         return self.test(data, absolute_offset, parent_match)
+
+
+class NDJSONTest(JSONTest):
+    """Matches newline-delimited JSON, which libmagic names separately from single-value JSON."""
+
+    NEWLINE_DELIMITED: bool = True
 
 
 class CSVTest(MagicTest):
@@ -3237,6 +3315,8 @@ class MagicMatcher:
                                        parent=parent, subtraction=subtraction, modulo=modulo)
             elif data_type == "json":
                 test = JSONTest(offset=offset, message=message, parent=parent)
+            elif data_type == "ndjson":
+                test = NDJSONTest(offset=offset, message=message, parent=parent)
             elif data_type == "csv":
                 test = CSVTest(offset=offset, message=message, parent=parent)
             elif data_type == "indirect" or data_type == "indirect/r":

--- a/polyfile/magic_defs/json
+++ b/polyfile/magic_defs/json
@@ -6,3 +6,9 @@
 0   json    x   JSON text data
 !:mime  application/json
 !:ext   json
+# libmagic names a file that holds more than one top-level JSON value
+# newline-delimited JSON, and gives it its own MIME type, so PolyFile adds a
+# second test type called `ndjson`:
+0   ndjson  x   New Line Delimited JSON text data
+!:mime  application/x-ndjson
+!:ext   ndjson/jsonl

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -245,6 +245,55 @@ class MagicTest(TestCase):
         )
         return matches[0]
 
+    def test_newline_delimited_json(self):
+        """Tests that a buffer holding more than one top-level JSON value matches NDJSON.
+
+        This is a regression test for trailofbits/polyfile#3486. `JSONTest` parsed the whole
+        buffer with a single `json.loads` call, which rejects `{}\\n{}\\n` as extra data, so
+        PolyFile reported `ascii text` where `file` reports `New Line Delimited JSON text data`.
+        """
+        match = self.only_match(b"{}\n{}\n", "New Line Delimited JSON text data")
+        self.assertEqual(["application/x-ndjson"], list(match.mimetypes))
+
+    def test_single_json_value(self):
+        """Tests that a single top-level JSON value still matches plain JSON rather than NDJSON."""
+        match = self.only_match(b'{"a": [1, 2]}\n', "JSON text data")
+        self.assertEqual(["application/json"], list(match.mimetypes))
+
+    def test_json_messages_are_not_shared(self):
+        """Tests that matching NDJSON does not change what a later plain JSON match reports.
+
+        A `MagicMatcher` reuses its test objects across calls to `match`, so deriving the NDJSON
+        message by assigning to `MagicTest.message` made every JSON file matched after the first
+        NDJSON file report `New Line Delimited JSON text data`.
+        """
+        matcher = MagicMatcher.DEFAULT_INSTANCE
+        self.assertIn("New Line Delimited JSON text data", self.messages(matcher, b"{}\n{}\n"))
+        plain = self.messages(matcher, b"{}")
+        self.assertIn("JSON text data", plain)
+        self.assertNotIn("New Line Delimited JSON text data", plain)
+
+    def test_json_values_must_share_a_first_byte(self):
+        """Tests that top-level JSON values with different first bytes are not NDJSON.
+
+        libmagic only continues past the first value if the next byte equals the first byte of
+        that value (`*ouc == *uc` in `file/src/is_json.c`), so `{}\\n[]\\n` is plain text.
+        """
+        messages = self.messages(MagicMatcher.DEFAULT_INSTANCE, b"{}\n[]\n")
+        self.assertNotIn("New Line Delimited JSON text data", messages)
+        self.assertNotIn("JSON text data", messages)
+        self.assertIn("ascii text", messages)
+
+    def test_bare_json_scalar_is_not_json(self):
+        """Tests that a bare top-level scalar is not JSON.
+
+        libmagic only reports JSON when it saw an object or an array (`st[JSON_OBJECT]` or
+        `st[JSON_ARRAYN]` in `file/src/is_json.c`), so `42` is plain text even though
+        `json.loads` accepts it.
+        """
+        messages = self.messages(MagicMatcher.DEFAULT_INSTANCE, b"42")
+        self.assertNotIn("JSON text data", messages)
+
     def test_der_certificate(self):
         with gzip.open(DER_CERTIFICATE, "rb") as f:
             certificate = f.read()

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -113,8 +113,8 @@ class MagicTest(TestCase):
             'images:2657', 'inform:9', 'java:19', 'java:49', 'java:51', 'javascript:10',
             'javascript:12', 'javascript:14', 'javascript:16', 'javascript:30', 'javascript:34',
             'javascript:38', 'javascript:42', 'javascript:46', 'javascript:50', 'javascript:54',
-            'javascript:6', 'javascript:60', 'javascript:8', 'json:6', 'k9:28', 'kde:10', 'kde:6',
-            'kde:8', 'lex:10', 'lex:12', 'linux:366', 'linux:369', 'linux:370', 'linux:54',
+            'javascript:6', 'javascript:60', 'javascript:8', 'json:12', 'json:6', 'k9:28', 'kde:10',
+            'kde:6', 'kde:8', 'lex:10', 'lex:12', 'linux:366', 'linux:369', 'linux:370', 'linux:54',
             'linux:938', 'lisp:16', 'lisp:18', 'lisp:20', 'lisp:22', 'lisp:24', 'lisp:26',
             'lisp:77', 'lua:11', 'lua:13', 'lua:15', 'lua:17', 'lua:9', 'm4:5', 'm4:8', 'magic:8',
             'mail.news:11', 'mail.news:13', 'mail.news:15', 'mail.news:17', 'mail.news:19',
@@ -345,7 +345,7 @@ class MagicTest(TestCase):
                         matches.add(actual)
                         print(f"\tActual:   {actual!r}")
                     if testfile.stem not in (
-                            "JW07022A.mp3", "gedcom", "cmd1", "cmd2", "cmd3", "cmd4", "jpeg-text", "jsonlines1",
+                            "JW07022A.mp3", "gedcom", "cmd1", "cmd2", "cmd3", "cmd4", "jpeg-text",
                             "multiple", "osm", "pnm1", "pnm2", "pnm3", "utf16xmlsvg"
                     ):
                         # The files we skip fail because there is a bug in our implementation that we have not yet fixed


### PR DESCRIPTION
Closes #3486

`JSONTest.test` parsed the whole buffer with one `json.loads` call, so `{}\n{}\n` raised
`JSONDecodeError: Extra data` and PolyFile fell through to `ascii text`.

## Before and after

`file/tests/jsonlines1.testfile` (contents `{}\n{}\n`), expected `New Line Delimited JSON text data`:

| | Message | MIME type |
|---|---|---|
| Before | `ascii text` | `text/plain` |
| After | `New Line Delimited JSON text data` | `application/x-ndjson` |

`json1` through `json8` are unchanged:

| Stem | Expected | Actual |
|---|---|---|
| `json1` | `JSON text data` | `JSON text data` |
| `json2` | `JSON text data` | `JSON text data` |
| `json3` | `JSON text data` | `JSON text data` |
| `json4` | `JSON text data` | `JSON text data` |
| `json5` | `ASCII text` | `ascii text` |
| `json6` | `JSON text data` | `JSON text data` |
| `json7` | `ASCII text` | `ascii text` |
| `json8` | `JSON text data` | `JSON text data` |

## What changed

`parse_json` parses one top-level value at a time with `json.JSONDecoder.raw_decode`, following
`file_is_json` (`file/src/funcs.c`) and `json_parse` (`file/src/is_json.c:405-412`):

* The top-level value must be an object or an array, because libmagic only reports JSON when
  `st[JSON_OBJECT]` or `st[JSON_ARRAYN]` is set.
* If data follows the first value, the buffer is newline-delimited JSON as long as the next byte
  equals the first byte of the first value (libmagic's `*ouc == *uc`) and a second value parses
  there. libmagic stops after that second value, so `{}\n{}\ngarbage` is NDJSON to `file` and now
  to PolyFile as well.

Checked against `file` built from the `file` submodule at FILE5_48: `{}\n{}\n`, `{}{}`, `{} {}`,
`{}\n{}\ngarbage`, `[1]\n[2]\n` and `{"a":1}\n{"b":2}\n{"c":3}\n` are NDJSON; `{}\n[]\n`, `1\n1\n`,
`[1] 2`, `42`, `"hello"` and `true` are plain text; `{}` and `[]` are JSON.

## Design

### Two tests, not one message

`polyfile/magic_defs/json` now declares a second test type, `ndjson`, and `MagicMatcher.parse_test`
maps it to `NDJSONTest`. `NDJSONTest` subclasses `JSONTest` and only flips
`JSONTest.NEWLINE_DELIMITED`, the class attribute that says which of libmagic's two verdicts the
test accepts; each test fails when the buffer holds the other kind.

The alternative was to assign the NDJSON message to `MagicTest.message` from inside
`JSONTest.test`. That is wrong: a `MagicMatcher` builds its tests once and reuses those objects
across calls to `match`, so the assignment leaks. Once one NDJSON buffer had been matched, every
later `json*` corpus stem reported `New Line Delimited JSON text data`. `PlainTextTest` gets away
with the same mutation only because `MagicMatcher.match` constructs a fresh instance per call.
Taking the message from the definition file instead keeps it a per-test constant, and
`test_json_messages_are_not_shared` matches NDJSON and then plain JSON with the same matcher to
hold that property in place.

A distinct test type also matches how PolyFile already handles the tests libmagic implements in C:
`json` and `csv` each get a type name, a message, and a MIME type from a definition file.

### `polyfile/magic_defs/json` is PolyFile's own file, not a copy of upstream

It is one of the five entries PolyFile owns in `polyfile/magic_defs`, listed in
`docs/updating_libmagic_defs.md`, and the update procedure excludes it from the rsync out of
`file/magic/Magdir/`. Editing it is not the `magic_defs` drift that #3479 is about; upstream
`file` has no `Magdir` entry for JSON at all, because `is_json.c` does the work.

## Side effect: a bare top-level scalar is no longer JSON

libmagic requires an object or an array, so `file` calls `42` plain text while `json.loads`
accepts it. PolyFile used to report `JSON text data` for it. It no longer does, which is covered by
`test_bare_json_scalar_is_not_json`. No corpus stem exercises a bare scalar, so nothing regressed.

One divergence from `file` is left alone: a buffer that starts with a UTF-8 BOM. `is_json.c` reads
raw bytes and the BOM fails its parse, while `parse_json` keeps `json.loads`' encoding detection
and still reports `JSON text data`. That is pre-existing behavior and out of scope here.

## Verification

Corpus differential over every `file/tests` stem, with the same normalization as
`test_file_corpus`:

```
NEWLY PASSING (1): ['jsonlines1']
STILL FAILING (13): ['JW07022A.mp3', 'cmd1', 'cmd2', 'cmd3', 'cmd4', 'gedcom', 'jpeg-text', 'multiple', 'osm', 'pnm1', 'pnm2', 'pnm3', 'utf16xmlsvg']
REGRESSIONS   (0):
```

`pytest tests`:

| | Result |
|---|---|
| Before | 1007 passed, 8 skipped, 362 subtests passed |
| After | 1012 passed, 8 skipped, 362 subtests passed |

The five new tests are the whole difference. `flake8 polyfile polymerge --max-complexity=10
--max-line-length=127 --exclude=polyfile/kaitai/parsers` reports the same 189 pre-existing findings
as `master`, with one number changed: the `C901` finding for `MagicMatcher.parse_test` goes from
complexity 33 to 34, because a new test type means a new branch in the definition-file dispatcher,
the same way `json` and `csv` did.

`jsonlines1` is dropped from the skip tuple in `test_file_corpus`. #3487 replaces that tuple with a
`KNOWN_FAILURES` map, so it should merge after this PR to avoid a conflict over the same lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VS8hTTRQeG8ZCmCZ9KLHiV
