### PR TITLE
Repair and expand the Kaitai Struct MIME type mapping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ PolyFile is a file analysis utility that identifies and maps the semantic and sy
 **Key capabilities:**
 - Pure-Python libmagic implementation (896 MIME types, from libmagic 5.48)
 - Recursive embedded file detection (like binwalk)
-- Parsers for PDF, ZIP, JPEG, iNES, and 183 Kaitai Struct formats
+- Parsers for PDF, ZIP, JPEG, iNES, and 183 compiled Kaitai Struct formats (44 mapped to MIME types)
 - Interactive HTML hex viewer with structure mapping
 - Drop-in replacement for Unix `file` command
 
@@ -193,6 +193,14 @@ you overwrite them.
 1. Add the `.ksy` file to the `kaitai_struct_formats/` submodule (upstream, or a local commit)
 2. Map the MIME type in `polyfile.kaitaimatcher.KAITAI_MIME_MAPPING`
 3. Rebuild: `python compile_kaitai_parsers.py`
+4. Add a sample to `TestKaitaiParsing` in `tests/test_kaitai.py`
+
+The MIME type must be one PolyFile can emit (check `polyfile --list`); dispatch is an exact lookup,
+so a key nothing emits is dead code that fails silently. Several MIME types may share one spec by
+repeating it as the value; use `EXTRA_PARSERS` to register a second parser for a MIME type that
+already has one. When libmagic detects a format but assigns no MIME type, add the test as an
+inline DSL snippet in Python (see the Doom WAD and Creative Voice File tests in
+`kaitaimatcher.py`) rather than editing `magic_defs/`.
 
 Only specifications under a permissive license are compiled—see the licensing policy below.
 
@@ -229,6 +237,9 @@ from an excluded spec reaches the package, or if `MANIFEST.in` drifts from the a
 
 ### Gotchas
 - `polyfile/kaitai/parsers/` is auto-generated—never edit manually
+- Four generated parsers (`wmf`, `regf`, `openpgp_message`, `sudoers_ts`) are invalid Python:
+  kaitai-struct-compiler 0.11 escapes neither Python reserved words nor docstring backslashes
+- `archive/rar.ksy` loops forever on RAR5, so it is deliberately unmapped
 - Java required at install time for Kaitai compilation
 - `compile_kaitai_parsers.py` runs at build time and must stay standard-library only
 - The downloaded `polyfile/kaitai/kaitai-struct-compiler-*/` is gitignored; it bundles its own

