### PR TITLE
Fix the string w flag, relative offsets, and wildcard values

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -73,6 +73,8 @@ MAGIC_DEFS: List[Path] = sorted([
 
 
 WHITESPACE: bytes = b" \r\t\n\v\f"
+# a whitespace byte of an `re.escape`-ed pattern, with or without the backslash that escaped it
+BLANK_IN_PATTERN: Pattern[bytes] = re.compile(rb"\\?[ \t\n\v\f\r]")
 ESCAPES = {
     "n": ord("\n"),
     "r": ord("\r"),
@@ -1458,13 +1460,20 @@ class StringMatch(StringTest):
         self.case_insensitive_upper: bool = case_insensitive_upper
         self.optional_blanks: bool = optional_blanks
         self.full_word_match: bool = full_word_match
-        if optional_blanks and compact_whitespace:
-            raise ValueError("Optional blanks `w` and compacting whitespace `W` cannot be selected at the same time")
         self._is_always_text: Optional[bool] = None
         self._pattern: Optional[re.Pattern] = None
         _ = self.pattern
 
     def pattern_string(self) -> bytes:
+        """Builds the regular expression that implements this test's string flags.
+
+        A definition may set both ``W`` (compact whitespace) and ``w`` (optional blanks);
+        ``polyfile/magic_defs/sgml`` does. libmagic keeps both bits and lets ``W`` win, because
+        ``file_strncmp`` tests it first (``file/src/softmagic.c:2103-2120``).
+
+        Returns:
+            The pattern to compile, with the flags folded into it.
+        """
         pattern = re.escape(self.string)
         if self.case_insensitive_lower and not self.case_insensitive_upper:
             # treat lower case letters as either lower or upper case
@@ -1505,7 +1514,7 @@ class StringMatch(StringTest):
                     pattern_bytes.extend(f"{{{count}}}".encode("utf-8"))
             pattern = bytes(pattern_bytes)
         elif self.optional_blanks:
-            pattern = pattern.replace(rb"\ ", rb"\ ?")
+            pattern = BLANK_IN_PATTERN.sub(rb"\\s*", pattern)
         if self.full_word_match:
             pattern = rb"\b" + pattern + rb"\b"
         return pattern
@@ -1605,6 +1614,7 @@ class StringType(DataType[StringTest]):
             case_insensitive_lower=self.case_insensitive_lower,
             case_insensitive_upper=self.case_insensitive_upper,
             compact_whitespace=self.compact_whitespace,
+            optional_blanks=self.optional_blanks,
             full_word_match=self.full_word_match,
             num_bytes=self.num_bytes
         )
@@ -1727,8 +1737,8 @@ class SearchType(StringType):
             repetitions=repetitions,
             case_insensitive_lower="c" in options,
             case_insensitive_upper="C" in options,
-            compact_whitespace="B" in options or "W" in options,
-            optional_blanks="b" in options or "w" in options,
+            compact_whitespace="W" in options,
+            optional_blanks="w" in options,
             full_word_match="f" in options,
             trim="T" in options,
             match_to_start="s" in options

--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -75,6 +75,10 @@ MAGIC_DEFS: List[Path] = sorted([
 WHITESPACE: bytes = b" \r\t\n\v\f"
 # a whitespace byte of an `re.escape`-ed pattern, with or without the backslash that escaped it
 BLANK_IN_PATTERN: Pattern[bytes] = re.compile(rb"\\?[ \t\n\v\f\r]")
+# a wildcard string value ends at the first of these, per `file/src/softmagic.c:683-684`
+VALUE_TERMINATOR: Pattern[bytes] = re.compile(rb"[\0\r\n]")
+# `MAXstring`, the size of the buffer libmagic copies a string value into: `file/src/file.h:179`
+MAX_STRING_BYTES: int = 128
 ESCAPES = {
     "n": ord("\n"),
     "r": ord("\r"),
@@ -1346,28 +1350,49 @@ class StringTest(ABC):
 
 
 class StringWildcard(StringTest):
+    def value_end(self, data: bytes, max_bytes: Optional[int] = None) -> int:
+        """Finds the length of the value that libmagic would read from the head of `data`.
+
+        A wildcard value ends at the first null byte, carriage return, or line feed, whichever
+        comes first (``file/src/softmagic.c:683-684`` and ``909-910``).
+
+        Args:
+            data: The bytes at the offset being tested.
+            max_bytes: The most bytes to read, if the type or the buffer bounds it.
+
+        Returns:
+            The number of bytes of `data` that make up the value.
+        """
+        end = len(data) if max_bytes is None else min(max_bytes, len(data))
+        terminator = VALUE_TERMINATOR.search(data, 0, end)
+        if terminator is None:
+            return end
+        return terminator.start()
+
     def matches(self, data: bytes) -> DataTypeMatch:
         if self.num_bytes is None:
-            first_null = data.find(b"\0")
+            max_bytes = MAX_STRING_BYTES
         else:
-            first_null = data.find(b"\0", 0, self.num_bytes)
-            if first_null < 0:
-                return self.post_process(data[:self.num_bytes])
-        if first_null >= 0:
-            return self.post_process(data[:first_null])
-        else:
-            return self.post_process(data)
+            max_bytes = min(self.num_bytes, MAX_STRING_BYTES)
+        return self.post_process(data[:self.value_end(data, max_bytes)])
 
     def is_always_text(self) -> bool:
         return False
 
     def search(self, data: bytes) -> DataTypeMatch:
-        # `num_bytes` bounds the start offsets a search tries, not the extent of the value it
-        # yields, so a search always reads up to the first null byte
-        first_null = data.find(b"\0")
-        if first_null >= 0:
-            return self.post_process(data[:first_null])
-        return self.post_process(data)
+        """Reads the value that a `search` test reports.
+
+        `num_bytes` bounds the start offsets a search tries, not the extent of the value it
+        yields, and a search reads the buffer in place rather than copying it into libmagic's
+        128-byte value union (``file/src/softmagic.c:1389-1395``), so neither bound applies here.
+
+        Args:
+            data: The bytes at the offset being tested.
+
+        Returns:
+            The value, ending at the first null byte, carriage return, or line feed.
+        """
+        return self.post_process(data[:self.value_end(data)])
 
     def __str__(self):
         return "null-terminated string"

--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -2330,11 +2330,40 @@ class ConstantMatchTest(MagicTest, Generic[T]):
     def calculate_absolute_offset(self, data: bytes, parent_match: Optional[TestResult] = None) -> int:
         return self.offset.to_absolute(data, parent_match, self.data_type.allows_invalid_offsets(self.constant))
 
+    def matched_test(
+            self, match: DataTypeMatch, absolute_offset: int, parent_match: Optional[TestResult]
+    ) -> MatchedTest:
+        """Records a successful match, with the relative base that libmagic would resolve against.
+
+        libmagic resolves a relative (``&``) offset after a ``string`` test with an ``=`` relation
+        against the declared length of the magic value rather than the number of bytes the match
+        consumed (``file/src/softmagic.c:904-905``). The two differ when the ``w`` flag matches
+        fewer blanks than the value declares. A ``search`` measures from where it found its value,
+        which PolyFile records as the extent it matched; libmagic adds the declared length there
+        too, but zeroes it for the ``s`` flag (``file/src/softmagic.c:966-968``), which PolyFile
+        does not model yet. A ``pstring`` carries its own length prefix, so neither takes this
+        path.
+
+        Args:
+            match: The match that this test's data type produced.
+            absolute_offset: The offset in the file at which the data type was applied.
+            parent_match: The result of the test that this one is nested under, if any.
+
+        Returns:
+            The result of the test, with its relative base set when the declared length applies.
+        """
+        result = MatchedTest(self, offset=absolute_offset + match.initial_offset,
+                             length=len(match.raw_match), value=match.value, parent=parent_match)
+        declares_its_length = (isinstance(self.data_type, StringType)
+                               and not isinstance(self.data_type, SearchType))
+        if declares_its_length and isinstance(self.constant, StringMatch):
+            result.relative_base = result.offset + len(self.constant.string)
+        return result
+
     def test(self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]) -> TestResult:
         match = self.data_type.match(data[absolute_offset:], self.constant)
         if match:
-            return MatchedTest(self, offset=absolute_offset + match.initial_offset, length=len(match.raw_match),
-                               value=match.value, parent=parent_match)
+            return self.matched_test(match, absolute_offset, parent_match)
         else:
             return FailedTest(
                 self,
@@ -2352,8 +2381,7 @@ class ConstantMatchTest(MagicTest, Generic[T]):
             data_type = self.data_type
         match = data_type.match(data[absolute_offset:], self.constant)
         if match:
-            return MatchedTest(self, offset=absolute_offset + match.initial_offset, length=len(match.raw_match),
-                               value=match.value, parent=parent_match)
+            return self.matched_test(match, absolute_offset, parent_match)
         else:
             return FailedTest(
                 self,

--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -1771,12 +1771,28 @@ class SearchType(StringType):
 
 
 class PascalStringType(DataType[StringTest]):
+    STRING_FLAGS: str = "CcTWwft"
+
     def __init__(
             self,
             byte_length: int = 1,
             endianness: Endianness = Endianness.BIG,
-            count_includes_length: bool = False
+            count_includes_length: bool = False,
+            string_flags: str = ""
     ):
+        """A length-prefixed string.
+
+        Args:
+            byte_length: The width of the length prefix, in bytes: 1, 2, or 4.
+            endianness: The byte order of a two- or four-byte length prefix.
+            count_includes_length: Whether the length prefix counts itself.
+            string_flags: The string modifier letters of the declaration, such as ``T``. libmagic
+                accepts them on ``pstring`` as it does on ``string``
+                (``file/src/apprentice.c:1943-2020``).
+
+        Raises:
+            ValueError: If `byte_length` or `endianness` is not one libmagic supports.
+        """
         if endianness != Endianness.BIG and endianness != Endianness.LITTLE:
             raise ValueError("Endianness must be either BIG or LITTLE")
         elif byte_length == 1:
@@ -1795,17 +1811,18 @@ class PascalStringType(DataType[StringTest]):
             raise ValueError("byte_length must be either 1, 2, or 4")
         if count_includes_length:
             modifier = f"{modifier}J"
-        super().__init__(f"pstring/{modifier}")
+        super().__init__(f"pstring/{modifier}{string_flags}")
         self.byte_length: int = byte_length
         self.endianness: Endianness = endianness
         self.count_includes_length: int = count_includes_length
+        self.string_type: StringType = StringType.parse(f"string/{string_flags}")
 
     def is_text(self, value: StringTest) -> bool:
         # TODO: See if Pascal strings should sometimes be forced to be text
         return False
 
     def parse_expected(self, specification: str) -> StringTest:
-        return StringTest.parse(specification)
+        return self.string_type.parse_expected(specification)
 
     def match(self, data: bytes, expected: StringTest) -> DataTypeMatch:
         if len(data) < self.byte_length:
@@ -1835,17 +1852,17 @@ class PascalStringType(DataType[StringTest]):
             m.raw_match = data[:self.byte_length + effective_len]
         return m
 
-    PSTRING_TYPE_FORMAT: Pattern[str] = re.compile(r"^pstring(/J?[BHhLl]?J?)?$")
+    PSTRING_TYPE_FORMAT: Pattern[str] = re.compile(r"^pstring(?P<opts>/[JBHhLlCcTWwft]*)?$")
 
     @classmethod
     def parse(cls, format_str: str) -> "PascalStringType":
         m = cls.PSTRING_TYPE_FORMAT.match(format_str)
         if not m:
             raise ValueError(f"Invalid pstring type declaration: {format_str!r}")
-        if m.group(1) is None:
-            options: Iterable[str] = ()
+        if m.group("opts") is None:
+            options: str = ""
         else:
-            options = m.group(1)
+            options = m.group("opts")
         if "H" in options:
             byte_length = 2
             endianness = Endianness.BIG
@@ -1864,7 +1881,8 @@ class PascalStringType(DataType[StringTest]):
         return PascalStringType(
             byte_length=byte_length,
             endianness=endianness,
-            count_includes_length="J" in options
+            count_includes_length="J" in options,
+            string_flags="".join(opt for opt in options if opt in cls.STRING_FLAGS)
         )
 
 

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -13,7 +13,9 @@ from uuid import UUID
 # from polyfile import logger
 import polyfile.der
 import polyfile.magic
-from polyfile.magic import MagicMatcher, MAGIC_DEFS, Match, MatchContext, SearchType, TestResult
+from polyfile.magic import (
+    MagicMatcher, MAGIC_DEFS, Match, MatchContext, SearchType, StringType, TestResult
+)
 
 
 # logger.setLevel(logger.TRACE)
@@ -489,8 +491,8 @@ class MagicMatchingRegressionTest(TestCase):
 
     def test_match_truthiness_is_lazy(self):
         """`bool(match)` used to match the whole subtree before it could answer."""
-        data = b"#!/bin/sh\nexec cat \"$@\"\n"
-        result = next(iter(MagicMatcher.DEFAULT_INSTANCE.match(data)))[0]
+        result = next(iter(MagicMatcher.DEFAULT_INSTANCE.match(b"plain ASCII text\n")))[0]
+        self.assertIsNotNone(result.test.mime, "bool() stops at the first result of a MIME match")
         match, produced = self.counting_match(result, 8)
         self.assertTrue(match)
         self.assertEqual(1, len(produced))
@@ -503,3 +505,77 @@ class MagicMatchingRegressionTest(TestCase):
         self.assertEqual(8192, expected.num_bytes)
         self.assertTrue(search.match(b"." * 8000 + b"needle", expected))
         self.assertFalse(search.match(b"." * 9000 + b"needle", expected))
+
+
+class StringDataTypeTest(TestCase):
+    """Regression tests for the `string` data type defects reported in issue #3483."""
+
+    @staticmethod
+    def messages(definition: str, data: bytes) -> Set[str]:
+        """Runs a single magic definition against `data`.
+
+        Args:
+            definition: The text of a magic definition file, with tab-separated columns.
+            data: The bytes to classify.
+
+        Returns:
+            The message of every match.
+        """
+        with TemporaryDirectory() as tmp_dir:
+            magic_file = Path(tmp_dir) / "test.magic"
+            magic_file.write_text(definition)
+            matcher = MagicMatcher.parse(magic_file)
+            return {str(match) for match in matcher.match(data)}
+
+    def test_optional_blanks_reach_the_matcher(self):
+        """`StringType.parse_expected` dropped the `w` flag, so `#!\\ ` needed a literal space.
+
+        This is what `magic_defs/varied.script` relies on to report both `#!/usr/bin/cmd` and
+        `#! /usr/bin/cmd`.
+        """
+        shebang = StringType.parse("string/wt")
+        self.assertTrue(shebang.optional_blanks)
+        expected = shebang.parse_expected("#!\\ ")
+        self.assertTrue(expected.optional_blanks)
+        for data in (b"#!/usr/bin/x", b"#! /usr/bin/x", b"#!\t/usr/bin/x", b"#!  \t/usr/bin/x"):
+            self.assertTrue(shebang.match(data, expected), repr(data))
+        self.assertFalse(shebang.match(b"#x/usr/bin/x", expected))
+
+    def test_optional_blanks_accept_any_whitespace(self):
+        """`w` was rendered as one optional literal space, so a tab or a run of blanks failed.
+
+        libmagic consumes a run of any whitespace, of any length including none, wherever the magic
+        value holds a blank (`file/src/softmagic.c:2116-2120`).
+        """
+        blanks = StringType.parse("string/w")
+        space_in_value = blanks.parse_expected("A\\ B")
+        for data in (b"AB", b"A B", b"A  B", b"A\tB", b"A \t B"):
+            self.assertTrue(blanks.match(data, space_in_value), repr(data))
+        self.assertFalse(blanks.match(b"AxB", space_in_value))
+        self.assertTrue(blanks.match(b"AB", blanks.parse_expected("A\\tB")))
+
+    def test_compact_whitespace_wins_over_optional_blanks(self):
+        """`StringMatch` raised when a definition set both `W` and `w`, as `magic_defs/sgml` does.
+
+        libmagic keeps both bits and lets `W` win, because `file_strncmp` tests it first
+        (`file/src/softmagic.c:2103-2120`).
+        """
+        both = StringType.parse("string/Ww")
+        self.assertTrue(both.compact_whitespace)
+        self.assertTrue(both.optional_blanks)
+        expected = both.parse_expected("A\\ B")
+        self.assertTrue(both.match(b"A  B", expected))
+        self.assertFalse(both.match(b"AB", expected))
+
+    def test_search_b_flag_is_not_optional_blanks(self):
+        """`search/…b…` was read as optional blanks; `b` selects the binary pass.
+
+        `CHAR_BINTEST` is `b` and `CHAR_COMPACT_OPTIONAL_WHITESPACE` is `w`
+        (`file/src/file.h:416` and `423`).
+        """
+        binary_test = SearchType.parse("search/100/b")
+        self.assertFalse(binary_test.optional_blanks)
+        self.assertFalse(binary_test.compact_whitespace)
+        sgml = SearchType.parse("search/4096/cWbt")
+        self.assertTrue(sgml.compact_whitespace)
+        self.assertFalse(sgml.optional_blanks)

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -347,7 +347,7 @@ class MagicTest(TestCase):
                         matches.add(actual)
                         print(f"\tActual:   {actual!r}")
                     if testfile.stem not in (
-                            "JW07022A.mp3", "gedcom", "cmd1", "cmd2", "cmd3", "cmd4", "jpeg-text", "jsonlines1",
+                            "JW07022A.mp3", "gedcom", "cmd1", "cmd2", "jpeg-text", "jsonlines1",
                             "multiple", "osm", "pnm1", "pnm2", "pnm3", "utf16xmlsvg"
                     ):
                         # The files we skip fail because there is a bug in our implementation that we have not yet fixed

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -579,3 +579,28 @@ class StringDataTypeTest(TestCase):
         sgml = SearchType.parse("search/4096/cWbt")
         self.assertTrue(sgml.compact_whitespace)
         self.assertFalse(sgml.optional_blanks)
+
+    def test_wildcard_string_stops_at_a_line_break(self):
+        """A wildcard value ran to the first null byte, so a `%s` leaked the rest of the file.
+
+        libmagic cuts it at the first carriage return or line feed
+        (`file/src/softmagic.c:683-684`) and reads at most `MAXstring` bytes
+        (`file/src/file.h:179`).
+        """
+        wildcard = StringType.parse("string").parse_expected("x")
+        self.assertEqual(b"first", wildcard.matches(b"first\nsecond").raw_match)
+        self.assertEqual(b"first", wildcard.matches(b"first\r\nsecond").raw_match)
+        self.assertEqual(b"first", wildcard.matches(b"first\0second").raw_match)
+        self.assertEqual(b"a" * 128, wildcard.matches(b"a" * 300).raw_match)
+
+    def test_gedcom_reports_one_version_and_not_four_lines(self):
+        """`magic_defs/scientific`'s `%s` reported four lines of `gedcom.testfile`.
+
+        `gedcom` still fails the corpus check because its message needs the encoding trailer
+        (trailofbits/polyfile#3488), so the corpus check does not pin what this fixes.
+        """
+        self.assertTrue(FILE_TEST_DIR.exists(),
+                        "Run `git submodule init && git submodule update` in the repository root.")
+        data = (FILE_TEST_DIR / "gedcom.testfile").read_bytes()
+        messages = {str(match) for match in MagicMatcher.DEFAULT_INSTANCE.match(data)}
+        self.assertEqual({"GEDCOM genealogy text version 5.5"}, messages)

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -580,6 +580,28 @@ class StringDataTypeTest(TestCase):
         self.assertTrue(sgml.compact_whitespace)
         self.assertFalse(sgml.optional_blanks)
 
+    def test_string_relative_base_is_the_declared_length(self):
+        """`>&-1` under a `string/w` read one byte early when `w` matched no blanks.
+
+        libmagic's `moffset` adds the declared length of the magic value, not the number of bytes
+        the match consumed (`file/src/softmagic.c:904-905`), which is what lets one definition
+        cover both `#!/bin/x` and `#! /bin/x`.
+        """
+        definition = "0\tstring/w\t#!\\ \tshebang\n>&-1\tstring\tx\t%s\n"
+        self.assertEqual({"shebang /bin/x"}, self.messages(definition, b"#!/bin/x\n"))
+        self.assertEqual({"shebang  /bin/x"}, self.messages(definition, b"#! /bin/x\n"))
+        self.assertEqual({"shebang \t/bin/x"}, self.messages(definition, b"#!\t/bin/x\n"))
+
+    def test_search_relative_base_starts_where_it_found_its_value(self):
+        """A `search` resolves a relative offset from where it found its value, not from where it
+        started looking (`file/src/softmagic.c:966-968`).
+
+        Measuring from the start of the search instead turned `gedcom.testfile`'s message into
+        `GEDCOM genealogy text version 2 VERS 2.x`.
+        """
+        definition = "0\tsearch/16\tVERS\tversion\n>&1\tstring\tx\t%s\n"
+        self.assertEqual({"version 5.5"}, self.messages(definition, b"xxx VERS 5.5\nnext line\n"))
+
     def test_wildcard_string_stops_at_a_line_break(self):
         """A wildcard value ran to the first null byte, so a `%s` leaked the rest of the file.
 

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -14,7 +14,7 @@ from uuid import UUID
 import polyfile.der
 import polyfile.magic
 from polyfile.magic import (
-    MagicMatcher, MAGIC_DEFS, Match, MatchContext, SearchType, StringType, TestResult
+    DataType, MagicMatcher, MAGIC_DEFS, Match, MatchContext, SearchType, StringType, TestResult
 )
 
 
@@ -626,3 +626,14 @@ class StringDataTypeTest(TestCase):
         data = (FILE_TEST_DIR / "gedcom.testfile").read_bytes()
         messages = {str(match) for match in MagicMatcher.DEFAULT_INSTANCE.match(data)}
         self.assertEqual({"GEDCOM genealogy text version 5.5"}, messages)
+
+    def test_pstring_forwards_its_string_flags(self):
+        """`PascalStringType` dropped every string flag, and rejected a declaration carrying one.
+
+        libmagic accepts the string modifiers on `pstring` (`file/src/apprentice.c:1943-2020`).
+        """
+        trimming = DataType.parse("pstring/BT")
+        self.assertEqual("hi", trimming.match(b"\x06  hi  ", trimming.parse_expected("x")).value)
+        verbatim = DataType.parse("pstring/B")
+        untrimmed = verbatim.match(b"\x06  hi  ", verbatim.parse_expected("x"))
+        self.assertEqual("  hi  ", untrimmed.value)


### PR DESCRIPTION
Closes #3483

Three defects around the `string` data type, all of which the `#!` shebang definitions in
`polyfile/magic_defs/varied.script:8-14` depend on.

## 1. The `w` (optional blanks) flag never reached the matcher

`StringType.parse_expected` forwarded six of the seven string flags, so
`StringMatch.optional_blanks` was `False` for every `string/…w…` in the corpus. Three things
travelled with forwarding it:

- `StringMatch.__init__` raised when a definition set both `W` and `w`, which
  `polyfile/magic_defs/sgml:44` does as `search/4096/cWbt`. libmagic ORs both bits without
  complaint (`file/src/apprentice.c:1953-1958`) and lets `W` win, because `file_strncmp` tests
  that bit first (`file/src/softmagic.c:2103-2120`). That is what the existing `if`/`elif` in
  `pattern_string` already did, so the guard is gone and the precedence is documented instead.
- `w` compiled to one optional literal space. libmagic consumes a run of any whitespace, of any
  length including none, wherever the magic value holds a blank
  (`file/src/softmagic.c:2116-2120`), so a blank now compiles to `\s*` whether the definition
  wrote a space or a tab. `cmd4` needs this: its shebang is `#!\t/usr/bin/cmd4`.
- `search` read `b` as optional blanks and `B` as compact whitespace. `b` is `CHAR_BINTEST` and
  `B` is a pstring length modifier (`file/src/file.h:415-425`). Dozens of bundled definitions
  pass `b` to a `search`, so forwarding the flag without this correction would have made all of
  them whitespace-insensitive. `b` keeps being ignored, as #3490 tracks.

`PascalStringType.parse_expected` forwarded no flags either, and the `pstring` declaration parser
rejected any declaration that carried one, so `pstring/BT` raised instead of trimming. libmagic
accepts every string modifier on a `pstring` (`file/src/apprentice.c:1943-2020`). The type now
keeps a `StringType` built from the modifier letters and delegates to it; its name carries those
letters so two declarations that differ only in their flags are not interned as one type. No
bundled definition uses a flag on a `pstring`.

## 2. A `string` test's relative base used the consumed length

`ConstantMatchTest.test` recorded `len(match.raw_match)`, and `MatchedTest.relative_base` resolves
a following `&` offset against it. When `w` matched no blanks, a `string/w` consumed two bytes for
a three-byte value, so `>&-1` landed on the `!` of the shebang rather than the interpreter path.

libmagic's `moffset` adds the declared length of the magic value for a `string` with an `=`
relation (`file/src/softmagic.c:904-905`), which is what lets one definition report both
`#!/usr/bin/cmd2` and `#! /usr/bin/cmd1`.

## 3. Wildcard string values were not cut at the first CR or LF

`StringWildcard` ended a value at the first null byte, so a definition that reports a wildcard
`string` with `%s` echoed the rest of the file into its message. This is the most serious part of
the issue: `magic_defs/scientific:82` reported four lines of `file/tests/gedcom.testfile`.

libmagic cuts the value at the first carriage return or line feed
(`file/src/softmagic.c:683-684`, and again at `909-910` when it measures the value for a relative
offset). It also copies at most `MAXstring`, 128, bytes into the value union
(`file/src/file.h:179` and `216`, applied in `mcopy` at `file/src/softmagic.c:1476-1479`), so a
`string` now stops at whichever comes first. A `search` reads the buffer in place instead of
copying it (`file/src/softmagic.c:1389-1395`), so only the line break bounds that one.

**On the 128-byte cap:** it changes no result in the corpus, and it is kept because it is what
libmagic reads and because it bounds how much of a file a `%s` can quote when the content holds
neither terminator — which is the leak this defect is about.

## `string` versus `search` scoping

The declared-length rule is applied to `string` only. `ConstantMatchTest.matched_test` checks the
data type and excludes `SearchType`; `PascalStringType` is not a `StringType` subclass, so it is
excluded already, and it carries its own length prefix.

This matters because `SearchType` subclasses `StringType`: `isinstance(constant, StringMatch)` is
not a sufficient guard. Resolving a `search` from the offset it *started* looking at, rather than
the offset it found its value at, turns `gedcom`'s message into
`GEDCOM genealogy text version 2 VERS 2.x`. `test_search_relative_base_starts_where_it_found_its_value`
and `test_gedcom_reports_one_version_and_not_four_lines` both fail if that rule leaks into
`search`; that was verified by making the change and watching them fail.

One correction to the issue text, from checking `moffset` case by case against the reference
binary: libmagic uses the declared length for `search` too, measured from where the search found
its value (`file/src/softmagic.c:966-968`), so

```
0	search/16/w	A\ B	found
>&0	string	x	%s
```

reports `found D` for `xxABCD` rather than `found CD`. PolyFile keeps the found extent there. The
two agree unless a `search` uses `w` or `W`, and adopting the rule for `search` also needs the `s`
flag (`REGEX_OFFSET_START`), which zeroes the length and which PolyFile does not model yet, so
that stays out of this change.

## Before and after

`file/tests/*.testfile`, with `MagicMatcher.DEFAULT_INSTANCE`:

| stem | `.result` expects | before | after |
| --- | --- | --- | --- |
| `cmd2` | `a /usr/bin/cmd2 script, ASCII text executable` | `ascii text` | `a /usr/bin/cmd2 script text executable`, `a /usr/bin/cmd2 script executable (binary data)` |
| `cmd3` | `a /usr/bin/cmd3 script executable (binary data)` | `data` | `a /usr/bin/cmd3 script executable (binary data)`, `a /usr/bin/cmd3 script text executable` |
| `cmd4` | `a /usr/bin/cmd4 script executable (binary data)` | `data` | `a /usr/bin/cmd4 script executable (binary data)`, `a /usr/bin/cmd4 script text executable` |
| `gedcom` | `GEDCOM genealogy text version 5.5, ASCII text` | `GEDCOM genealogy text version 5.5\n2 FORM Lineage-Linked\n1 CHAR UNICODE\n1 LANG Italian\n` | `GEDCOM genealogy text version 5.5` |

`cmd3` and `cmd4` now pass, and they come out of the corpus test's skip tuple. `cmd1` and `cmd2`
still report both the text and the binary variant of the message, because the `t` and `b` flags do
not select a soft-magic pass yet (#3490). `gedcom` still fails because its message needs the
encoding trailer (#3488); `test_gedcom_reports_one_version_and_not_four_lines` pins the part this
change fixes, since the corpus test cannot.

One other file changes: `matilde.arm` gains `a AMR script executable (binary data)` and
`a AMR script text executable`, because its first bytes are `#!AMR`. The reference binary reports
the same match:

```
$ file -b -k -m file/magic/magic.mgc file/tests/matilde.arm.testfile
Adaptive Multi-Rate Codec (GSM telephony)\012- a AMR script executable (binary data)\012- data
```

It still reports its expected message, so it still passes.

## Verification

Corpus differential over every `file/tests` stem, comparing against the 14 stems `master` skipped:

```
NEWLY PASSING (2): ['cmd3', 'cmd4']
STILL FAILING (12): ['JW07022A.mp3', 'cmd1', 'cmd2', 'gedcom', 'jpeg-text', 'jsonlines1', 'multiple', 'osm', 'pnm1', 'pnm2', 'pnm3', 'utf16xmlsvg']
REGRESSIONS   (0):
```

`pytest tests`: 1007 passed, 8 skipped, 362 subtests before; 1016 passed, 8 skipped, 362 subtests
after. The nine new tests are the difference; no test changes status.

`flake8 polyfile polymerge --max-complexity=10 --max-line-length=127
--exclude=polyfile/kaitai/parsers`: 189 findings before and after, none of them in the lines this
change touches, and none in the `E9,F63,F7,F82` set that CI blocks on. `tests/test_magic.py` is
clean at a 100-character limit.

Each new test was checked by breaking the fix it covers and confirming it fails: dropping the
`optional_blanks` forwarding, restoring the single-optional-space rendering, restoring the `W`/`w`
guard, restoring `b` as optional blanks, dropping the declared-length rule, applying it from the
search start, cutting only at a null byte, removing the 128-byte cap, and dropping the `pstring`
flag delegation. Every one of those is caught.

`test_match_truthiness_is_lazy` needed a new fixture: it classified a shell script whose only match
used to be `ascii text`, the shebang definitions now match that script, and no result of those
matches carries a MIME type for `bool()` to stop at. It uses plain text now and asserts the
property it depends on, so the assertion is unchanged in strength.

## Merge order

#3487 converts this skip tuple into a `KNOWN_FAILURES` map; it should merge after this PR, so that
it records the shorter list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VS8hTTRQeG8ZCmCZ9KLHiV
