### PR TITLE
Make a use test true only if its named list matched

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -2467,6 +2467,26 @@ class NamedTest(MagicTest):
         return self.name
 
 
+def prints_a_message(result: TestResult, context: MatchContext) -> bool:
+    """Reports whether a test result would print something.
+
+    libmagic raises its ``found_match`` flag only for an entry whose description is not empty
+    (``file/src/softmagic.c:323`` and ``:439``), and it strips a leading ``\\b`` — the NOSPACE
+    flag — off the description while parsing the entry (``file/src/apprentice.c:2427-2435``).
+    A bare ``name`` line therefore prints nothing and raises nothing.
+
+    Args:
+        result: The result of running a test. A failed test never prints.
+        context: The context that the test ran against, used to resolve the message.
+
+    Returns:
+        True if the result is a match whose resolved message is not empty.
+    """
+    if not result:
+        return False
+    return bool(result.test.message.resolve(context).removeprefix("\b"))
+
+
 class UseTest(MagicTest):
     def __init__(
             self,
@@ -2505,25 +2525,48 @@ class UseTest(MagicTest):
             absolute_offset = self.offset.to_absolute(context.data, last_match=parent_match)
         except InvalidOffsetError:
             return None
-        log.trace(
-            f"{self.source_info!s}\tTrue\t{absolute_offset}\t{context.data[absolute_offset:absolute_offset + 20]!r}"
-        )
         use_match = MatchedTest(self, None, absolute_offset, 0, parent=parent_match)
-        yielded = False
-        for named_result in self.referenced_test._match(context, use_match, flip_endianness=flip_endianness):
-            if not yielded:
-                yielded = True
-                yield use_match
-            yield named_result
-        if not yielded:
-            # the named test did not match anything, so don't try any of our children
+        named_results = self._match_referenced_test(context, use_match, flip_endianness)
+        matched = any(prints_a_message(result, context) for result in named_results)
+        log.trace(
+            f"{self.source_info!s}\t{matched}\t{absolute_offset}\t"
+            f"{context.data[absolute_offset:absolute_offset + 20]!r}"
+        )
+        if not matched:
             return
-        elif context.only_match_mime and not self.can_match_mime:
+        yield use_match
+        for named_result in named_results:
+            if not context.only_match_mime or named_result.test.mime is not None:
+                yield named_result
+        if context.only_match_mime and not self.can_match_mime:
             # none of our children can produce a mime type
             return
         for child in self.children:
             if not context.only_match_mime or child.can_match_mime:
                 yield from child._match(context=context, parent_match=use_match, flip_endianness=flip_endianness)
+
+    def _match_referenced_test(
+            self, context: MatchContext, use_match: MatchedTest, flip_endianness: bool
+    ) -> List[TestResult]:
+        """Runs the referenced named test list and collects everything it matched.
+
+        libmagic evaluates the whole named list and uses the number of entries that printed as the
+        ``use`` test's truth value (``file/src/softmagic.c:2001-2039`` and ``:2429-2430``), so
+        MIME-only pruning is lifted for the run: whether the list can report a MIME type must not
+        decide whether the ``use`` succeeds. The caller reapplies the pruning when it picks the
+        results to yield.
+
+        Args:
+            context: The context to match against.
+            use_match: The match for this ``use`` test, which parents the named test's results.
+            flip_endianness: Whether the named test reads its operands with flipped endianness.
+
+        Returns:
+            Every result the named test list matched, in the order it produced them.
+        """
+        if context.only_match_mime:
+            context = MatchContext(data=context.data, path=context.path)
+        return list(self.referenced_test._match(context, use_match, flip_endianness=flip_endianness))
 
     def test(self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]) -> TestResult:
         raise NotImplementedError("This function should never be called")

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -503,3 +503,93 @@ class MagicMatchingRegressionTest(TestCase):
         self.assertEqual(8192, expected.num_bytes)
         self.assertTrue(search.match(b"." * 8000 + b"needle", expected))
         self.assertFalse(search.match(b"." * 9000 + b"needle", expected))
+
+
+class UseTestSemanticsTest(TestCase):
+    """Regression tests for the `use` test truth value reported in issue #3484."""
+
+    DESCRIBED_NAMED_LIST: str = "\n".join((
+        "0\tname\ttrailer",
+        ">4\tstring\tOK\t\\b, named list matched",
+        "",
+        "0\tstring\tHEAD",
+        ">0\tuse\ttrailer",
+        ">>0\tstring\tx\t\\b, continuation ran",
+        "",
+    ))
+    """A `use` whose named list prints a message when the input ends in `OK`."""
+
+    UNDESCRIBED_NAMED_LIST: str = "\n".join((
+        "0\tname\ttrailer",
+        ">4\tstring\tOK",
+        "",
+        "0\tstring\tHEAD",
+        ">0\tuse\ttrailer",
+        ">>0\tstring\tx\t\\b, continuation ran",
+        "",
+    ))
+    """The same definitions, with the named list's only entry left undescribed."""
+
+    @staticmethod
+    def messages(definitions: str, data: bytes) -> Set[str]:
+        """Matches `data` against ad-hoc definitions and collects the resulting messages.
+
+        Args:
+            definitions: The contents of a libmagic definition file, with tab separated columns.
+            data: The bytes to classify.
+
+        Returns:
+            The message of every match the definitions produce.
+        """
+        with TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "use_semantics"
+            path.write_text(definitions)
+            matcher = MagicMatcher.parse(path)
+            return {str(match) for match in matcher.match(data)}
+
+    def test_use_matches_when_the_named_list_matches(self):
+        """A `use` succeeds when its named list prints something, and its children then run.
+
+        `file -b -k -m <definitions>` reports both `, named list matched` and
+        `, continuation ran` for this input.
+        """
+        self.assertIn(
+            ", named list matched, continuation ran", self.messages(self.DESCRIBED_NAMED_LIST, b"HEADOK")
+        )
+
+    def test_use_fails_when_the_named_list_does_not_match(self):
+        """A `use` used to succeed even when its named list matched nothing.
+
+        The named list's only entry needs the input to end in `OK`, so nothing in it matches
+        `HEADNO`. libmagic returns the list's match count as the `use`'s truth value
+        (`file/src/softmagic.c:2429-2430`) and reports no match for this input, but PolyFile used
+        to run the `use`'s continuation lines anyway.
+        """
+        for message in self.messages(self.DESCRIBED_NAMED_LIST, b"HEADNO"):
+            self.assertNotIn("named list matched", message)
+            self.assertNotIn("continuation ran", message)
+
+    def test_use_fails_when_the_named_list_prints_nothing(self):
+        """An undescribed named test cannot on its own satisfy the `use` that referenced it.
+
+        libmagic raises `found_match` only for an entry with a non-empty description
+        (`file/src/softmagic.c:323` and `:439`), so neither the bare `0 name trailer` line nor the
+        undescribed entry beneath it counts. `file` reports no match for `HEADOK` against these
+        definitions, even though the same input matches once that entry carries a message.
+        """
+        for message in self.messages(self.UNDESCRIBED_NAMED_LIST, b"HEADOK"):
+            self.assertNotIn("continuation ran", message)
+
+    def test_efi_signature_list_is_not_a_false_positive(self):
+        """The `efi_sig_list` `use` used to report EFI matches for UTF-16 text.
+
+        `polyfile/magic_defs/efi:41-53` guards two `use efi_sig_list` entries behind zero-byte
+        tests that any UTF-16LE ASCII text passes, and relies on the named list's 19 `guid`
+        comparisons to reject. None of them match this file, and
+        `file -m file/magic/Magdir/efi` reports no EFI match for it.
+        """
+        testfile = FILE_TEST_DIR / "utf16xmlsvg.testfile"
+        self.assertTrue(testfile.exists(), "Make sure to run `git submodule init && git submodule update`")
+        for match in MagicMatcher.DEFAULT_INSTANCE.match(testfile.read_bytes()):
+            self.assertNotIn("EFI variable", str(match))
+            self.assertNotIn("total size", str(match))


### PR DESCRIPTION
Closes #3484

## The change

A `use` test succeeded whenever the referenced named test list yielded anything, and
`NamedTest.test` always yields a placeholder when it has a parent, so every `use` succeeded and
its continuation lines always ran.

libmagic's contract is the opposite, in two parts, and this PR implements both:

1. **A `use` is true only if its named list matched.** `mget` runs the named list with a fresh
   `nfound_match` and stores the count in `ms->ms_value.q`
   (`file/src/softmagic.c:2001-2039`); `magiccheck` returns it as the test's truth value
   (`file/src/softmagic.c:2429-2430`: `case FILE_USE: return ms->ms_value.q != 0;`).
2. **"Matched" means an entry with a non-empty description matched.** `match` raises
   `found_match` only for such an entry (`file/src/softmagic.c:323` and `:439`:
   `if (*m->desc) { *found_match = 1; }`), and a leading `\b` — the NOSPACE flag — is stripped
   off the description while the entry is parsed (`file/src/apprentice.c:2427-2435`). A bare
   `0 name foo` line therefore prints nothing and counts for nothing, so the placeholder cannot
   satisfy the `use` that referenced it.

`UseTest._match` now collects the named list's results and succeeds only if one of them resolves
to a non-empty message. MIME-only pruning is lifted while the list runs, because libmagic
evaluates the whole list regardless: whether the list can report a MIME type must not decide the
truth value. The caller reapplies the pruning when it picks the results to yield, so
`only_match_mime` behaviour is unchanged (verified in the spot-checks below). The `log.trace`
line reports the real verdict instead of a hardcoded `True`.

## Before and after: `file/tests/utf16xmlsvg.testfile`

The chain is `polyfile/magic_defs/efi:41` → `:42` → `:43` → `:44` (the `use`) → `:20` (the `name`
placeholder) → `:45`. The zero-byte guards at 19, 23, 27 and 31 are the high bytes of UTF-16LE
ASCII characters, so they genuinely pass, and `efi:20-39` defines `efi_sig_list` as 19 `guid`
comparisons and nothing else — none of which match.

Before:

```
, EFI variable 3997439, total size: 6881395 bytes
, total size: 7471205 bytes
```

After:

```
UTF-16 text
```

The reference binary agrees that there is no EFI match:

```console
$ TZ=UTC ./file/src/file -b -k -m file/magic/Magdir/efi file/tests/utf16xmlsvg.testfile
Unicode text, UTF-16, little-endian text
```

The `utf16xmlsvg` stem still fails the corpus check and stays in the skip tuple at
`tests/test_magic.py:347-350`: it also needs #3489 (a UTF-16 text buffer) and #3488 (the encoding
trailer), both out of scope here. What this PR removes is the two false positives.

The two `use` entries at `efi:44` and `efi:51` also produced false positives on unrelated real
files, and those are gone too (see the spot-checks).

## The `netpbm` chain still contributes its message

`polyfile/magic_defs/images:186-215`. The `use netpbm` entries now correctly fail on `master`,
because PolyFile's only described entry in that named list is the `regex` at `images:192`, which
`master` cannot match yet (#3482 — the `=` operator is not stripped, so the pattern compiles as a
literal `=` followed by `^`). The `\b, greymap` style entries are *siblings* of the `use`, not its
continuation lines, so they still run and still report:

| stem | before | after |
|---|---|---|
| `pnm1` | `, greymap` | `, greymap` |
| `pnm2` | `, rawbits, greymap` | `, rawbits, greymap` |
| `pnm3` | `, pixmap` | `, pixmap` |

MIME types are unchanged too (`image/x-portable-greymap` etc.). Once #3482 lands, the `regex` will
match, the `use` will succeed on its merits, and the `Netpbm image data, size = …` prefix will
appear. Nothing here blocks that.

The positive EFI case is also unaffected: `file/tests/efi-signature-list-sha256.testfile` still
reports `EFI Signature List, SHA256, total size: 76 bytes`, matching the oracle, because a `guid`
comparison with a description does match there.

## Verification

Corpus differential over all 88 stems of `file/tests`, applying the same normalization as
`test_file_corpus`:

```
NEWLY PASSING (0): []
STILL FAILING (14): ['JW07022A.mp3', 'cmd1', 'cmd2', 'cmd3', 'cmd4', 'gedcom', 'jpeg-text',
                     'jsonlines1', 'multiple', 'osm', 'pnm1', 'pnm2', 'pnm3', 'utf16xmlsvg']
REGRESSIONS   (0):
```

The 14 still-failing stems are exactly the 14 `master` skips. No stem changed verdict.

`pytest tests`: 1007 passed, 8 skipped, 362 subtests before; 1011 passed, 8 skipped, 362 subtests
after. The four new tests are the difference; no test changed from passing to failing.

`flake8 polyfile polymerge --max-complexity=10 --max-line-length=127
--exclude=polyfile/kaitai/parsers`: 189 findings before and after, 27 of them in
`polyfile/magic.py` before and after. No new findings.

### Spot-checks

Ran a set of unrelated real files through the matcher on `master` and on this branch, and compared
against `file -b -m file/magic/magic.mgc`. Only three files changed, and each lost a false
positive that the oracle never reported:

| file | change |
|---|---|
| `arj.testfile` | dropped `, EFI variable 3336800, total size: 0 bytes` |
| `issue311docx.testfile` | dropped `, total size: 0 bytes` |
| `ext4.testfile` | dropped `, EFI variable 0, total size: 0 bytes` and `, total size: 0 bytes` |
| `utf16xmlsvg.testfile` | dropped both EFI matches, now reports `UTF-16 text` / `text/plain` |

Unchanged, and matching the oracle: an ARM ELF (`busybox`), a Mach-O universal binary (`/bin/ls`),
a JPEG with Exif, a PDF, a PostScript document, an APNG, a gzip stream, a GEDCOM file, an ext4
image, a docx, `efi-signature-list-sha256.testfile`, `pnm2.testfile` and an ASCII PGM. Every
file's `only_match_mime` result was identical before and after.

### New tests

`tests/test_magic.py::UseTestSemanticsTest` covers a `use` whose named list matches (its
continuation lines run and contribute their message), one whose list matches nothing, one whose
list matches but prints nothing, and the `efi_sig_list` regression on `utf16xmlsvg.testfile`.
Each case was first confirmed against `file -b -k -m` with the same ad-hoc definitions, and each
test was verified to fail against three separate reintroductions of the bug: the old
"did the list yield anything" truth value, counting the `\b` NOSPACE sentinel as a printed
message, and making the `use` never succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VS8hTTRQeG8ZCmCZ9KLHiV