--- a/docs/extending_polyfile.md
+++ b/docs/extending_polyfile.md
@@ -157,6 +157,47 @@ KAITAI_MIME_MAPPING: Dict[str, str] = {
 }
 ```
 
+Several MIME types may share one specification. Repeat the specification as the value of each key,
+as `font/ttf`, `font/otf`, and `application/vnd.ms-opentype` all do for `font/ttf.ksy`. To register
+a second parser for a MIME type that already has one, add it to `EXTRA_PARSERS` instead; both
+parsers are tried, and one that cannot handle the data raises `InvalidMatch` and is skipped.
+
+#### Adding a mapping
+
+Three things have to hold, and `tests/test_kaitai.py` checks all of them:
+
+1. **PolyFile must be able to emit the MIME type.** Dispatch is an exact lookup on the MIME type
+   the magic matcher resolved, so a key that no matcher emits is dead code: the parser never runs
+   and nothing reports an error. Check the key against `polyfile --list`.
+2. **The generated parser must be importable.** kaitai-struct-compiler 0.11 does not escape Python
+   reserved words used as identifiers, nor backslashes in the docstrings it copies from a
+   specification's `doc:` key, so a handful of generated parsers are not valid Python.
+3. **Parsing a real file must yield more than a root node.** `StructNode.explore` walks only a
+   specification's `seq:` fields, never its `instances:`, so a specification that keeps its content
+   in `instances:` produces an empty tree. Add a sample to `TestKaitaiParsing` to prove otherwise.
+
+Watch for specifications that can loop forever. `archive/rar.ksy` is deliberately unmapped because
+its `blocks` field is `repeat: eos` over a switch whose RAR5 case consumes no bytes, so a 76-byte
+RAR5 file makes it allocate until memory runs out. `TestKaitaiParsing.test_truncated_input_does_not_hang`
+guards the mapped specifications against the same shape of bug.
+
+#### When libmagic detects a format but assigns no MIME type
+
+Some bundled definitions identify a format without an `!:mime` line, which leaves PolyFile with no
+key to dispatch on. Do not add the `!:mime` line to `polyfile/magic_defs/`: those files are a
+hand-maintained copy of upstream Magdir, and a local edit there is easy to lose the next time they
+are refreshed. Define the test in Python instead, the way [`polyfile/nitf.py`](../polyfile/nitf.py)
+and the Doom WAD and Creative Voice File tests in
+[`polyfile/kaitaimatcher.py`](../polyfile/kaitaimatcher.py) do:
+
+```python
+with ExactNamedTempfile(b"""0\tstring\t=IWAD\t\tDoom main IWAD data
+!:mime application/x-doom
+!:ext wad
+""", name="KaitaiMimeMatchers") as t:
+    MagicMatcher.DEFAULT_INSTANCE.add(Path(t), test_type=TestType.BINARY)
+```
+
 #### Licensing of generated parsers
 
 A parser produced by the Kaitai Struct compiler is a derivative work of the `.ksy` specification it

--- a/polyfile/kaitaimatcher.py
+++ b/polyfile/kaitaimatcher.py
@@ -1,63 +1,151 @@
 import base64
-import re
-from typing import Dict, Iterator, List, Tuple, Type
+from pathlib import Path
+from typing import Dict, Iterator, List, Tuple
 
-from kaitaistruct import KaitaiStruct, KaitaiStructError
+from kaitaistruct import KaitaiStructError
 
+from .fileutils import ExactNamedTempfile
 from .kaitai.parser import ASTNode, KaitaiParser, RootNode
 from .logger import getStatusLogger
-from .polyfile import register_parser, InvalidMatch, Match, Parser, Submatch
+from .magic import MagicMatcher, TestType
+from .polyfile import register_parser, InvalidMatch, Match, Submatch
 
 
 log = getStatusLogger(__name__)
 
+# libmagic detects these formats but associates no MIME type with them, so PolyFile had no key on
+# which to dispatch their Kaitai parsers. Defining the tests here rather than patching
+# `polyfile/magic_defs/` keeps them from being clobbered the next time those definitions are
+# refreshed from upstream Magdir. This is the same approach `polyfile/nitf.py` takes.
+with ExactNamedTempfile(b"""# Doom WAD; see the description-only test in magic_defs/games.
+0\tstring\t=IWAD\t\tDoom main IWAD data
+!:mime application/x-doom
+!:ext wad
+0\tstring\t=PWAD\t\tDoom patch PWAD data
+!:mime application/x-doom
+!:ext wad
+# Creative Voice File; see the description-only test in magic_defs/audio.
+0\tstring\tCreative\\ Voice\\ File\tCreative Labs voice data
+!:mime audio/x-voc
+!:ext voc
+""", name="KaitaiMimeMatchers") as t:
+    MagicMatcher.DEFAULT_INSTANCE.add(Path(t), test_type=TestType.BINARY)
+
+# Maps a MIME type to the Kaitai Struct specification that parses it. Several keys may share one
+# specification, either because libmagic subtypes a container (OLE2) or because one spec covers a
+# family (ELF, sfnt fonts).
+#
+# Every key must be a MIME type that some PolyFile matcher can emit, and every value must name an
+# importable parser. `tests/test_kaitai.py` enforces both: dispatch is an exact lookup on the
+# resolved MIME type, so a key nothing emits is dead code that fails silently.
 KAITAI_MIME_MAPPING: Dict[str, str] = {
+    # Images
     "image/gif": "image/gif.ksy",
     "image/png": "image/png.ksy",
     "image/jpeg": "image/jpeg.ksy",
+    "image/bmp": "image/bmp.ksy",
+    "image/webp": "image/webp.ksy",
     "image/vnd.microsoft.icon": "image/ico.ksy",
-#    "image/wmf": "image/wmf.ksy",  # there is currently a problem with this parser in Python
-    "application/vnd.nitf": "image/nitf.ksy",
-    "application/vnd.tcpdump.pcap": "network/pcap.ksy",
-    "application/x-sqlite3": "database/sqlite3.ksy",
-    "application/x-rar": "archive/rar.ksy",
-    "font/sfnt": "font/ttf.ksy",
-    "application/x-pie-executable": "executable/elf.ksy",
-    "application/gzip": "archive/gzip.ksy",
-    "application/x-xar": "archive/xar.ksy",
-    "application/x-python-code": "executable/python_pyc_27.ksy",
-    "application/x-shockwave-flash": "executable/swf.ksy",
-    "application/x-doom": "game/doom_wad.ksy",
+    "image/x-tga": "image/tga.ksy",
+    "image/vnd.zbrush.pcx": "image/pcx.ksy",
     "image/x-dcx": "image/pcx_dcx.ksy",
-    "model/gltf-binary": "3d/gltf_binary.ksy",
+    "image/x-gimp-gbr": "image/gimp_brush.ksy",
+    "application/vnd.nitf": "image/nitf.ksy",
+    "application/dicom": "image/dicom.ksy",
+    # Only ICC v4 profiles parse; the spec validates the version field, so v2 profiles raise a
+    # KaitaiStructError and fall through to the next parser.
+    "application/vnd.iccprofile": "image/icc_4.ksy",
+    # image/wmf is unmapped because polyfile/kaitai/parsers/wmf.py is not valid Python:
+    # kaitai-struct-compiler 0.11 does not escape Python reserved words, so the spec's `not` enum
+    # member compiles to `not = 6` at line 32. See TestGeneratedParsers in tests/test_kaitai.py.
+
+    # Audio and video
+    "audio/midi": "media/standard_midi_file.ksy",
+    "audio/x-voc": "media/creative_voice_file.ksy",
+    "audio/x-wav": "media/wav.ksy",
+    "audio/basic": "media/au.ksy",
+    "audio/x-dec-basic": "media/au.ksy",
+    "application/ogg": "media/ogg.ksy",
+    "audio/ogg": "media/ogg.ksy",
+    "video/ogg": "media/ogg.ksy",
+    "video/x-msvideo": "media/avi.ksy",
+    "video/quicktime": "media/quicktime_mov.ksy",
+    "video/mp4": "media/quicktime_mov.ksy",
+    # Executables
+    "application/x-executable": "executable/elf.ksy",
+    "application/x-pie-executable": "executable/elf.ksy",
+    "application/x-sharedlib": "executable/elf.ksy",
+    "application/x-object": "executable/elf.ksy",
+    "application/x-coredump": "executable/elf.ksy",
+    # A Mach-O file is either thin or universal, and libmagic reports both the same way, so both
+    # parsers are registered and the one that does not apply raises a KaitaiStructError.
+    "application/x-mach-binary": "executable/mach_o.ksy",
+    "application/vnd.microsoft.portable-executable": "executable/microsoft_pe.ksy",
+    "application/x-dosexec": "executable/microsoft_pe.ksy",
+    "application/x-java-applet": "executable/java_class.ksy",
+    "application/x-shockwave-flash": "executable/swf.ksy",
+    # Only CPython 2.7 bytecode parses; other versions raise a KaitaiStructError.
+    "application/x-bytecode.python": "executable/python_pyc_27.ksy",
+    # Archives and filesystems
+    "application/gzip": "archive/gzip.ksy",
+    # application/vnd.rar is unmapped because archive/rar.ksy hangs on RAR5. Its `blocks`
+    # field is `repeat: eos` over a switch whose v5 case, `block_v5`, is an empty stub that
+    # consumes no bytes, so the loop never advances the stream and grows the block list until
+    # memory runs out. A 76-byte RAR5 file is enough. RAR5 has been the default since 2013.
+    "application/x-xar": "archive/xar.ksy",
     "application/x-rpm": "archive/rpm.ksy",
     "application/x-cpio": "archive/cpio_old_le.ksy",
-    "image/x-gimp-gbr": "image/gimp_brush.ksy",
-#    "application/dicom": "image/dicom.ksy",  # there is currently a problem with this parser in Python
-    "image/bmp": "image/bmp.ksy",
-    "application/x-blender": "media/blender_blend.ksy",
-    "audio/x-voc": "media/creative_voice_file.ksy",
-    "audio/midi": "media/standard_midi_file.ksy",
-    "application/dime": "network/dime_message.ksy",
-    "application/bson": "serialization/bson.ksy",
+    # Databases and serialization
+    "application/vnd.sqlite3": "database/sqlite3.ksy",
+    "application/geopackage+sqlite3": "database/sqlite3.ksy",
+    "application/x-audacity-project+sqlite3": "database/sqlite3.ksy",
+    "application/x-dbf": "database/dbf.ksy",
+    "application/x-gettext-translation": "database/gettext_mo.ksy",
+    "application/x-python-pickle": "serialization/python_pickle.ksy",
+    "application/pkix-cert": "serialization/asn1/asn1_der.ksy",
+    "application/pkcs10": "serialization/asn1/asn1_der.ksy",
+    "application/pkcs7-mime": "serialization/asn1/asn1_der.ksy",
+    # OLE2 compound files. This is a curated subset of the container types libmagic subtypes;
+    # msword, vnd.ms-excel and vnd.ms-powerpoint are also emitted by non-OLE2 definitions
+    # (magic_defs/rtf, magic_defs/msdos), where the parser raises a KaitaiStructError.
+    "application/x-ole-storage": "serialization/microsoft_cfb.ksy",
+    "application/msword": "serialization/microsoft_cfb.ksy",
+    "application/vnd.ms-excel": "serialization/microsoft_cfb.ksy",
+    "application/vnd.ms-powerpoint": "serialization/microsoft_cfb.ksy",
+    "application/vnd.ms-project": "serialization/microsoft_cfb.ksy",
+    "application/vnd.visio": "serialization/microsoft_cfb.ksy",
+    "application/x-msi": "serialization/microsoft_cfb.ksy",
+    "application/x-ms-msg": "serialization/microsoft_cfb.ksy",
+    "application/x-ms-thumbnail": "serialization/microsoft_cfb.ksy",
+    # Fonts
+    "font/ttf": "font/ttf.ksy",
+    "font/otf": "font/ttf.ksy",
+    "application/vnd.ms-opentype": "font/ttf.ksy",
+    # Everything else
+    "application/vnd.tcpdump.pcap": "network/pcap.ksy",
     "application/x-ms-shortcut": "windows/windows_lnk_file.ksy",
-    "application/x-java-applet": "executable/java_class.ksy",
-    # Uncomment this when/if Kaitai fixes its upstream compilation bug for ICC
-# (https://github.com/kaitai-io/kaitai_struct_formats/issues/347#ref-commit-fde2866)
-#    "application/vnd.iccprofile": "image/icc_4.ksy"
+    "application/x-apple-rsr": "macos/resource_fork.ksy",
+    "application/x-blender": "media/blender_blend.ksy",
+    "application/x-doom": "game/doom_wad.ksy",
+    "model/gltf-binary": "3d/gltf_binary.ksy",
 }
+
+# A universal Mach-O binary shares `application/x-mach-binary` with a thin one, so its parser is
+# registered separately rather than displacing the thin parser in the mapping above.
+EXTRA_PARSERS: Tuple[Tuple[str, str], ...] = (
+    ("application/x-mach-binary", "executable/mach_o_fat.ksy"),
+)
 
 IMAGE_MIMETYPES = {
     "image/gif",
     "image/jpeg",
     "image/png",
     "image/bmp",
+    "image/webp",
 }
 
-MIME_BY_PARSER: Dict[Type[KaitaiStruct], str] = {}
 
-
-def ast_to_matches(ast: RootNode, parent: Match) -> Iterator[Submatch]:
+def ast_to_matches(ast: RootNode, parent: Match, mimetype: str) -> Iterator[Submatch]:
     stack: List[Tuple[Match, ASTNode]] = [(parent, ast)]
     while stack:
         parent, node = stack.pop()
@@ -70,11 +158,8 @@ def ast_to_matches(ast: RootNode, parent: Match) -> Iterator[Submatch]:
             parent=parent
         )
 
-        if node is ast and node.obj.__class__ in MIME_BY_PARSER:  # type: ignore
-            mtype = MIME_BY_PARSER[node.obj.__class__]  # type: ignore
-            if mtype in IMAGE_MIMETYPES:  # type: ignore
-                # this is an image type, so create a preview
-                new_node.img_data = f"data:{mtype};base64,{base64.b64encode(ast.raw_value).decode('utf-8')}"
+        if node is ast and mimetype in IMAGE_MIMETYPES:
+            new_node.img_data = f"data:{mimetype};base64,{base64.b64encode(ast.raw_value).decode('utf-8')}"
 
         yield new_node
         stack.extend(reversed([(new_node, c) for c in node.children]))
@@ -92,29 +177,32 @@ class LazyKaitaiParser:
     def kaitai_parser(self):
         if self._kaitai_parser is None:
             self._kaitai_parser = KaitaiParser.load(self.kaitai_path)
-            MIME_BY_PARSER[self._kaitai_parser.struct_type] = self.mimetype
         return self._kaitai_parser
 
     def __call__(self, stream, match):
         try:
             ast = self.kaitai_parser.parse(stream).ast
         except KaitaiStructError as e:
-            log.warning(f"Error parsing {stream.name} using {self.kaitai_parser}: {e!s}")
+            # Several MIME types share a specification, and some specifications cover only part of
+            # what their MIME type denotes, so this is an expected outcome rather than a problem.
+            log.debug(f"Error parsing {stream.name} using {self.kaitai_parser}: {e!s}")
             raise InvalidMatch()
         except Exception as e:
             log.error(f"Unexpected exception parsing {stream.name} using {self.kaitai_parser}: {e!s}")
             raise InvalidMatch()
-        yield from ast_to_matches(ast, parent=match)
+        yield from ast_to_matches(ast, parent=match, mimetype=self.mimetype)
 
 
-for mimetype, kaitai_path in KAITAI_MIME_MAPPING.items():
-    func_name = mimetype.replace("/", "_").replace("-", "_")
+def _register(mimetype: str, kaitai_path: str) -> None:
     parser = LazyKaitaiParser(kaitai_path, mimetype)
-    parser.__name__ = f"parse_{func_name}"
-    parser.__qualname__ = f"parse_{func_name}"
+    func_name = f"parse_{Path(kaitai_path).stem}"
+    parser.__name__ = func_name
+    parser.__qualname__ = func_name
     register_parser(mimetype)(parser)
 
-del func_name
-del kaitai_path
-del mimetype
-del parser
+
+for _mimetype, _kaitai_path in tuple(KAITAI_MIME_MAPPING.items()) + EXTRA_PARSERS:
+    _register(_mimetype, _kaitai_path)
+
+del _mimetype
+del _kaitai_path

--- a/tests/corkami_corpus.py
+++ b/tests/corkami_corpus.py
@@ -1,0 +1,61 @@
+"""Access to the Corkami "pocs" corpus of polyglot and edge-case files.
+
+The corpus is downloaded on demand rather than vendored (``tests/.gitignore`` excludes it), so
+importing this module is cheap and has no side effects.
+"""
+
+from pathlib import Path
+import shutil
+from tempfile import TemporaryDirectory
+from typing import Iterator
+import urllib.request
+from zipfile import ZipFile, ZipInfo
+
+CORKAMI_CORPUS_ZIP = Path(__file__).absolute().parent / "corkami.zip"
+CORKAMI_URL = "https://github.com/corkami/pocs/archive/refs/heads/master.zip"
+
+
+class CorkamiFile:
+    def __init__(self, path_in_zip: Path, info: ZipInfo):
+        self.path_in_zip: Path = path_in_zip
+        self.info: ZipInfo = info
+        self._tmpdir: TemporaryDirectory = None  # type: ignore
+
+    def __enter__(self) -> Path:
+        self._tmpdir = TemporaryDirectory()
+        self._tmpdir.__enter__()
+        with ZipFile(CORKAMI_CORPUS_ZIP, "r") as z:
+            return Path(z.extract(self.info, self._tmpdir.name))
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._tmpdir.__exit__(exc_type, exc_val, exc_tb)
+
+
+class CorkamiCorpus:
+    @classmethod
+    def download(cls):
+        with urllib.request.urlopen(CORKAMI_URL) as response, open(CORKAMI_CORPUS_ZIP, "wb") as out_file:
+            shutil.copyfileobj(response, out_file)
+
+    @classmethod
+    def ensure_downloaded(cls):
+        if not CORKAMI_CORPUS_ZIP.exists():
+            cls.download()
+
+    @classmethod
+    def read(cls, path_in_zip: str) -> bytes:
+        """Returns the contents of one file in the corpus, downloading the corpus if necessary."""
+        cls.ensure_downloaded()
+        with ZipFile(CORKAMI_CORPUS_ZIP, "r") as z:
+            return z.read(path_in_zip)
+
+    @classmethod
+    def files(cls) -> Iterator[CorkamiFile]:
+        cls.ensure_downloaded()
+        with ZipFile(CORKAMI_CORPUS_ZIP, "r") as z:
+            for info in z.infolist():
+                if info.is_dir() or info.file_size <= 0:
+                    continue
+                path = Path(info.filename)
+                if not path.name.startswith("."):
+                    yield CorkamiFile(path_in_zip=path, info=info)

--- a/tests/test_corkami.py
+++ b/tests/test_corkami.py
@@ -3,17 +3,14 @@ from pathlib import Path
 import re
 import shutil
 import subprocess
-from tempfile import TemporaryDirectory
-from typing import Iterator, Set
+from typing import Set
 from unittest import TestCase
-import urllib.request
-from zipfile import ZipFile, ZipInfo
 
 from polyfile.magic import MAGIC_DEFS, MagicMatcher, MatchContext
 
-CORKAMI_CORPUS_ZIP = Path(__file__).absolute().parent / "corkami.zip"
+from .corkami_corpus import CorkamiCorpus
+
 FAILED_FILE_DIR = Path(__file__).absolute().parent / "failed_corkami_files"
-CORKAMI_URL = "https://github.com/corkami/pocs/archive/refs/heads/master.zip"
 SCRIPT_DIR = Path(__file__).absolute().parent
 FILE_DIR = SCRIPT_DIR.parent / "file"
 FILE_PATH = FILE_DIR / "src" / "file"
@@ -48,41 +45,6 @@ KNOWN_BAD_FILES = {
 
 FILE_MIMETYPE_PATTERN = re.compile(rb"^(.*?:|-)\s*(?P<mime>[^/\s]+/[^/;\s]+)\s*(;.*?$|$)(?P<remainder>.*)",
                                    re.MULTILINE)
-
-
-class CorkamiFile:
-    def __init__(self, path_in_zip: Path, info: ZipInfo):
-        self.path_in_zip: Path = path_in_zip
-        self.info: ZipInfo = info
-        self._tmpdir: TemporaryDirectory = None  # type: ignore
-
-    def __enter__(self) -> Path:
-        self._tmpdir = TemporaryDirectory()
-        self._tmpdir.__enter__()
-        with ZipFile(CORKAMI_CORPUS_ZIP, "r") as z:
-            return Path(z.extract(self.info, self._tmpdir.name))
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self._tmpdir.__exit__(exc_type, exc_val, exc_tb)
-
-
-class CorkamiCorpus:
-    @classmethod
-    def download(cls):
-        with urllib.request.urlopen(CORKAMI_URL) as response, open(CORKAMI_CORPUS_ZIP, "wb") as out_file:
-            shutil.copyfileobj(response, out_file)
-
-    @classmethod
-    def files(cls) -> Iterator[CorkamiFile]:
-        if not CORKAMI_CORPUS_ZIP.exists():
-            cls.download()
-        with ZipFile(CORKAMI_CORPUS_ZIP, "r") as z:
-            for info in z.infolist():
-                if info.is_dir() or info.file_size <= 0:
-                    continue
-                path = Path(info.filename)
-                if not path.name.startswith("."):
-                    yield CorkamiFile(path_in_zip=path, info=info)
 
 
 class CorkamiDifferentialTests(TestCase):

--- a/tests/test_kaitai.py
+++ b/tests/test_kaitai.py
@@ -1,9 +1,26 @@
+from contextlib import contextmanager
+import gzip
 from pathlib import Path
-from tempfile import NamedTemporaryFile
-from unittest import TestCase
+import pickle
+import signal
+import struct
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+from typing import Tuple
+from unittest import skipUnless, TestCase
+from urllib.error import URLError
 import zipfile
 
-from polyfile.kaitai.parser import KaitaiParser, RootNode, Segment
+from kaitaistruct import KaitaiStructError
+
+from polyfile.kaitai.parser import KaitaiParser, PARSER_DIR, RootNode, Segment
+from polyfile.kaitaimatcher import EXTRA_PARSERS, KAITAI_MIME_MAPPING
+from polyfile.magic import MagicMatcher
+from polyfile.polyfile import Matcher, Submatch
+
+from .corkami_corpus import CorkamiCorpus
+
+DER_CERTIFICATE = Path(__file__).absolute().parent / "msjdbc.cer.gz"
+PARSE_TIMEOUT_SECONDS = 20
 
 
 class TestKaitai(TestCase):
@@ -43,3 +60,186 @@ class TestKaitai(TestCase):
         self.assertRaises(IndexError, s.__getitem__, len(s))
         self.assertRaises(ValueError, s.__getitem__, slice(0, 1, 5))
         self.assertFalse(s[20:30])
+
+
+class TestKaitaiMimeMapping(TestCase):
+    """Guards the invariants that make an entry in ``KAITAI_MIME_MAPPING`` do anything at all."""
+
+    def test_mapping_keys_are_reachable(self):
+        """Every mapped MIME type must be one that a PolyFile matcher can emit.
+
+        Dispatch in :meth:`polyfile.polyfile.Matcher.handle_mimetype` is an exact lookup on the
+        MIME type the magic matcher resolved, so a key that no matcher emits is dead code: the
+        parser never runs and nothing reports an error. Eight entries had rotted this way by the
+        time this test was written.
+        """
+        emittable = set(MagicMatcher.DEFAULT_INSTANCE.mimetypes)
+        for mimetype in sorted(KAITAI_MIME_MAPPING):
+            with self.subTest(mimetype=mimetype):
+                self.assertIn(mimetype, emittable)
+
+    def test_mapped_parsers_load(self):
+        """Every mapped ``.ksy`` must resolve to an importable parser class."""
+        registered = set(KAITAI_MIME_MAPPING.values()) | {ksy_path for _, ksy_path in EXTRA_PARSERS}
+        for ksy_path in sorted(registered):
+            with self.subTest(ksy_path=ksy_path):
+                self.assertIsNotNone(KaitaiParser.load(ksy_path))
+
+
+class TestGeneratedParsers(TestCase):
+    """Guards against mapping a ``.ksy`` whose generated Python cannot even be imported."""
+
+    # kaitai-struct-compiler 0.11 neither escapes Python reserved words used as identifiers nor
+    # escapes backslashes in the docstrings it copies from a spec's `doc:` key, so these four
+    # generated parsers are not valid Python and cannot be mapped:
+    #
+    #     wmf.py:32               `not = 6`     (enum member)
+    #     sudoers_ts.py:22        `global = 1`  (enum member)
+    #     openpgp_message.py:816  `self.class`  (sequence field)
+    #     regf.py:14              an unescaped `\N` in a docstring
+    KNOWN_UNCOMPILABLE = {
+        "openpgp_message.py",
+        "regf.py",
+        "sudoers_ts.py",
+        "wmf.py",
+    }
+
+    @staticmethod
+    def compiles(path: Path) -> bool:
+        try:
+            compile(path.read_text(encoding="utf-8"), str(path), "exec")
+        except (SyntaxError, ValueError):
+            return False
+        return True
+
+    def test_generated_parsers_compile(self):
+        for path in sorted(PARSER_DIR.glob("*.py")):
+            if path.name in self.KNOWN_UNCOMPILABLE:
+                continue
+            with self.subTest(parser=path.name):
+                self.assertTrue(self.compiles(path))
+
+    def test_known_uncompilable_parsers_still_fail(self):
+        """Prune ``KNOWN_UNCOMPILABLE`` once upstream fixes a parser, then consider mapping it."""
+        for name in sorted(self.KNOWN_UNCOMPILABLE):
+            with self.subTest(parser=name):
+                self.assertFalse(self.compiles(PARSER_DIR / name))
+
+
+class TestKaitaiParsing(TestCase):
+    """Checks that each mapped specification extracts real structure from a real file.
+
+    A specification that parses without error but yields nothing but a root node is not worth
+    mapping, so every case asserts more than one AST node. ``StructNode.explore`` walks only
+    ``SEQ_FIELDS`` and never ``instances:``, so specs that keep their content in ``instances:``
+    (iso9660, id3v1_1, ext2 among them) fail that bar and are deliberately unmapped.
+    """
+
+    # Files from the Corkami "pocs" corpus, which is downloaded on demand.
+    CORKAMI_SAMPLES: Tuple[Tuple[str, str], ...] = (
+        ("image/gif.ksy", "mini/gif89.gif"),
+        ("image/png.ksy", "mini/png.png"),
+        ("image/jpeg.ksy", "mini/jpg.jpg"),
+        ("image/bmp.ksy", "mini/bmp.bmp"),
+        ("image/ico.ksy", "mini/ico.ico"),
+        ("image/webp.ksy", "mini/webp.webp"),
+        ("image/dicom.ksy", "mini/dicom.dcm"),
+        ("media/avi.ksy", "mini/avi.avi"),
+        ("media/wav.ksy", "mini/riff.wav"),
+        ("media/ogg.ksy", "mini/vorbis.ogg"),
+        ("media/quicktime_mov.ksy", "mini/qt.mov"),
+        ("media/quicktime_mov.ksy", "mini/mp4.mp4"),
+        ("executable/elf.ksy", "mini/mini.elf"),
+        ("executable/mach_o.ksy", "mini/mini.macho"),
+        ("executable/microsoft_pe.ksy", "mini/pe32.exe"),
+        ("executable/java_class.ksy", "mini/java.class"),
+        ("executable/swf.ksy", "mini/mini.swf"),
+        ("archive/gzip.ksy", "mini/gzip.gz"),
+        ("archive/cpio_old_le.ksy", "mini/binary.cpio"),
+        ("game/doom_wad.ksy", "mini/wad.wad"),
+    )
+
+    @staticmethod
+    def node_count(ksy_path: str, data: bytes) -> int:
+        return len(list(KaitaiParser.load(ksy_path).parse(data).ast.dfs()))
+
+    def test_corkami_samples(self):
+        try:
+            CorkamiCorpus.ensure_downloaded()
+        except URLError as e:
+            self.skipTest(f"could not download the Corkami corpus: {e}")
+        for ksy_path, sample in self.CORKAMI_SAMPLES:
+            with self.subTest(ksy_path=ksy_path, sample=sample):
+                data = CorkamiCorpus.read(f"pocs-master/{sample}")
+                self.assertGreater(self.node_count(ksy_path, data), 1)
+
+    def test_synthesized_samples(self):
+        """Covers mapped specs with no sample in the Corkami corpus."""
+        samples = {
+            "media/au.ksy": b".snd" + struct.pack(">IIIII", 24, 8, 1, 8000, 1) + bytes(8),
+            "image/tga.ksy": (
+                bytes([0, 0, 2, 0, 0, 0, 0, 0]) + struct.pack("<HHHHBB", 0, 0, 2, 2, 24, 0) + bytes(12)
+            ),
+            "media/creative_voice_file.ksy": (
+                b"Creative Voice File\x1a" + struct.pack("<HHH", 26, 0x010A, 0x1129) + b"\x00"
+            ),
+            "serialization/python_pickle.ksy": pickle.dumps({"polyfile": [1, 2, 3]}),
+            "serialization/asn1/asn1_der.ksy": gzip.decompress(DER_CERTIFICATE.read_bytes()),
+        }
+        for ksy_path, data in sorted(samples.items()):
+            with self.subTest(ksy_path=ksy_path):
+                self.assertGreater(self.node_count(ksy_path, data), 1)
+
+    @skipUnless(hasattr(signal, "SIGALRM"), "bounding a runaway parse needs SIGALRM")
+    def test_truncated_input_does_not_hang(self):
+        """A truncated file must fail fast rather than loop forever.
+
+        `archive/rar.ksy` is unmapped because it does loop forever on RAR5: its `blocks` field is
+        `repeat: eos` over a switch whose v5 case consumes no bytes. This guards the mapped specs
+        against the same shape of bug, which a plain parse test would hang on rather than fail.
+        """
+        try:
+            CorkamiCorpus.ensure_downloaded()
+        except URLError as e:
+            self.skipTest(f"could not download the Corkami corpus: {e}")
+        for ksy_path, sample in self.CORKAMI_SAMPLES:
+            data = CorkamiCorpus.read(f"pocs-master/{sample}")
+            for fraction in (10, 50, 90):
+                truncated = data[:max(1, len(data) * fraction // 100)]
+                with self.subTest(ksy_path=ksy_path, sample=sample, percent=fraction):
+                    with self.assertCompletesQuickly(ksy_path):
+                        try:
+                            self.node_count(ksy_path, truncated)
+                        except KaitaiStructError:
+                            pass
+
+    @contextmanager
+    def assertCompletesQuickly(self, ksy_path: str, seconds: int = PARSE_TIMEOUT_SECONDS):
+        def on_alarm(signum, frame):
+            raise TimeoutError(f"{ksy_path} did not finish parsing within {seconds}s")
+
+        previous = signal.signal(signal.SIGALRM, on_alarm)
+        signal.alarm(seconds)
+        try:
+            yield
+        except TimeoutError as e:
+            self.fail(str(e))
+        finally:
+            signal.alarm(0)
+            signal.signal(signal.SIGALRM, previous)
+
+
+class TestKaitaiRegistration(TestCase):
+    def test_parser_runs_end_to_end(self):
+        """A mapped MIME type must actually dispatch its parser through `Matcher.match`."""
+        try:
+            CorkamiCorpus.ensure_downloaded()
+        except URLError as e:
+            self.skipTest(f"could not download the Corkami corpus: {e}")
+        with TemporaryDirectory() as tmpdir:
+            webp = Path(tmpdir) / "sample.webp"
+            webp.write_bytes(CorkamiCorpus.read("pocs-master/mini/webp.webp"))
+            matches = list(Matcher().match(webp))
+        self.assertTrue(any(m.name == "image/webp" for m in matches))
+        submatches = [m for m in matches if isinstance(m, Submatch)]
+        self.assertGreater(len(submatches), 1)


### PR DESCRIPTION
Audits `KAITAI_MIME_MAPPING` against the MIME types PolyFile can actually emit, repairs the entries that had rotted, and maps 17 more specifications. PolyFile ships 183 compiled Kaitai parsers but only 20 of them were reachable; this brings that to 44, across 66 MIME types.

## Eight mappings had never run

Parser dispatch (`Matcher.handle_mimetype`) is an exact lookup on the MIME type the magic matcher resolved, so a key no matcher emits is dead code: the parser never runs and nothing reports an error. Comparing the table against `MagicMatcher.DEFAULT_INSTANCE.mimetypes` found eight such keys.

Four had drifted from the MIME type PolyFile emits and are re-keyed:

| Was (never matched) | Now |
| --- | --- |
| `application/x-sqlite3` | `application/vnd.sqlite3` (+ geopackage, audacity) |
| `font/sfnt` | `font/ttf`, `font/otf`, `application/vnd.ms-opentype` |
| `application/x-python-code` | `application/x-bytecode.python` |
| `application/x-rar` | dropped, see below |

Doom WAD and Creative Voice File had no emittable MIME type at all: libmagic detects both but assigns no `!:mime`. Rather than patching `polyfile/magic_defs/`, whose contents are overwritten whenever they are refreshed from upstream Magdir, the tests are registered as inline DSL snippets in `kaitaimatcher.py` — the approach `polyfile/nitf.py` already uses. `application/dime` and `application/bson` are removed; neither format has a magic test, and BSON is only a length prefix.

## Two disabled parsers work now, one still does not

`image/dicom.ksy` and `image/icc_4.ksy` were commented out in 2021 and are re-enabled: DICOM yields 212 AST nodes on a real study, and ICC parses v4 profiles (it validates the version field, so v2 profiles fail cleanly to `InvalidMatch`).

`image/wmf.ksy` remains unmapped, but the vague 2021 note is replaced with the root cause. It is not a parser-quality problem: `polyfile/kaitai/parsers/wmf.py` is not valid Python. kaitai-struct-compiler 0.11 does not escape Python reserved words, and the spec has an enum member named `not`, so line 32 reads `not = 6`. Three other generated parsers are broken the same way (`regf`, `openpgp_message`, `sudoers_ts`), which no test would have caught.

## RAR is deliberately left unmapped

`archive/rar.ksy` hangs on RAR5. Its `blocks` field is `repeat: eos` over a switch whose v5 case, `block_v5`, is an empty stub that consumes no bytes, so the loop never advances the stream and grows the block list until memory runs out. A 76-byte RAR5 file is enough, and RAR5 has been the default since 2013. The dead `application/x-rar` key had been masking this; repairing it without checking would have introduced a denial of service into a tool that runs on untrusted input.

## New coverage

ELF was mapped only for `application/x-pie-executable`; the four other types `magic_defs/elf` emits are added, so an ordinary non-PIE executable is now parsed. Seventeen specifications are newly mapped, each verified against a real sample: WebP, AVI, WAV, Ogg, QuickTime/MP4, Mach-O (thin and universal), PE, TGA, PCX, Sun/NeXT audio, Python pickle, DER, gettext `.mo`, dBase, macOS resource forks, and OLE2 compound files (a curated subset of the container types libmagic subtypes).

Measured through the CLI, before and after:

| Sample | master | this branch |
| --- | --- | --- |
| `webp.webp` | 1 element | 21 |
| `qt.mov` | 1 | 146 |
| `dicom.dcm` | 1 | 213 |
| `mini.macho` | 1 | 47 |
| `busybox` | 1 | 23 |

Specs that parse without error but expose only a root node are deliberately excluded — `iso9660`, `id3v1_1` and `ext2` keep their content in `instances:`, which `StructNode.explore` never walks. `image/exif.ksy` is excluded for a different reason: it parses a bare TIFF header, but it specifies the Exif blob, so it would root a plain TIFF's tree at "Exif" in exchange for four extra nodes.

## Tests

Nothing previously checked any of this, which is how eight entries went unnoticed. `tests/test_kaitai.py` gains reachability, importability, per-format parse, and end-to-end registration tests, plus a SIGALRM-bounded truncation test so a runaway parse fails instead of hanging. The compile test carries an allowlist of the four compiler-broken parsers together with an assertion that the allowlist has not gone stale. Each test was confirmed to fail when the defect it targets is reintroduced.

`tests/corkami_corpus.py` is extracted from `test_corkami.py` so a test module can read one corpus sample without triggering the download-and-register-944-tests import side effect.

## Follow-ups, not in this PR

- Upstream status of the three compiler/spec bugs behind the unmapped parsers:
  - Reserved words used as identifiers: already tracked in kaitai-io/kaitai_struct#90 (open since 2017; it lists `not` for `mach_o.ksy`, and `wmf.ksy` and `sudoers_ts.ksy` hit the same thing).
  - Unescaped backslashes in generated docstrings: already tracked in kaitai-io/kaitai_struct#1226.
  - RAR5 non-termination: filed as kaitai-io/kaitai_struct_formats#773.
- Teaching `StructNode.explore` to walk `instances:` would unlock iso9660 and ext2 and deepen the PE tree considerably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyjAPnwiiNMeqPYL58peMj
