### PR TITLE
Port libmagic's type and relation strength terms

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -24,8 +24,8 @@ import struct
 import sys
 from time import gmtime, localtime, strftime
 from typing import (
-    Any, BinaryIO, Callable, Dict, Generic, Iterable, Iterator, List, NamedTuple, Optional, Set,
-    Tuple, Type, TypeVar, Union
+    Any, BinaryIO, Callable, Dict, FrozenSet, Generic, Iterable, Iterator, List, NamedTuple,
+    Optional, Set, Tuple, Type, TypeVar, Union
 )
 from uuid import UUID
 
@@ -296,6 +296,29 @@ class StrengthOp(Enum):
     MINUS = "-"
     TIMES = "*"
     DIV = "/"
+
+
+STRENGTH_MULT: int = 10
+"""libmagic's strength unit, ``MULT`` in ``file/src/apprentice.c:928``."""
+
+STRENGTH_BASELINE: int = 2 * STRENGTH_MULT
+"""The strength every test starts from, before its type and relation terms."""
+
+RELATION_STRENGTH: Dict[str, int] = {
+    "=": STRENGTH_MULT,
+    ">": -2 * STRENGTH_MULT,
+    "<": -2 * STRENGTH_MULT,
+    "^": -STRENGTH_MULT,
+    "&": -STRENGTH_MULT,
+}
+"""How each relational operator adjusts a test's strength (``file/src/apprentice.c:1034-1051``).
+
+An exact match is the most specific, so it gains a unit; an inequality is the least specific of the
+operators that still read a value, so it loses two.
+"""
+
+UNSELECTIVE_RELATIONS: FrozenSet[str] = frozenset({"x", "!"})
+"""The relations libmagic zeroes the strength for, because they match anything or almost anything."""
 
 
 def parse_numeric(text: Union[str, bytes]) -> int:
@@ -860,12 +883,59 @@ class MagicTest(ABC):
     def subtest_type(self) -> TestType:
         raise NotImplementedError()
 
+    def type_strength(self) -> int:
+        """The term this test's type contributes to its strength.
+
+        libmagic grows the term with how much of the file the type inspects, so a wider integer or
+        a longer string outranks a narrower one (``file/src/apprentice.c:930-1030``). The types
+        that only dispatch another test — ``indirect``, ``name``, ``use``, and ``clear`` — add
+        nothing.
+
+        Returns:
+            The number to add to the baseline strength.
+        """
+        return 0
+
+    def relation(self) -> str:
+        """The relational operator libmagic parsed for this test.
+
+        Every type takes an operator from the head of its value, defaulting to ``=`` when the value
+        names none (``file/src/apprentice.c:2366-2401``).
+
+        Returns:
+            One of ``=``, ``<``, ``>``, ``&``, ``^``, ``!``, or ``x``.
+        """
+        return "="
+
     def base_strength(self) -> int:
-        """Computes the base strength value before applying !:strength modifier."""
-        return 20
+        """Computes the base strength value before applying !:strength modifier.
+
+        This is libmagic's ``apprentice_magic_strength_1``
+        (``file/src/apprentice.c:925-1058``): a fixed baseline plus a term for the type, then
+        adjusted by the relational operator. A relation that matches anything discards both terms.
+
+        Returns:
+            The strength before the ``!:strength`` factor, the clamp, and the description bonus.
+        """
+        rel = self.relation()
+        if rel in UNSELECTIVE_RELATIONS:
+            return 0
+        return STRENGTH_BASELINE + self.type_strength() + RELATION_STRENGTH[rel]
 
     def compute_strength(self) -> int:
-        """Computes the test strength for sorting, mimicking libmagic's algorithm."""
+        """Computes the test strength for sorting, mimicking libmagic's algorithm.
+
+        This is libmagic's ``file_magic_strength`` (``file/src/apprentice.c:1064-1120``): the base
+        strength, then the ``!:strength`` factor, then a clamp to a positive value, and finally a
+        bonus for a test with no description, which depends on its children to print anything.
+
+        A description made only of blanks counts as absent, because libmagic skips the blanks
+        between the value and the description before it copies what remains
+        (``file/src/apprentice.c:2425-2436``).
+
+        Returns:
+            The sort key libmagic would use for this test.
+        """
         val = self.base_strength()
         if self.strength_op == StrengthOp.PLUS:
             val += self.strength_factor
@@ -875,6 +945,10 @@ class MagicTest(ABC):
             val *= self.strength_factor
         elif self.strength_op == StrengthOp.DIV and self.strength_factor != 0:
             val //= self.strength_factor
+        if val <= 0:
+            val = 1
+        if not str(self.message).strip():
+            val += 1
         return val
 
     @property
@@ -1200,6 +1274,29 @@ class DataType(ABC, Generic[T]):
     def allows_invalid_offsets(self, expected: T) -> bool:
         return False
 
+    def strength_term(self, expected: T) -> int:
+        """The term this type contributes to a test's strength.
+
+        Args:
+            expected: The value the test compares against, which sizes the term for the types
+                whose values vary in length.
+
+        Returns:
+            The number to add to the baseline strength.
+        """
+        return 0
+
+    def relation(self, expected: T) -> str:
+        """The relational operator that `expected` carried in the definition.
+
+        Args:
+            expected: The parsed value, which records the operator it was declared with.
+
+        Returns:
+            One of ``=``, ``<``, ``>``, ``&``, ``^``, ``!``, or ``x``.
+        """
+        return "="
+
     @abstractmethod
     def is_text(self, value: T) -> bool:
         raise NotImplementedError()
@@ -1277,6 +1374,13 @@ class GUIDType(DataType[Union[UUID, UUIDWildcard]]):
     def is_text(self, value: Union[UUID, UUIDWildcard]) -> bool:
         return False
 
+    def strength_term(self, expected: Union[UUID, UUIDWildcard]) -> int:
+        """A GUID is sized like the sixteen-byte integer it is (``file/src/apprentice.c:912-915``)."""
+        return 16 * STRENGTH_MULT
+
+    def relation(self, expected: Union[UUID, UUIDWildcard]) -> str:
+        return "x" if isinstance(expected, UUIDWildcard) else "="
+
     def parse_expected(self, specification: str) -> Union[UUID, UUIDWildcard]:
         if specification.strip() == "x":
             return UUIDWildcard()
@@ -1315,6 +1419,15 @@ class UTF16Type(DataType[bytes]):
     def is_text(self, value: bytes) -> bool:
         return True
 
+    def strength_term(self, expected: bytes) -> int:
+        """Half of what the same value would score as a `string` (``file/src/apprentice.c:1003``).
+
+        libmagic stores a sixteen-bit string's value as the bytes the definition spelled and widens
+        it only when matching, so its ``vallen`` counts characters, not the code units PolyFile
+        holds here.
+        """
+        return len(expected) // 2 * STRENGTH_MULT // 2
+
     def parse_expected(self, specification: str) -> bytes:
         specification = unescape(specification).decode("utf-8")
         if self.endianness == Endianness.LITTLE:
@@ -1339,6 +1452,27 @@ class StringTest(ABC):
         self.trim: bool = trim
         self.compact_whitespace: bool = compact_whitespace
         self.num_bytes: Optional[int] = num_bytes
+
+    @property
+    def value_length(self) -> int:
+        """The number of unescaped bytes in this test's value, libmagic's ``m->vallen``.
+
+        libmagic reads no value at all for the ``x`` relation, so a wildcard has none
+        (``file/src/apprentice.c:2409``).
+
+        Returns:
+            The length that sizes this test's strength term.
+        """
+        return 0
+
+    @property
+    def relation(self) -> str:
+        """The relational operator this test was declared with.
+
+        Returns:
+            One of ``=``, ``<``, ``>``, ``!``, or ``x``.
+        """
+        return "x"
 
     def post_process(self, data: bytes, initial_offset: int = 0) -> DataTypeMatch:
         value = data
@@ -1461,6 +1595,14 @@ class NegatedStringTest(StringWildcard):
         super().__init__(trim=parent_test.trim, compact_whitespace=parent_test.compact_whitespace)
         self.parent: StringTest = parent_test
 
+    @property
+    def value_length(self) -> int:
+        return self.parent.value_length
+
+    @property
+    def relation(self) -> str:
+        return "!"
+
     def is_always_text(self) -> bool:
         return self.parent.is_always_text()
 
@@ -1488,11 +1630,21 @@ class StringLengthTest(StringWildcard):
         super().__init__(trim=trim, compact_whitespace=compact_whitespace, num_bytes=num_bytes)
         self.raw_pattern: str = to_match
         self.to_match: bytes = unescape(to_match)
+        self._value_length: int = len(self.to_match)
         null_termination_index = self.to_match.find(0)
         if null_termination_index >= 0:
             self.to_match = self.to_match[:null_termination_index]
         self.desired_length: int = len(self.to_match)
         self.test_smaller: bool = test_smaller
+
+    @property
+    def value_length(self) -> int:
+        """The declared length, which libmagic counts past an embedded null byte."""
+        return self._value_length
+
+    @property
+    def relation(self) -> str:
+        return "<" if self.test_smaller else ">"
 
     def matches(self, data: bytes) -> DataTypeMatch:
         match = super().matches(data)
@@ -1546,6 +1698,14 @@ class StringMatch(StringTest):
         self._is_always_text: Optional[bool] = None
         self._pattern: Optional[re.Pattern] = None
         _ = self.pattern
+
+    @property
+    def value_length(self) -> int:
+        return len(self.string)
+
+    @property
+    def relation(self) -> str:
+        return "="
 
     def pattern_string(self) -> bytes:
         """Builds the regular expression that implements this test's string flags.
@@ -1687,6 +1847,16 @@ class StringType(DataType[StringTest]):
     def is_text(self, value: StringTest) -> bool:
         return self.force_text
 
+    def strength_term(self, expected: StringTest) -> int:
+        """One unit per byte of the value, the dominant term for most definitions.
+
+        See ``file/src/apprentice.c:998-1000``.
+        """
+        return expected.value_length * STRENGTH_MULT
+
+    def relation(self, expected: StringTest) -> str:
+        return expected.relation
+
     def allows_invalid_offsets(self, expected: StringTest) -> bool:
         return isinstance(expected, NegatedStringTest)
 
@@ -1784,6 +1954,18 @@ class SearchType(StringType):
     def is_text(self, value: StringTest) -> bool:
         return value.is_always_text()
 
+    def strength_term(self, expected: StringTest) -> int:
+        """Far less than a `string` of the same length, because a search roams the buffer.
+
+        libmagic caps the per-byte credit so the whole term never exceeds one unit's worth for a
+        value of two bytes or more (``file/src/apprentice.c:1008-1012``): ``vallen * max(MULT //
+        vallen, 1)`` is ``MULT`` for a one-byte value and ``vallen`` beyond that.
+        """
+        vallen = expected.value_length
+        if vallen == 0:
+            return 0
+        return vallen * max(STRENGTH_MULT // vallen, 1)
+
     def match(self, data: bytes, expected: StringTest) -> DataTypeMatch:
         return expected.search(data)
 
@@ -1879,6 +2061,17 @@ class PascalStringType(DataType[StringTest]):
         # TODO: See if Pascal strings should sometimes be forced to be text
         return False
 
+    def strength_term(self, expected: StringTest) -> int:
+        """Scored like a `string`, counting the length prefix as part of the value.
+
+        ``getstr`` folds ``file_pstring_length_size`` into ``m->vallen`` for a ``pstring``
+        (``file/src/apprentice.c:3181-3188``), so the prefix widens the term.
+        """
+        return (expected.value_length + self.byte_length) * STRENGTH_MULT
+
+    def relation(self, expected: StringTest) -> str:
+        return expected.relation
+
     def parse_expected(self, specification: str) -> StringTest:
         return self.string_type.parse_expected(specification)
 
@@ -1964,7 +2157,82 @@ def posix_to_python_re(match: bytes) -> bytes:
     return match
 
 
-class RegexType(DataType[Pattern[bytes]]):
+def nonmagic(pattern: bytes) -> int:
+    """Counts the literal characters of a regular expression, libmagic's ``nonmagic``.
+
+    Metacharacters describe how to match rather than what to match, so they earn no strength
+    (``file/src/apprentice.c:813-849``). A bracketed class counts one, for its closing bracket; a
+    braced repetition counts nothing; an escape counts one, whatever it escapes.
+
+    Note that libmagic applies this to the *unescaped* value, so a pattern written ``\\.`` arrives
+    here as a bare ``.`` and counts zero, which is why libmagic warns to write ``\\\\.`` instead.
+    For the same reason an escaped null byte ends the count, because libmagic walks the value as a
+    C string.
+
+    Args:
+        pattern: The unescaped pattern bytes.
+
+    Returns:
+        The number of literal characters, at least one.
+    """
+    count = 0
+    i = 0
+    terminator = pattern.find(b"\0")
+    if terminator >= 0:
+        pattern = pattern[:terminator]
+    while i < len(pattern):
+        char = pattern[i:i + 1]
+        if char == b"\\":
+            i += 2 if i + 1 < len(pattern) else 1
+            count += 1
+        elif char in (b"?", b"*", b".", b"+", b"^", b"$"):
+            i += 1
+        elif char == b"[":
+            closing = pattern.find(b"]", i)
+            i = len(pattern) if closing < 0 else closing
+        elif char == b"{":
+            closing = pattern.find(b"}", i)
+            i = len(pattern) if closing < 0 else closing + 1
+        else:
+            i += 1
+            count += 1
+    return max(count, 1)
+
+
+class MagicRegex:
+    """A definition's regular expression, alongside the literal count libmagic scores it by.
+
+    libmagic counts literals on the value as its own unescaping left it
+    (``file/src/apprentice.c:1015``), which is before PolyFile rewrites POSIX character classes
+    into their Python equivalents. The rewrite drops the inner ``:]`` that ends libmagic's bracket
+    scan, so the count is one lower per class unless it is taken first.
+    """
+
+    def __init__(self, specification: bytes, flags: int = 0):
+        """Compiles `specification`, counting its literals before the POSIX rewrite.
+
+        Args:
+            specification: The unescaped pattern, as libmagic would hold it.
+            flags: The regular expression flags to compile with.
+
+        Raises:
+            re.error: If `specification` is not a valid regular expression.
+        """
+        self.literal_count: int = nonmagic(specification)
+        self.pattern: bytes = posix_to_python_re(specification)
+        self.compiled: Pattern[bytes] = re.compile(self.pattern, flags)
+
+    def search(self, data: bytes) -> Optional["re.Match[bytes]"]:
+        return self.compiled.search(data)
+
+    def match(self, data: bytes) -> Optional["re.Match[bytes]"]:
+        return self.compiled.match(data)
+
+    def __str__(self):
+        return self.pattern.decode("utf-8", errors="replace")
+
+
+class RegexType(DataType[MagicRegex]):
     def __init__(
             self,
             length: Optional[int] = None,
@@ -1988,27 +2256,31 @@ class RegexType(DataType[Pattern[bytes]]):
 
     DOLLAR_PATTERN = re.compile(rb"(^|[^\\])\$", re.MULTILINE)
 
-    def is_text(self, value: Pattern[bytes]) -> bool:
+    def is_text(self, value: MagicRegex) -> bool:
         try:
             _ = value.pattern.decode("ascii")
             return True
         except UnicodeDecodeError:
             return False
 
-    def parse_expected(self, specification: str) -> Pattern[bytes]:
+    def strength_term(self, expected: MagicRegex) -> int:
+        """One unit per literal character, capped the way a `search` is.
+
+        See ``file/src/apprentice.c:1014-1017``.
+        """
+        literals = expected.literal_count
+        return literals * max(STRENGTH_MULT // literals, 1)
+
+    def parse_expected(self, specification: str) -> MagicRegex:
         if specification.startswith("="):
             # libmagic parses a leading `=` as the equality operator, not as part of the pattern
             # (`file/src/apprentice.c:2383-2384`)
             specification = specification[1:]
-        # handle POSIX-style character classes:
-        unescaped_spec = posix_to_python_re(unescape(specification))
-        # convert '$' to '[\r$]'
-        # unescaped_spec = self.__class__.DOLLAR_PATTERN.sub(rb"[\r$]", unescaped_spec)
+        flags = re.MULTILINE
+        if self.case_insensitive:
+            flags |= re.IGNORECASE
         try:
-            if self.case_insensitive:
-                return re.compile(unescaped_spec, re.IGNORECASE | re.MULTILINE)
-            else:
-                return re.compile(unescaped_spec, re.MULTILINE)
+            return MagicRegex(unescape(specification), flags)
         except re.error as e:
             raise ValueError(str(e))
 
@@ -2040,7 +2312,7 @@ class RegexType(DataType[Pattern[bytes]]):
             return DataTypeMatch(raw_match, value, initial_offset=start, relative_base=start)
         return DataTypeMatch(raw_match, value, initial_offset=start)
 
-    def match(self, data: bytes, expected: Pattern[bytes]) -> DataTypeMatch:
+    def match(self, data: bytes, expected: MagicRegex) -> DataTypeMatch:
         if not self.limit_lines:
             m = expected.search(data[:self.length])
             if m is None:
@@ -2299,6 +2571,15 @@ class NumericDataType(DataType[NumericValue]):
     def is_text(self, value: NumericValue) -> bool:
         return False
 
+    def strength_term(self, expected: NumericValue) -> int:
+        """One unit per byte the type reads (``file/src/apprentice.c:975-996``)."""
+        return self.base_type.num_bytes * STRENGTH_MULT
+
+    def relation(self, expected: NumericValue) -> str:
+        if isinstance(expected, NumericWildcard):
+            return "x"
+        return expected.operator.symbol
+
     def parse_expected(self, specification: str) -> NumericValue:
         if specification.strip() == "x":
             return NumericWildcard()
@@ -2412,6 +2693,12 @@ class ConstantMatchTest(MagicTest, Generic[T]):
         self.data_type: DataType[T] = data_type
         self.constant: T = constant
 
+    def type_strength(self) -> int:
+        return self.data_type.strength_term(self.constant)
+
+    def relation(self) -> str:
+        return self.data_type.relation(self.constant)
+
     def subtest_type(self) -> TestType:
         if self.data_type.is_text(self.constant):
             return TestType.TEXT
@@ -2504,6 +2791,15 @@ class OffsetMatchTest(MagicTest):
         self.value: IntegerValue = value
         self.subtraction: int = subtraction
         self.modulo: int = modulo
+
+    def type_strength(self) -> int:
+        """``offset`` is an eight-byte quantity (``file/src/apprentice.c:906-908``)."""
+        return 8 * STRENGTH_MULT
+
+    def relation(self) -> str:
+        if isinstance(self.value, NumericWildcard):
+            return "x"
+        return self.value.operator.symbol
 
     def subtest_type(self) -> TestType:
         return TestType.UNKNOWN
@@ -2880,6 +3176,14 @@ class DefaultTest(MagicTest):
     def subtest_type(self) -> TestType:
         return TestType.UNKNOWN
 
+    def base_strength(self) -> int:
+        """Zero, so that a `default` sorts last (``file/src/apprentice.c:932-938``).
+
+        libmagic returns before reaching the relation term here, and its own clamp then raises the
+        zero to one, so a `default` is the weakest test rather than a strengthless one.
+        """
+        return 0
+
     def test(self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]) -> TestResult:
         if parent_match is None or not parent_match.child_matched:
             return MatchedTest(self, offset=absolute_offset, length=0, value=True, parent=parent_match)
@@ -2896,6 +3200,10 @@ class DefaultTest(MagicTest):
 class ClearTest(MagicTest):
     def subtest_type(self) -> TestType:
         return TestType.UNKNOWN
+
+    def relation(self) -> str:
+        """``clear`` takes no value, so libmagic parses it as the ``x`` relation."""
+        return "x"
 
     def test(self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]) -> MatchedTest:
         if parent_match is None:
@@ -2926,6 +3234,10 @@ class DERTest(MagicTest):
         super().__init__(offset=offset, mime=mime, extensions=extensions, message=message,
                          parent=parent, comments=comments)
         self.specification: DERSpecification = specification
+
+    def type_strength(self) -> int:
+        """One flat unit, whatever the specification says (``file/src/apprentice.c:1024-1026``)."""
+        return STRENGTH_MULT
 
     def subtest_type(self) -> TestType:
         return TestType.BINARY

--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -3582,6 +3582,44 @@ class MagicMatcher:
         test.source_info = SourceInfo(def_file, line_number, line)
         return test
 
+    STRENGTH_OPS: Dict[str, StrengthOp] = {
+        "+": StrengthOp.PLUS,
+        "-": StrengthOp.MINUS,
+        "*": StrengthOp.TIMES,
+        "/": StrengthOp.DIV,
+    }
+
+    @staticmethod
+    def parse_strength(specification: bytes, current_test: MagicTest):
+        """Records a ``!:strength`` factor on the entry that the directive applies to.
+
+        libmagic assigns the factor to ``me->mp[0]``, the level-0 test of the entry, whatever depth
+        the directive appears at, and keeps the first factor an entry declares
+        (``file/src/apprentice.c:2470-2497``). A ``name`` entry rejects the directive outright.
+
+        Args:
+            specification: The rest of the line after ``!:strength``.
+            current_test: The most recently parsed test, which locates the entry.
+        """
+        entry = current_test
+        while entry.parent is not None:
+            entry = entry.parent
+        if isinstance(entry, NamedTest) or entry.strength_op != StrengthOp.NONE:
+            return
+        spec = specification.strip().decode("utf-8")
+        if not spec:
+            return
+        op = MagicMatcher.STRENGTH_OPS.get(spec[0])
+        if op is None:
+            factor_str, op = spec, StrengthOp.PLUS
+        else:
+            factor_str = spec[1:].strip()
+        try:
+            entry.strength_factor = int(factor_str)
+        except ValueError:
+            return
+        entry.strength_op = op
+
     @staticmethod
     def _parse_file(
             def_file: Union[str, Path], matcher: "MagicMatcher"
@@ -3614,25 +3652,7 @@ class MagicMatcher:
                     continue
                 elif raw_line.startswith(b"!:strength"):
                     if current_test is not None:
-                        strength_spec = raw_line[10:].strip().decode("utf-8")
-                        if strength_spec:
-                            op = strength_spec[0]
-                            factor_str = strength_spec[1:].strip()
-                            if op == '+':
-                                current_test.strength_op = StrengthOp.PLUS
-                            elif op == '-':
-                                current_test.strength_op = StrengthOp.MINUS
-                            elif op == '*':
-                                current_test.strength_op = StrengthOp.TIMES
-                            elif op == '/':
-                                current_test.strength_op = StrengthOp.DIV
-                            else:
-                                factor_str = strength_spec
-                                current_test.strength_op = StrengthOp.PLUS
-                            try:
-                                current_test.strength_factor = int(factor_str)
-                            except ValueError:
-                                pass
+                        MagicMatcher.parse_strength(raw_line[10:], current_test)
                     continue
                 try:
                     line = raw_line.decode("utf-8")

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1008,3 +1008,222 @@ class UseTestSemanticsTest(TestCase):
         for match in MagicMatcher.DEFAULT_INSTANCE.match(testfile.read_bytes()):
             self.assertNotIn("EFI variable", str(match))
             self.assertNotIn("total size", str(match))
+
+
+class TestStrengthTest(TestCase):
+    """Regression tests for the strength computation reported in issue #3477.
+
+    `MagicTest.base_strength` used to return a constant 20, so 96% of the shipped tests tied and
+    the sort that orders them by specificity had almost no key to work with. Each test here pins
+    one term of libmagic's `apprentice_magic_strength_1` and `file_magic_strength`
+    (`file/src/apprentice.c:925-1120`), checked against what `file -l` prints.
+    """
+
+    @staticmethod
+    def only_test(definition: str) -> polyfile.magic.MagicTest:
+        """Parses `definition` and returns its single level-0 test.
+
+        Args:
+            definition: The text of a magic definition file, with tab-separated columns.
+
+        Returns:
+            The one test the definition declares at level 0.
+        """
+        with TemporaryDirectory() as tmp_dir:
+            magic_file = Path(tmp_dir) / "test.magic"
+            magic_file.write_text(definition)
+            matcher = MagicMatcher.parse(magic_file)
+            tests = matcher.text_tests | matcher.non_text_tests
+        assert len(tests) == 1, f"expected one test, got {len(tests)}"
+        return next(iter(tests))
+
+    def strength(self, definition: str) -> int:
+        """The strength of the single level-0 test that `definition` declares."""
+        return self.only_test(definition).compute_strength()
+
+    def test_numeric_types_score_by_their_width(self):
+        """Every test scored 20, so a `bequad` sorted level with a `byte`.
+
+        libmagic adds `typesize(type) * MULT` for a numeric, date, or GUID type
+        (`file/src/apprentice.c:975-996`), on top of the 20 baseline and the 10 an `=` earns. The
+        expected values are what `file -l` reports for these definitions.
+        """
+        for data_type, expected in (
+                ("byte", 40), ("leshort", 50), ("lelong", 70), ("lequad", 110),
+                ("float", 70), ("double", 110), ("date", 70), ("qdate", 110),
+                ("msdosdate", 50), ("msdostime", 50),
+        ):
+            self.assertEqual(expected, self.strength(f"0\t{data_type}\t1\tdesc\n"), data_type)
+
+    def test_guid_scores_as_sixteen_bytes(self):
+        """A `guid` is the widest type libmagic sizes, at 16 bytes."""
+        self.assertEqual(
+            190, self.strength("0\tguid\t00000000-0000-0000-0000-000000000000\tdesc\n"))
+
+    def test_der_scores_one_flat_unit(self):
+        """`der` adds a single unit whatever its specification (`file/src/apprentice.c:1024`)."""
+        self.assertEqual(40, self.strength("0\tder\tseq\tdesc\n"))
+
+    def test_string_scores_one_unit_per_byte(self):
+        """A constant 20 made a one-byte `string` as strong as an eight-byte one.
+
+        libmagic adds `vallen * MULT`, counting the value after unescaping
+        (`file/src/apprentice.c:998-1000`), which is the dominant term for most definitions.
+        """
+        self.assertEqual(40, self.strength("0\tstring\tA\tdesc\n"))
+        self.assertEqual(110, self.strength("0\tstring\tbplist00\tdesc\n"))
+        self.assertEqual(70, self.strength("0\tstring\t\\x02\\x01\\x13\\x13\tdesc\n"))
+
+    def test_pstring_counts_its_length_prefix(self):
+        """`getstr` folds the prefix width into `vallen` (`file/src/apprentice.c:3181-3188`)."""
+        self.assertEqual(80, self.strength("0\tpstring\tabcd\tdesc\n"))
+        self.assertEqual(90, self.strength("0\tpstring/H\tabcd\tdesc\n"))
+        self.assertEqual(110, self.strength("0\tpstring/l\tabcd\tdesc\n"))
+
+    def test_string16_scores_half_of_a_string(self):
+        """libmagic halves the term for a sixteen-bit string (`file/src/apprentice.c:1003`)."""
+        self.assertEqual(50, self.strength("0\tlestring16\tabcd\tdesc\n"))
+
+    def test_search_credits_at_most_one_unit_per_value(self):
+        """A `search` roams the buffer, so libmagic caps its credit.
+
+        `vallen * MAX(MULT / vallen, 1)` (`file/src/apprentice.c:1008-1012`) is a full unit for a
+        one-byte value and then flattens to one point per byte, which is why an eight-byte
+        `search` scores 38 where the same `string` scores 110.
+        """
+        self.assertEqual(40, self.strength("0\tsearch/8192\tA\tdesc\n"))
+        self.assertEqual(40, self.strength("0\tsearch/8192\tAB\tdesc\n"))
+        self.assertEqual(38, self.strength("0\tsearch/8192\t#include\tdesc\n"))
+        self.assertEqual(43, self.strength("0\tsearch/512\t@opaque(lang=\tdesc\n"))
+
+    def test_search_range_does_not_change_its_strength(self):
+        """The `search/N` range is not part of the term, contrary to a plausible reading of it."""
+        for repetitions in ("1", "100", "8192"):
+            self.assertEqual(38, self.strength(f"0\tsearch/{repetitions}\t#include\tdesc\n"))
+
+    def test_regex_counts_only_its_literal_characters(self):
+        """A regular expression earns nothing for its metacharacters.
+
+        `nonmagic` (`file/src/apprentice.c:813-849`) counts escapes and literals but not `?*.+^$`,
+        counts a bracketed class as the one closing bracket, and a braced repetition as nothing.
+        The term is then capped the way a `search`'s is.
+        """
+        self.assertEqual(39, self.strength("0\tregex\tabc.*\tdesc\n"))
+        self.assertEqual(38, self.strength("0\tregex\tabcd\\ efg\tdesc\n"))
+        self.assertEqual(40, self.strength("0\tregex\t\\^[a-z]+\tdesc\n"))
+
+    def test_regex_literals_are_counted_before_the_posix_rewrite(self):
+        """PolyFile rewrites POSIX classes to Python ones, which used to lose a literal each.
+
+        libmagic scans `[[:space:]]` and stops its bracket scan at the inner `:]`, so the trailing
+        `]` counts as a second literal; the rewritten `[ \\t\\n\\r\\f\\v]` offers only one. Thirteen
+        shipped definitions differed by up to four points before the count moved ahead of the
+        rewrite. `file -l` reports 36 for the `clojure` entry below.
+        """
+        self.assertEqual(36, self.strength(
+            "0\tregex\t\\^\\\\\\(ns[[:space:]]+[a-z]\tClojure module source text\n"))
+        self.assertEqual(41, self.strength(
+            "0\tregex/4006\t\\^PROC[[:space:]][a-zA-Z0-9_[:space:]]*[[:space:]]=\tdesc\n"))
+
+    def test_regex_literal_count_ends_at_an_escaped_null(self):
+        """`nonmagic` walks a C string, so a `\\000` in the value ends the count.
+
+        `magic_defs/cad:317` is the shipped case: everything after its `\\000` is invisible to
+        libmagic's count, which is why `file -l` reports 40 rather than 39.
+        """
+        self.assertEqual(40, self.strength("0\tregex\t\\^[\\ \\t]*0\\r?\\000$\n"))
+        self.assertEqual(self.strength("0\tregex\tab\\000cdefgh\tdesc\n"),
+                         self.strength("0\tregex\tab\tdesc\n"))
+
+    def test_regex_escaped_dot_counts_nothing(self):
+        """libmagic unescapes before counting, so `\\.` arrives as a bare `.` and scores zero.
+
+        This is what its "escaped dot found, use \\\\. instead" warning is about.
+        """
+        self.assertEqual(self.strength("0\tregex\tab.\tdesc\n"),
+                         self.strength("0\tregex\tab\\.\tdesc\n"))
+
+    def test_relational_operators_adjust_the_strength(self):
+        """Every relation scored the same 20, so a wildcard tied with an exact match.
+
+        libmagic prefers an exact match by a unit, penalizes an inequality by two, penalizes a bit
+        mask by one, and zeroes anything matching (almost) everything
+        (`file/src/apprentice.c:1034-1051`). A zero is then clamped up to one.
+        """
+        self.assertEqual(50, self.strength("0\tleshort\t=1\tdesc\n"))
+        self.assertEqual(20, self.strength("0\tleshort\t>1\tdesc\n"))
+        self.assertEqual(20, self.strength("0\tleshort\t<1\tdesc\n"))
+        self.assertEqual(30, self.strength("0\tleshort\t&1\tdesc\n"))
+        self.assertEqual(30, self.strength("0\tleshort\t^1\tdesc\n"))
+        self.assertEqual(1, self.strength("0\tleshort\t!1\tdesc\n"))
+        self.assertEqual(1, self.strength("0\tleshort\tx\tdesc\n"))
+
+    def test_string_relations_adjust_the_strength(self):
+        """The string family carries its relation in the parsed value, not in a numeric operator."""
+        self.assertEqual(70, self.strength("0\tstring\t=abcd\tdesc\n"))
+        self.assertEqual(40, self.strength("0\tstring\t>abcd\tdesc\n"))
+        self.assertEqual(40, self.strength("0\tstring\t<abcd\tdesc\n"))
+        self.assertEqual(1, self.strength("0\tstring\t!abcd\tdesc\n"))
+        self.assertEqual(1, self.strength("0\tstring\tx\tdesc\n"))
+
+    def test_undescribed_test_gains_a_point(self):
+        """A test with no description depends on its children to print, so libmagic favors it.
+
+        See `file/src/apprentice.c:1111-1117`. A description of nothing but blanks counts as
+        absent, because libmagic skips them before copying what remains.
+        """
+        self.assertEqual(70, self.strength("0\tstring\tabcd\tdesc\n"))
+        self.assertEqual(71, self.strength("0\tstring\tabcd\n"))
+        self.assertEqual(71, self.strength("0\tstring\tabcd\t\t\n"))
+
+    def test_strength_modifier_applies_on_top_of_the_computed_value(self):
+        """`!:strength` used to be the only thing that moved a strength off 20.
+
+        libmagic applies the factor after the type and relation terms
+        (`file/src/apprentice.c:1085-1105`), and clamps the result to at least one.
+        """
+        self.assertEqual(70, self.strength("0\tstring\tabcd\tdesc\n"))
+        self.assertEqual(85, self.strength("0\tstring\tabcd\tdesc\n!:strength + 15\n"))
+        self.assertEqual(60, self.strength("0\tstring\tabcd\tdesc\n!:strength -10\n"))
+        self.assertEqual(140, self.strength("0\tstring\tabcd\tdesc\n!:strength *2\n"))
+        self.assertEqual(23, self.strength("0\tstring\tabcd\tdesc\n!:strength / 3\n"))
+        self.assertEqual(1, self.strength("0\tstring\tabcd\tdesc\n!:strength -200\n"))
+
+    def test_strength_modifier_applies_to_the_entry_not_the_last_test(self):
+        """A `!:strength` under a continuation line used to score the continuation instead.
+
+        libmagic always assigns the factor to `me->mp[0]`, the level-0 test of the entry, whatever
+        depth the directive appears at (`file/src/apprentice.c:2470-2478`). 55 shipped entries put
+        the directive after at least one continuation, `varied.script:8` among them, where `file
+        -l` reports 20 for a term that would otherwise be 60.
+        """
+        definition = "0\tstring/wt\t#!\\ \ta\n>&-1\tstring/T\tx\t%s script text executable\n!:strength / 3\n"
+        self.assertEqual(20, self.strength(definition))
+
+    def test_multiple_magic_sidecars_match_libmagic(self):
+        """`file/tests/multiple.testfile` needs its four matches in descending strength order.
+
+        `file -l` reports 40, 40, 38, 38 for these four `search` tests. The stem stays in
+        `KNOWN_FAILURES` for unrelated reasons, so this pins the strengths on their own.
+        """
+        strengths = []
+        for sidecar in ("multiple-A.magic", "multiple-B.magic"):
+            path = FILE_TEST_DIR / sidecar
+            self.assertTrue(path.exists(), "Make sure to run `git submodule init && git submodule update`")
+            matcher = MagicMatcher.parse(path)
+            tests = matcher.text_tests | matcher.non_text_tests
+            strengths.extend(sorted((t.compute_strength() for t in tests), reverse=True))
+        self.assertEqual([40, 40, 38, 38], strengths)
+
+    def test_shipped_definitions_span_libmagic_s_range_of_strengths(self):
+        """96.5% of the shipped tests used to score exactly 20, over just 29 distinct values.
+
+        `file -l` reports 133 distinct strengths over the same definitions, from 2 to 670. This
+        asserts the distribution stays in that neighborhood, so a regression to a near-constant
+        key is caught even if every individual term still looks right.
+        """
+        tests = MagicMatcher.DEFAULT_INSTANCE.text_tests | MagicMatcher.DEFAULT_INSTANCE.non_text_tests
+        strengths = [test.compute_strength() for test in tests]
+        self.assertGreater(len(set(strengths)), 120)
+        self.assertGreater(max(strengths), 600)
+        self.assertLess(sum(1 for s in strengths if s == 20) / len(strengths), 0.05)


### PR DESCRIPTION
Closes #3477

`MagicTest.base_strength` returned a constant 20 for every test, and no subclass overrode it, so
3732 of the 3868 shipped level-0 tests tied at that one value and only 29 distinct strengths
existed. This ports the rest of libmagic's algorithm and pins it against libmagic's own numbers.

## What was ported

From `apprentice_magic_strength_1` and `file_magic_strength` in `file/src/apprentice.c:925-1120`,
with `MULT == 10`:

| Step | Source | Where it lives now |
| --- | --- | --- |
| Baseline `2 * MULT` | `apprentice.c:929` | `STRENGTH_BASELINE` |
| Numeric, date, GUID, `offset`, MS-DOS date and time: `typesize(type) * MULT` | `apprentice.c:944-996`, `typesize` at `:853-920` | `NumericDataType.strength_term`, `GUIDType.strength_term`, `OffsetMatchTest.type_strength` |
| `string`, `pstring`, `octal`: `vallen * MULT` | `apprentice.c:998-1000` | `StringType.strength_term`, `PascalStringType.strength_term` |
| `bestring16`, `lestring16`: `vallen * MULT / 2` | `apprentice.c:1002-1005` | `UTF16Type.strength_term` |
| `search`: `vallen * MAX(MULT / vallen, 1)` | `apprentice.c:1007-1012` | `SearchType.strength_term` |
| `regex`: `nonmagic(value) * MAX(MULT / v, 1)` | `apprentice.c:1014-1017`, `nonmagic` at `:813-849` | `nonmagic`, `RegexType.strength_term` |
| `der`: `+ MULT` | `apprentice.c:1024-1026` | `DERTest.type_strength` |
| `indirect`, `name`, `use`, `clear`: no term | `apprentice.c:1019-1022` | the `MagicTest.type_strength` default of 0 |
| `default`: return 0 before the relation term | `apprentice.c:932-938` | `DefaultTest.base_strength` |
| Relation: `=` `+MULT`, `<`/`>` `-2*MULT`, `&`/`^` `-MULT`, `x`/`!` set to 0 | `apprentice.c:1034-1051` | `RELATION_STRENGTH`, `UNSELECTIVE_RELATIONS`, `DataType.relation` |
| `!:strength` factor, applied after the above | `apprentice.c:1085-1105` | `MagicTest.compute_strength`, which already did this |
| `if (val <= 0) val = 1` | `apprentice.c:1107-1108` | `MagicTest.compute_strength` |
| `if (m->desc[0] == '\0') val++` | `apprentice.c:1110-1117` | `MagicTest.compute_strength` |

The type term is dispatched through a new `DataType.strength_term` hook rather than a chain of
`elif`s, because `ConstantMatchTest` serves every data type. The relation comes from the parsed
value, which already records the operator it was declared with, through a matching
`DataType.relation` hook.

`nonmagic` runs on the value as libmagic's own unescaping leaves it. PolyFile rewrites POSIX
character classes into Python ones when it compiles a pattern, and the rewrite drops the inner
`:]` that ends libmagic's bracket scan, costing a literal per class. `MagicRegex` therefore carries
the literal count taken *before* the rewrite. It keeps `.pattern`, `.search` and `.match`, so the
matcher and the existing regex tests are unchanged.

## Differential against `file -l`

`file -l` prints libmagic's own strength for every test, so it is an exact oracle. Running it once
per definition file attributes each strength to a `file:line`, which joins cleanly onto
`MagicTest.source_info`:

| | before | after |
| --- | --- | --- |
| Level-0 tests attributable to a `file -l` entry | 3865 | 3865 |
| **Agree with `file -l` exactly** | **2** | **3863** |
| Distinct strengths (libmagic: 133) | 29 | 132 |
| Tests at exactly 20 | 3732 | 2 |
| Range | -20 to 113 | 2 to 670 (libmagic: 2 to 670) |

Attribution is complete in both directions: no `file -l` entry lacks a PolyFile test. Three PolyFile
level-0 tests have no oracle counterpart, all expected — `magic_defs/json:6`, `magic_defs/json:12`
and `magic_defs/csv:6` use the PolyFile-specific `json`, `ndjson` and `csv` types, which libmagic
cannot load at all.

### The two that still differ

- `magic_defs/ctf:22` — 100 against the oracle's 105. Its `!:strength + 5` carries a trailing
  comment, which a bare `except ValueError: pass` drops. That is **#3476**, a separate one-line
  parse bug, deliberately not worked around here.
- `magic_defs/fortran:6` — 36 against the oracle's 2. `0 regex/100l !\^[^Cc\ \t].*$` declares the
  `!` relation, which libmagic reads as "the pattern must *not* match"
  (`file/src/softmagic.c:2376-2396` sets `v` to 1 on no-match, and `magiccheck`'s `!` case at
  `:2465-2466` inverts it). PolyFile compiles the `!` into the pattern instead, giving `!^...`, which can
  never match. Reading the relation without also negating the verdict would fix the strength while
  leaving the matching bug in place, so this needs its own change. Two shipped definitions declare a
  `!` on a `regex`: this one and `magic_defs/archive:1629`, a continuation.

## The `multiple` sidecars

`file -l` reports 40, 40, 38, 38 for the four `search` tests in `file/tests/multiple-A.magic` and
`multiple-B.magic`. PolyFile now computes the same four values, in the same order
(`test_multiple_magic_sidecars_match_libmagic`). The stem stays in `KNOWN_FAILURES`: it also needs
#3491 and #3488.

## Broad comparison against the oracle

109 files — every `file/tests/*.testfile` plus a mixed spread of source, binaries, archives and
plain text — compared before and after:

- **The set of matches PolyFile reports is byte-identical for all 109 files.** Strength affects
  ordering, never whether a test matches.
- The highest-strength match changed for 4 files, and in all four the new answer agrees with the
  oracle where the old one did not; agreement went from 68 to 72 of 109. Nothing moved the other
  way.

  | file | oracle | strongest before | strongest after |
  | --- | --- | --- | --- |
  | `JW07022A.mp3.testfile` | Audio file with ID3 version 2.2.0, contains: MPEG ADTS… | tar archive (old), type 'C' ID3… (20) | Audio file with ID3 version 2.2.0, contains: MPEG ADTS… (71) |
  | `gpkg-1-zst.testfile` | Gentoo GLEP 78 (GPKG) binary package… | POSIX tar archive, file inkscape-1.2.1-r2-1/gpkg-1… (20) | Gentoo GLEP 78 (GPKG) binary package… (81) |
  | `matilde.arm.testfile` | Adaptive Multi-Rate Codec (GSM telephony) | a AMR script text executable (20) | Adaptive Multi-Rate Codec (GSM telephony) (80) |
  | `file/magic/magic.mgc` | magic binary file for file(1) cmd (version 21) (little endian) | JavaScript source (40) | magic binary file for file(1) cmd (version 21) (little endian) (70) |

### One correction to the issue

The issue and #3477's description both assume the level-0 sort at `polyfile/magic.py:3710` decides
what PolyFile reports. It does not, today. `matcher.add` appends to a list in the sorted order, but
`_reassign_test_types` then redistributes those tests into `self._text_tests` and
`self._non_text_tests`, which are **`set`s**, and `MagicMatcher.match` iterates those sets. Yield
order is therefore set-hash order and varies between runs of the same binary on the same input —
verified by running the same comparison twice and diffing. `--format file` also prints *every*
distinct match, one per line, not just the strongest.

So this change makes `compute_strength` correct without yet changing what PolyFile names for a
polyglot; the four rows above are what a strength-ordered consumer would now pick. Making
`MagicMatcher.match` yield in descending strength order is the follow-up that turns this into
observable behaviour, and it is what `multiple` needs from #3491.

## Also fixed

A `!:strength` directive was recorded on the most recently parsed test, so one written after a
continuation line scored the continuation instead of the entry. libmagic's `parse_strength` always
assigns the factor to `me->mp[0]`, the entry's level-0 test, whatever depth the directive appears
at, and keeps the first factor an entry declares (`file/src/apprentice.c:2470-2497`). 53 of the 190
shipped directives sit under at least one continuation. This accounted for 49 of the 68 mismatches
that remained after the type and relation terms alone.

## Tests

19 new tests in `tests/test_magic.py::TestStrengthTest`, one per term, with every expected value
taken from `file -l` for the definition alongside it. Two cover the set as a whole: the four
`multiple*.magic` strengths, and an assertion that the shipped definitions keep more than 120
distinct strengths, so a regression to a near-constant key is caught even when each individual term
still looks right.

Each test was verified to fail against a targeted mutation of the term it names — 19 mutations
applied one at a time (drop each type term, uncap `search` and `regex`, divide `search` by its
range, count regex literals after the POSIX rewrite, remove the null truncation, count `.` as a
literal, flatten the relation table, stop zeroing `x`/`!`, remove the clamp, remove the
undescribed-test bonus, ignore blank-only descriptions, ignore the `!:strength` factor, apply it to
the last test instead of the entry), each caught by the test that names it.

## Verification

```
corpus differential:  NEWLY PASSING (5): JW07022A.mp3, cmd3, cmd4, jsonlines1, pnm2
                      STILL FAILING (9): cmd1, cmd2, gedcom, jpeg-text, multiple, osm,
                                         pnm1, pnm3, utf16xmlsvg
                      REGRESSIONS   (0)
pytest tests:         1051 passed, 8 skipped, 372 subtests passed
                      (1032 + 19 new tests; baseline 1032 passed, 8 skipped, 372 subtests)
flake8 blocking:      0   (--select=E9,F63,F7,F82)
flake8 full:          233, unchanged from the branch point
```

The five `NEWLY PASSING` stems were already fixed on `master`; the harness's baseline set is the
original 14, so it reports them. `flake8` findings are unchanged per file as well: `polyfile/magic.py`
holds at 19 pre-existing findings and `tests/test_magic.py` at 0. The one difference is that
`MagicMatcher._parse_file`'s cyclomatic complexity drops from 29 to 22, since `!:strength` parsing
moved into its own method. It is still over the limit, as it was before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VS8hTTRQeG8ZCmCZ9KLHiV
