### PR TITLE
Fix the regex data type's =, %s extent, and s flag semantics

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -1097,15 +1097,32 @@ T = TypeVar("T")
 
 
 class DataTypeMatch:
+    """The portion of the tested data that a :class:`DataType` matched.
+
+    Attributes:
+        raw_match: The bytes that matched, or `None` if the data type did not match.
+        value: The value to interpolate into the message of the test that matched.
+        initial_offset: The offset of `raw_match` within the data that was tested.
+        relative_base: The offset within the tested data that a subsequent relative (`&`) offset
+            resolves against, or `None` to resolve against the end of `raw_match`.
+    """
+
     INVALID: "DataTypeMatch"
 
-    def __init__(self, raw_match: Optional[bytes] = None, value: Optional[Any] = None, initial_offset: int = 0):
+    def __init__(
+            self,
+            raw_match: Optional[bytes] = None,
+            value: Optional[Any] = None,
+            initial_offset: int = 0,
+            relative_base: Optional[int] = None
+    ):
         self.raw_match: Optional[bytes] = raw_match
         if value is None and raw_match is not None:
             self.value: Optional[bytes] = raw_match
         else:
             self.value = value
         self.initial_offset: int = initial_offset
+        self.relative_base: Optional[int] = relative_base
 
     def __bool__(self):
         return self.raw_match is not None
@@ -1921,7 +1938,13 @@ class RegexType(DataType[Pattern[bytes]]):
             value = raw_match
         if self.trim:
             value = value.strip()
-        return DataTypeMatch(raw_match, value, initial_offset=subject_offset + m.start())
+        start = subject_offset + m.start()
+        if self.match_to_start:
+            # the `s` flag resolves a subsequent relative offset from the start of the match rather
+            # than from its end (`CHAR_REGEX_OFFSET_START` in `file/src/file.h:419`, applied in
+            # `moffset`'s `FILE_REGEX` case at `file/src/softmagic.c:959-963`)
+            return DataTypeMatch(raw_match, value, initial_offset=start, relative_base=start)
+        return DataTypeMatch(raw_match, value, initial_offset=start)
 
     def match(self, data: bytes, expected: Pattern[bytes]) -> DataTypeMatch:
         if not self.limit_lines:
@@ -2304,11 +2327,30 @@ class ConstantMatchTest(MagicTest, Generic[T]):
     def calculate_absolute_offset(self, data: bytes, parent_match: Optional[TestResult] = None) -> int:
         return self.offset.to_absolute(data, parent_match, self.data_type.allows_invalid_offsets(self.constant))
 
+    def matched_test(
+            self, match: DataTypeMatch, absolute_offset: int, parent_match: Optional[TestResult]
+    ) -> "MatchedTest":
+        """Builds the result of a successful match of this test's data type.
+
+        Args:
+            match: The match that the data type reported.
+            absolute_offset: The offset at which the data type was tested.
+            parent_match: The result of the parent test, if this test has one.
+
+        Returns:
+            The result, positioned at the match and carrying the relative base that the data type
+            asked for.
+        """
+        result = MatchedTest(self, offset=absolute_offset + match.initial_offset,
+                             length=len(match.raw_match), value=match.value, parent=parent_match)
+        if match.relative_base is not None:
+            result.relative_base = absolute_offset + match.relative_base
+        return result
+
     def test(self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]) -> TestResult:
         match = self.data_type.match(data[absolute_offset:], self.constant)
         if match:
-            return MatchedTest(self, offset=absolute_offset + match.initial_offset, length=len(match.raw_match),
-                               value=match.value, parent=parent_match)
+            return self.matched_test(match, absolute_offset, parent_match)
         else:
             return FailedTest(
                 self,
@@ -2326,8 +2368,7 @@ class ConstantMatchTest(MagicTest, Generic[T]):
             data_type = self.data_type
         match = data_type.match(data[absolute_offset:], self.constant)
         if match:
-            return MatchedTest(self, offset=absolute_offset + match.initial_offset, length=len(match.raw_match),
-                               value=match.value, parent=parent_match)
+            return self.matched_test(match, absolute_offset, parent_match)
         else:
             return FailedTest(
                 self,

--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -1901,41 +1901,46 @@ class RegexType(DataType[Pattern[bytes]]):
         except re.error as e:
             raise ValueError(str(e))
 
+    def matched_extent(self, m: "re.Match[bytes]", subject_offset: int) -> DataTypeMatch:
+        """Builds the match that libmagic reports for a regular expression match.
+
+        libmagic reports only the bytes between `pmatch.rm_so` and `pmatch.rm_eo`, positioned at
+        `rm_so` (`file/src/softmagic.c:2413-2416`, printed at `file/src/softmagic.c:785-801`).
+
+        Args:
+            m: The regular expression match.
+            subject_offset: The offset of `m`'s subject within the data that was tested.
+
+        Returns:
+            A match covering only the matched bytes, positioned at the start of the match.
+        """
+        raw_match = m.group()
+        try:
+            value: Any = raw_match.decode("utf-8")
+        except UnicodeDecodeError:
+            value = raw_match
+        if self.trim:
+            value = value.strip()
+        return DataTypeMatch(raw_match, value, initial_offset=subject_offset + m.start())
+
     def match(self, data: bytes, expected: Pattern[bytes]) -> DataTypeMatch:
-        if self.limit_lines:
-            limit = self.length
-            offset = 0
-            byte_limit = 80 * self.length  # libmagic uses an implicit byte limit assuming 80 characters per line
-            while limit > 0:
-                limit -= 1
-                line_offset = data.find(b"\n", offset, byte_limit)
-                if line_offset < 0:
-                    return DataTypeMatch.INVALID
-                line = data[offset:line_offset]
-                m = expected.match(line)
-                if m:
-                    match = data[:offset + m.end()]
-                    try:
-                        value = match.decode("utf-8")
-                    except UnicodeDecodeError:
-                        value = match
-                    if self.trim:
-                        value = value.strip()
-                    return DataTypeMatch(match, value)
-                offset = line_offset + 1
-        else:
+        if not self.limit_lines:
             m = expected.search(data[:self.length])
-            if m:
-                match = data[:m.end()]
-                try:
-                    value = match.decode("utf-8")
-                except UnicodeDecodeError:
-                    value = match
-                if self.trim:
-                    value = value.strip()
-                return DataTypeMatch(match, value)
-            else:
+            if m is None:
                 return DataTypeMatch.INVALID
+            return self.matched_extent(m, 0)
+        offset = 0
+        # libmagic uses an implicit byte limit that assumes 80 characters per line
+        byte_limit = 80 * self.length
+        for _ in range(self.length):
+            line_offset = data.find(b"\n", offset, byte_limit)
+            if line_offset < 0:
+                return DataTypeMatch.INVALID
+            m = expected.match(data[offset:line_offset])
+            if m is not None:
+                return self.matched_extent(m, offset)
+            offset = line_offset + 1
+        return DataTypeMatch.INVALID
 
     REGEX_TYPE_FORMAT: Pattern[str] = re.compile(
         r"^regex(/(?P<length>\d+)?(?P<flags1>[cslTt]*)(/(?P<flags2>[cslTt]*))?(b\d*)?)?$"

--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -1885,6 +1885,10 @@ class RegexType(DataType[Pattern[bytes]]):
             return False
 
     def parse_expected(self, specification: str) -> Pattern[bytes]:
+        if specification.startswith("="):
+            # libmagic parses a leading `=` as the equality operator, not as part of the pattern
+            # (`file/src/apprentice.c:2383-2384`)
+            specification = specification[1:]
         # handle POSIX-style character classes:
         unescaped_spec = posix_to_python_re(unescape(specification))
         # convert '$' to '[\r$]'

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -348,7 +348,7 @@ class MagicTest(TestCase):
                         print(f"\tActual:   {actual!r}")
                     if testfile.stem not in (
                             "JW07022A.mp3", "gedcom", "cmd1", "cmd2", "cmd3", "cmd4", "jpeg-text", "jsonlines1",
-                            "multiple", "osm", "pnm1", "pnm2", "pnm3", "utf16xmlsvg"
+                            "multiple", "osm", "pnm1", "pnm3", "utf16xmlsvg"
                     ):
                         # The files we skip fail because there is a bug in our implementation that we have not yet fixed
                         if expected == "ASCII text" and expected not in matches:

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -514,6 +514,19 @@ class RegexSemanticsTest(TestCase):
     """Test data whose only run of digits starts at offset 2 and ends at offset 5."""
 
     @staticmethod
+    def relative_offset_definition(flags: str, follow_up: str) -> str:
+        """Builds a definition whose second test reads at `&0` after a regex match.
+
+        Args:
+            flags: The flags to append to the `regex` type, such as `/s`.
+            follow_up: The string that the second test expects to find at `&0`.
+
+        Returns:
+            The contents of a libmagic definition file.
+        """
+        return f"0\tregex{flags}\t=[0-9]{{1,3}}\tdigits\n>&0\tstring\t{follow_up}\tthen\n"
+
+    @staticmethod
     def messages(definition: str, data: bytes) -> Set[str]:
         """Classifies `data` with a matcher built from a single magic definition.
 
@@ -555,3 +568,22 @@ class RegexSemanticsTest(TestCase):
         self.assertEqual(2, match.initial_offset)
         self.assertEqual({"digits 123"},
                          self.messages("0\tregex\t=[0-9]{1,3}\tdigits %s\n", self.DATA))
+
+    def test_regex_relative_offset_resolves_from_the_match_end(self):
+        """A `&` offset after a plain `regex` reads from the end of the match, at offset 5."""
+        self.assertEqual({"digits then"},
+                         self.messages(self.relative_offset_definition("", "bb"), self.DATA))
+        self.assertEqual({"digits"},
+                         self.messages(self.relative_offset_definition("", "123"), self.DATA))
+
+    def test_regex_s_relative_offset_resolves_from_the_match_start(self):
+        """The `s` flag was parsed and then never read, so `&` resolved from the match end.
+
+        `CHAR_REGEX_OFFSET_START` (`file/src/file.h:419`) makes a following relative offset
+        resolve from the start of the match, at offset 2 rather than offset 5
+        (`file/src/softmagic.c:959-963`).
+        """
+        self.assertEqual({"digits then"},
+                         self.messages(self.relative_offset_definition("/s", "123"), self.DATA))
+        self.assertEqual({"digits"},
+                         self.messages(self.relative_offset_definition("/s", "bb"), self.DATA))

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -13,7 +13,9 @@ from uuid import UUID
 # from polyfile import logger
 import polyfile.der
 import polyfile.magic
-from polyfile.magic import MagicMatcher, MAGIC_DEFS, Match, MatchContext, SearchType, TestResult
+from polyfile.magic import (
+    MagicMatcher, MAGIC_DEFS, Match, MatchContext, RegexType, SearchType, TestResult
+)
 
 
 # logger.setLevel(logger.TRACE)
@@ -503,3 +505,38 @@ class MagicMatchingRegressionTest(TestCase):
         self.assertEqual(8192, expected.num_bytes)
         self.assertTrue(search.match(b"." * 8000 + b"needle", expected))
         self.assertFalse(search.match(b"." * 9000 + b"needle", expected))
+
+
+class RegexSemanticsTest(TestCase):
+    """Regression tests for the `regex` data type reported in issue #3482."""
+
+    DATA: bytes = b"aa123bb"
+    """Test data whose only run of digits starts at offset 2 and ends at offset 5."""
+
+    @staticmethod
+    def messages(definition: str, data: bytes) -> Set[str]:
+        """Classifies `data` with a matcher built from a single magic definition.
+
+        Args:
+            definition: The contents of a libmagic definition file.
+            data: The bytes to classify.
+
+        Returns:
+            The message of every match.
+        """
+        with TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "regex_semantics"
+            path.write_text(definition)
+            matcher = MagicMatcher.parse(path)
+        return {str(match) for match in matcher.match(data)}
+
+    def test_regex_strips_the_equality_operator(self):
+        """A leading `=` used to compile into the pattern, so such a test could never match.
+
+        libmagic consumes the relation operator before it compiles the pattern
+        (`file/src/apprentice.c:2383-2384`). 40 `=`-prefixed regex tests ship in the definitions,
+        among them the `netpbm` chain that `file/tests/pnm2.testfile` exercises.
+        """
+        regex = RegexType.parse("regex")
+        self.assertEqual(b"^[0-9]{1,50}", regex.parse_expected("=\\^[0-9]{1,50}").pattern)
+        self.assertTrue(regex.match(self.DATA, regex.parse_expected("=[0-9]{1,3}")))

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -540,3 +540,18 @@ class RegexSemanticsTest(TestCase):
         regex = RegexType.parse("regex")
         self.assertEqual(b"^[0-9]{1,50}", regex.parse_expected("=\\^[0-9]{1,50}").pattern)
         self.assertTrue(regex.match(self.DATA, regex.parse_expected("=[0-9]{1,3}")))
+
+    def test_regex_reports_only_the_matched_extent(self):
+        """`%s` used to report every byte from offset 0 through the end of the match.
+
+        libmagic reports only the bytes between `rm_so` and `rm_eo`
+        (`file/src/softmagic.c:2413-2416`), and positions the match at `rm_so` rather than at the
+        offset the test ran at.
+        """
+        regex = RegexType.parse("regex")
+        match = regex.match(self.DATA, regex.parse_expected("=[0-9]{1,3}"))
+        self.assertEqual(b"123", match.raw_match)
+        self.assertEqual("123", match.value)
+        self.assertEqual(2, match.initial_offset)
+        self.assertEqual({"digits 123"},
+                         self.messages("0\tregex\t=[0-9]{1,3}\tdigits %s\n", self.DATA))


### PR DESCRIPTION
Closes #3482

`RegexType` diverged from libmagic in three ways. Together they made the `regex` data type report
the wrong text and resolve a following relative offset from the wrong place.

## What changed

**1. The `=` equality operator is stripped from the specification.** libmagic consumes a leading
relation operator before it compiles the value (`file/src/apprentice.c:2383-2384`), so `regex =foo`
compiles to `/foo/`. `RegexType.parse_expected` compiled the raw specification, so the 40
`=`-prefixed regex tests in the definitions became patterns beginning with a literal `=`, which
cannot match. `StringTest.parse` already strips the operator, so only `regex` was affected.

**2. A regex test reports only the matched extent.** `RegexType.match` built its value from the
start of the buffer through the end of the match, so `%s` interpolated unrelated leading bytes.
libmagic reports only `pmatch.rm_so..rm_eo` (`file/src/softmagic.c:2413-2416`, printed through
`strndup(ms->search.s, ms->search.rm_len)` at `file/src/softmagic.c:785-801`). The match also left
`initial_offset` at 0, so `ConstantMatchTest` recorded it at the offset the test ran at rather than
at the match; it now reports `m.start()`.

**3. The `s` flag resolves a following relative offset from the match start.** `match_to_start` was
parsed and never read. `CHAR_REGEX_OFFSET_START` (`file/src/file.h:419`) makes a following `&`
offset resolve from the start of the match instead of its end, which `moffset` applies in its
`FILE_REGEX` case (`file/src/softmagic.c:959-963`):

```c
case FILE_REGEX:
    vlen = (m->str_flags & REGEX_OFFSET_START) == 0 ? ms->search.rm_len : 0;
    o = CAST(int32_t, ms->search.offset + vlen - offset);
```

`DataTypeMatch` now carries an optional `relative_base` that a data type can use to move where a
subsequent relative offset resolves from, and `ConstantMatchTest` applies it to the result it
builds. With fix 2 in place, the default (`offset + length`) already gives the match end for a
plain `regex`.

Extracting `RegexType.matched_extent()` also drops `RegexType.match` below the cyclomatic
complexity limit, which removes a pre-existing `C901` finding.

## Before and after

The `netpbm` chain at `polyfile/magic_defs/images:186-215` needs all three fixes:

| stem | before | after | expected |
|------|--------|-------|----------|
| `pnm2` | `, rawbits, greymap` | `Netpbm image data, size = 2 x 2, rawbits, greymap` | `Netpbm image data, size = 2 x 2, rawbits, greymap` |
| `pnm1` | `, greymap` | `Netpbm image data, size = 2 x 2, greymap` | `Netpbm image data, size = 2 x 2, greymap, ASCII text` |
| `pnm3` | `, pixmap` | `Netpbm image data, size = 10 x 20, pixmap` | `Netpbm image data, size = 10 x 20, pixmap, ASCII text` |

`pnm2` now matches the reference binary exactly. `pnm1` and `pnm3` reach the same prefix but still
lack the `, ASCII text` trailer tracked in #3488, so they stay in the skip tuple.

Fixing defect 1 alone yields `Netpbm image data, size = \n255 x, rawbits, greymap`; fixing 1 and 2
yields `size = 255 x`. All three are needed for `size = 2 x 2`.

## Verification

Corpus differential over `file/tests` (the same normalization `test_file_corpus` applies):

```
NEWLY PASSING (1): ['pnm2']
STILL FAILING (13): ['JW07022A.mp3', 'cmd1', 'cmd2', 'cmd3', 'cmd4', 'gedcom', 'jpeg-text',
                     'jsonlines1', 'multiple', 'osm', 'pnm1', 'pnm3', 'utf16xmlsvg']
REGRESSIONS   (0):
```

`pytest tests`: 1007 passed, 8 skipped, 362 subtests before; 1011 passed, 8 skipped, 362 subtests
after. The four new tests are in `tests/test_magic.py::RegexSemanticsTest`, one per defect plus the
match-end case. Each was checked by reverting its fix and confirming the test fails.

flake8 (`--max-complexity=10 --max-line-length=127`, the CI invocation): 189 findings before, 188
after, with no new findings. The one that goes away is
`polyfile/magic.py: C901 'RegexType.match' is too complex (12)`.

## Notes

- The two `# NOTE:` comments claiming the `regex` `b` and `t` flags are ignorable are still wrong
  (they are `CHAR_BINTEST`/`CHAR_TEXTTEST`), but that is #3490 and is untouched here.
- #3487 converts the corpus test's skip tuple into a `KNOWN_FAILURES` map, so it should merge after
  this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VS8hTTRQeG8ZCmCZ9KLHiV
