### PR TITLE
Append libmagic's text encoding description to a match

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -30,8 +30,6 @@ from typing import (
 )
 from uuid import UUID
 
-from chardet.universaldetector import UniversalDetector
-
 from .arithmetic import CStyleInt, make_c_style_int
 from .der import DERHeader, DERSpecification, InvalidDER, mime_type_for_message
 from .fileutils import Streamable
@@ -848,6 +846,24 @@ class MagicTest(ABC):
                             self._type = TestType.UNKNOWN
             delattr(self, "__calculating_test_type")
         return self._type
+
+    @property
+    def appends_text_encoding(self) -> bool:
+        """Whether libmagic appends its text-encoding description to this test's message.
+
+        The description comes from ``file_ascmagic``, which ``file_buffer`` reaches only after its
+        binary soft magic pass printed nothing, so it lands on whatever the ``TEXTTEST`` soft magic
+        pass printed (``src/funcs.c`` and ``src/ascmagic.c``). ``set_test_type`` in
+        ``src/apprentice.c`` decides which pass a definition runs in from the type and flags of its
+        level 0 test alone, and that is what `subtest_type` reports. `test_type`, which chooses the
+        pass PolyFile itself runs the test in, cannot answer this: it reports a group with any
+        binary subtest as binary, which is why libmagic describes the encoding of
+        ``file/tests/pnm1.testfile`` while PolyFile matches it in its binary pass.
+
+        Returns:
+            True if libmagic would append the description to this test's message.
+        """
+        return bool(self.subtest_type() & TestType.TEXT)
 
     @test_type.setter
     def test_type(self, value: TestType):
@@ -2821,6 +2837,19 @@ class JSONTest(MagicTest):
     def subtest_type(self) -> TestType:
         return TestType.TEXT
 
+    @property
+    def appends_text_encoding(self) -> bool:
+        """libmagic never appends its text-encoding description to a JSON verdict.
+
+        ``file_is_json`` runs ahead of soft magic in ``file_buffer`` and its match ends the run, so
+        ``file_ascmagic`` never sees it: `file` reports ``JSON text data``, not
+        ``JSON text data, ASCII text``.
+
+        Returns:
+            False.
+        """
+        return False
+
     def test_flip_endianness(
             self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]
     ) -> TestResult:
@@ -2870,6 +2899,18 @@ class CSVTest(MagicTest):
 
     def subtest_type(self) -> TestType:
         return TestType.TEXT
+
+    @property
+    def appends_text_encoding(self) -> bool:
+        """libmagic never appends its text-encoding description to a CSV verdict.
+
+        ``file_is_csv`` runs ahead of soft magic in ``file_buffer``, names the encoding itself, and
+        its match ends the run, so ``file_ascmagic`` never sees it.
+
+        Returns:
+            False.
+        """
+        return False
 
     def test_flip_endianness(
             self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]
@@ -3242,6 +3283,13 @@ class TextEncodingDescription:
 
 
 class PlainTextTest(MagicTest):
+    """Matches any buffer that libmagic would classify as text.
+
+    The test carries no message of its own. libmagic names the encoding in the description that
+    `TextEncodingDescription.describe` builds, which `MagicMatcher.match` attaches to the match
+    instead, so this test holds no per-match state and is safe to share across matches.
+    """
+
     AUTO_REGISTER_TEST = False
 
     def __init__(
@@ -3250,53 +3298,23 @@ class PlainTextTest(MagicTest):
             mime: Union[str, TernaryExecutableMessage] = "text/plain",
             extensions: Iterable[str] = ("txt",),
             parent: Optional["MagicTest"] = None,
-            comments: Iterable[Comment] = (),
-            minimum_encoding_confidence: float = 0.5
+            comments: Iterable[Comment] = ()
     ):
         super().__init__(offset, mime, extensions, "", parent, comments)
-        self.minimum_encoding_confidence: float = minimum_encoding_confidence
 
     def subtest_type(self) -> TestType:
         return TestType.TEXT
 
-    def encoding_name(self, data: bytes, fallback: str) -> str:
-        """Names the encoding of `data` for the human-readable match message.
-
-        Args:
-            data: the text whose encoding to name.
-            fallback: the name to use when chardet is not confident enough to name one itself.
-
-        Returns:
-            The chardet encoding name if its confidence reaches `minimum_encoding_confidence`,
-            and `fallback` otherwise.
-        """
-        detector = UniversalDetector()
-        offset = 0
-        while not detector.done and offset < min(len(data), 5000000):
-            # feed 1kB at a time until we have high confidence in the classification
-            # up to a maximum of 5MiB
-            detector.feed(data[offset:offset+1024])
-            offset += 1024
-        detector.close()
-        if detector.result["encoding"] is None \
-                or detector.result["confidence"] < self.minimum_encoding_confidence:
-            return fallback
-        return detector.result["encoding"]
-
     def test(self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]) -> TestResult:
-        if not isinstance(self.message, ConstantMessage) or self.message.message:
-            raise ValueError(f"A new PlainTextTest must be constructed for each call to .test")
         content = data[absolute_offset:]
-        character_class = detect_text_encoding(content)
-        if character_class is None:
+        encoding = detect_text_encoding(content)
+        if encoding is None:
             return FailedTest(self, offset=absolute_offset, parent=parent_match, message="the data do not appear to "
                                                                                          "be encoded in a text format")
-        encoding = self.encoding_name(content, character_class)
         try:
             value: Union[str, bytes] = content.decode(encoding)
         except (UnicodeDecodeError, LookupError):
             value = content
-        self.message = ConstantMessage(f"{encoding} text")
         return MatchedTest(self, offset=absolute_offset, length=len(content), parent=parent_match,
                            value=value)
 
@@ -3363,11 +3381,26 @@ def _split_with_escapes(text: str) -> Tuple[str, str]:
 
 
 class Match:
+    """One level 0 test's verdict on a buffer, and the results of the subtests it reached."""
+
     def __init__(
-            self, matcher: "MagicMatcher", context: MatchContext, results: Iterable[TestResult]
+            self,
+            matcher: "MagicMatcher",
+            context: MatchContext,
+            results: Iterable[TestResult],
+            text_encoding: Optional[TextEncodingDescription] = None
     ):
+        """
+        Args:
+            matcher: the matcher that produced this match.
+            context: the buffer the tests ran against.
+            results: the result of every test that matched.
+            text_encoding: the text description libmagic appends to this match's message, or None
+                when libmagic would leave the message alone.
+        """
         self.matcher: MagicMatcher = matcher
         self.context: MatchContext = context
+        self.text_encoding: Optional[TextEncodingDescription] = text_encoding
         self._result_iter: Optional[Iterator[TestResult]] = iter(results)
         self._results: List[TestResult] = []
 
@@ -3436,7 +3469,12 @@ class Match:
                 break
             i += 1
 
-    def message(self) -> str:
+    def _soft_magic_message(self) -> str:
+        """Concatenates the message of every test that matched.
+
+        Returns:
+            The description soft magic alone produces, which is empty when nothing printed.
+        """
         msg = ""
         for result in self:
             m = result.test.message.resolve(self.context).lstrip()
@@ -3461,6 +3499,18 @@ class Match:
             result_str = result_str.replace("%%", "%")
             msg = f"{msg}{result_str}"
         return msg
+
+    def message(self) -> str:
+        """Describes this match the way `file` describes it.
+
+        Returns:
+            What soft magic printed, followed by the text description libmagic appends to a text
+            file's description when it applies.
+        """
+        msg = self._soft_magic_message()
+        if self.text_encoding is None:
+            return msg
+        return self.text_encoding.describe(msg)
 
     __str__ = message
 
@@ -3614,27 +3664,53 @@ class MagicMatcher:
         """Returns the set of extensions this matcher is capable of matching"""
         return self.tests_by_ext.keys()
 
+    def _run_tests(
+            self,
+            tests: Iterable[MagicTest],
+            context: MatchContext,
+            text_encoding: Optional[TextEncodingDescription],
+            description: str
+    ) -> Iterator[Match]:
+        """Yields a match for each of `tests` that matches `context`.
+
+        Args:
+            tests: the level 0 tests to run.
+            context: the buffer to run them against.
+            text_encoding: the description of `context`'s text encoding, or None if it is not text.
+            description: the label for the progress log.
+
+        Yields:
+            One match per test that matched, carrying `text_encoding` if libmagic would append it
+            to that test's message.
+        """
+        for test in log.range(tests, desc=description, unit=" tests", delay=1.0):
+            m = Match(matcher=self, context=context, results=test.match(context))
+            # the description is how a match is rendered, so it must not make an empty message
+            # look like a match
+            if m and (not context.only_match_mime or any(t is not None for t in m.mimetypes)):
+                if test.appends_text_encoding:
+                    m.text_encoding = text_encoding
+                yield m
+
     def match(self, to_match: Union[bytes, BinaryIO, str, Path, MatchContext]) -> Iterator[Match]:
         if isinstance(to_match, bytes):
             to_match = MatchContext(to_match)
         elif not isinstance(to_match, MatchContext):
             to_match = MatchContext.load(to_match)
+        text_encoding = TextEncodingDescription.detect(to_match.data)
         yielded = False
-        for test in log.range(self.non_text_tests, desc="binary matching", unit=" tests", delay=1.0):
-            m = Match(matcher=self, context=to_match, results=test.match(to_match))
-            if m and (not to_match.only_match_mime or any(t is not None for t in m.mimetypes)):
-                yield m
-                yielded = True
+        for m in self._run_tests(self.non_text_tests, to_match, text_encoding, "binary matching"):
+            yield m
+            yielded = True
         # is this a plain text file?
         text_matcher = Match(matcher=self, context=to_match, results=PlainTextTest().match(to_match))
         is_text = text_matcher and (not to_match.only_match_mime or any(t is not None for t in text_matcher.mimetypes))
         if is_text:
+            text_matcher.text_encoding = text_encoding
             # this is a text file, so try all of the textual tests:
-            for test in log.range(self.text_tests, desc="text matching", unit=" tests", delay=1.0):
-                m = Match(matcher=self, context=to_match, results=test.match(to_match))
-                if m and (not to_match.only_match_mime or any(t is not None for t in m.mimetypes)):
-                    yield m
-                    yielded = True
+            for m in self._run_tests(self.text_tests, to_match, text_encoding, "text matching"):
+                yield m
+                yielded = True
         if not yielded:
             if is_text:
                 yield text_matcher

--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -9,6 +9,7 @@ details about the file.
 
 """
 from abc import ABC, abstractmethod
+import codecs
 from collections import defaultdict
 import csv
 import functools
@@ -24,8 +25,8 @@ import struct
 import sys
 from time import gmtime, localtime, strftime
 from typing import (
-    Any, BinaryIO, Callable, Dict, Generic, Iterable, Iterator, List, NamedTuple, Optional, Set,
-    Tuple, Type, TypeVar, Union
+    Any, BinaryIO, Callable, Dict, FrozenSet, Generic, Iterable, Iterator, List, NamedTuple,
+    Optional, Set, Tuple, Type, TypeVar, Union
 )
 from uuid import UUID
 
@@ -3054,6 +3055,190 @@ def detect_text_encoding(data: bytes) -> Optional[str]:
     if ucs_encoding is not None:
         return ucs_encoding
     return _eight_bit_encoding(data)
+
+
+LIBMAGIC_ENCODING_NAMES: Dict[str, str] = {
+    "ascii": "ASCII",
+    "utf-8": "Unicode text, UTF-8",
+    "utf-16le": "Unicode text, UTF-16, little-endian",
+    "utf-16be": "Unicode text, UTF-16, big-endian",
+    "utf-32le": "Unicode text, UTF-32, little-endian",
+    "utf-32be": "Unicode text, UTF-32, big-endian",
+    "iso-8859-1": "ISO-8859",
+    "unknown-8bit": "Non-ISO extended-ASCII",
+}
+"""libmagic's name for each encoding `detect_text_encoding` reports, from ``src/encoding.c``."""
+
+MAX_LINE_LENGTH: int = 300
+"""libmagic's ``MAXLINELEN``: the longest line it considers sane (``src/ascmagic.c``)."""
+
+TEXT_ENCODING_MAX_BYTES: int = 64 * 1024
+"""libmagic's ``FILE_ENCODING_MAX``: how many bytes it decodes to describe text (``src/file.h``)."""
+
+_EIGHT_BIT_ENCODINGS: FrozenSet[str] = frozenset({"ascii", "iso-8859-1", "unknown-8bit"})
+
+_UCS_BOM_LENGTHS: Dict[str, int] = {
+    encoding: len(bom) for bom, encoding, _ in _UCS_BYTE_ORDER_MARKS
+}
+
+_LINE_TERMINATOR_PATTERN: Pattern[str] = re.compile("[\n\r\x85]")
+
+
+def _decode_text(data: bytes, encoding: str) -> str:
+    """Decodes the prefix of `data` that libmagic examines when it describes text.
+
+    libmagic decodes at most ``FILE_ENCODING_MAX`` bytes into the buffer that
+    ``file_ascmagic_with_encoding`` scans, so a line that only grows long past that point does not
+    count as a long line. Each eight bit encoding it names copies a byte's value straight into that
+    buffer, which is what decoding as Latin-1 does.
+
+    Args:
+        data: the bytes to decode.
+        encoding: the encoding `detect_text_encoding` named for `data`.
+
+    Returns:
+        The decoded characters, dropping any character the byte limit cut in half.
+    """
+    prefix = data[:TEXT_ENCODING_MAX_BYTES]
+    if encoding in _EIGHT_BIT_ENCODINGS:
+        return prefix.decode("latin-1")
+    prefix = prefix[_UCS_BOM_LENGTHS.get(encoding, 0):]
+    return codecs.getincrementaldecoder(encoding)().decode(prefix, final=False)
+
+
+def _longest_line(text: str) -> int:
+    """Measures the longest line of `text`, as libmagic's ``has_long_lines`` counter does.
+
+    Args:
+        text: the decoded characters to measure.
+
+    Returns:
+        The length of the longest line, or 0 when every line is at most `MAX_LINE_LENGTH`
+        characters long.
+    """
+    longest = 0
+    line_start = -1
+    for terminator in _LINE_TERMINATOR_PATTERN.finditer(text):
+        longest = max(longest, terminator.start() - 1 - line_start)
+        line_start = terminator.start()
+    longest = max(longest, len(text) - 1 - line_start)
+    if longest > MAX_LINE_LENGTH:
+        return longest
+    return 0
+
+
+class TextEncodingDescription:
+    """How libmagic describes a text file: its character encoding and the shape of its lines.
+
+    ``file_ascmagic_with_encoding`` in libmagic's ``src/ascmagic.c`` rewrites the tail of whatever
+    soft magic printed, appends the name of the character encoding, and then reports the file's
+    longest line, the line terminators it uses, and whether it holds escape or backspace
+    characters. `describe` applies that rewrite to one match's message.
+    """
+
+    def __init__(self, code: str, text: str):
+        """
+        Args:
+            code: libmagic's name for the encoding, such as ``ASCII``.
+            text: the decoded characters libmagic would scan.
+        """
+        self.code: str = code
+        self.crlf: int = text.count("\r\n")
+        self.lf: int = text.count("\n") - self.crlf
+        # libmagic counts a CR when it reads the character after it, so a CR that ends the buffer
+        # only counts if it is the only line terminator there is
+        ends_with_cr = text.endswith("\r")
+        self.cr: int = text.count("\r") - self.crlf - int(ends_with_cr)
+        if ends_with_cr and self.cr == 0 and self.crlf == 0:
+            self.cr = 1
+        self.nel: int = text.count("\x85")
+        self.longest_line: int = _longest_line(text)
+        self.has_escapes: bool = "\x1b" in text
+        self.has_overstriking: bool = "\b" in text
+
+    @classmethod
+    def detect(cls, data: bytes) -> Optional["TextEncodingDescription"]:
+        """Classifies `data` and measures the line shape libmagic would report for it.
+
+        Args:
+            data: the bytes to classify.
+
+        Returns:
+            The description, or None if `data` is not text.
+
+        Raises:
+            ValueError: if `detect_text_encoding` named an encoding that
+                `LIBMAGIC_ENCODING_NAMES` does not describe.
+        """
+        encoding = detect_text_encoding(data)
+        if encoding is None:
+            return None
+        if encoding not in LIBMAGIC_ENCODING_NAMES:
+            raise ValueError(f"there is no libmagic description for the text encoding "
+                             f"{encoding!r}; add one to LIBMAGIC_ENCODING_NAMES")
+        return cls(LIBMAGIC_ENCODING_NAMES[encoding], _decode_text(data, encoding))
+
+    def _splice(self, message: str) -> Tuple[str, bool]:
+        """Replaces a soft magic message's trailing ``text`` with the separator libmagic uses.
+
+        libmagic rewrites the tail of its output buffer with ``file_replace(ms, " text$", ", ")``,
+        falling back to ``" text executable$"`` and then to appending ``", "``, so
+        ``POSIX shell script text executable`` becomes ``POSIX shell script, `` and keeps its
+        ``executable`` to print after the encoding.
+
+        Args:
+            message: the message soft magic produced, which is empty if nothing matched.
+
+        Returns:
+            The rewritten message, and whether it named an executable.
+        """
+        if not message:
+            return "", False
+        elif message.endswith(" text"):
+            return f"{message[:-len(' text')]}, ", False
+        elif message.endswith(" text executable"):
+            return f"{message[:-len(' text executable')]}, ", True
+        return f"{message}, ", False
+
+    def _line_terminators(self) -> str:
+        """Names the line terminators the text uses.
+
+        libmagic reports terminators only when it finds one that is not LF, or when it finds none
+        at all, so a file with Unix line endings gets no clause.
+
+        Returns:
+            The clause to append, or the empty string when there is nothing to report.
+        """
+        present = [name for count, name in
+                   ((self.crlf, "CRLF"), (self.cr, "CR"), (self.lf, "LF"), (self.nel, "NEL"))
+                   if count]
+        if not present:
+            return ", with no line terminators"
+        elif present == ["LF"]:
+            return ""
+        return f", with {', '.join(present)} line terminators"
+
+    def describe(self, message: str) -> str:
+        """Appends this description to the message a match's soft magic tests produced.
+
+        Args:
+            message: the message soft magic produced, which is empty if nothing matched.
+
+        Returns:
+            The description libmagic reports for the file.
+        """
+        head, executable = self._splice(message)
+        description = f"{head}{self.code} text"
+        if executable:
+            description = f"{description} executable"
+        if self.longest_line:
+            description = f"{description}, with very long lines ({self.longest_line})"
+        description = f"{description}{self._line_terminators()}"
+        if self.has_escapes:
+            description = f"{description}, with escape sequences"
+        if self.has_overstriking:
+            description = f"{description}, with overstriking"
+        return description
 
 
 class PlainTextTest(MagicTest):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
     python_requires='>=3.10',
     install_requires=[
         "abnf~=2.2.0",
-        "chardet>=5.0.0",
         "cint>=1.0.0",
         "fickling>=0.0.8",
         "filelock>=3.20.3",

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1008,3 +1008,122 @@ class UseTestSemanticsTest(TestCase):
         for match in MagicMatcher.DEFAULT_INSTANCE.match(testfile.read_bytes()):
             self.assertNotIn("EFI variable", str(match))
             self.assertNotIn("total size", str(match))
+
+
+class TextEncodingDescriptionTest(TestCase):
+    """Tests for the text description libmagic appends, reported in issue #3488.
+
+    Every string these tests expect is what `file -b` prints for the same input, checked against
+    libmagic 5.48 built from the `file` submodule.
+    """
+
+    def describe(self, data: bytes, message: str = "") -> str:
+        """Describes `data` the way libmagic describes a match on it.
+
+        Args:
+            data: The bytes to classify.
+            message: The message soft magic produced for `data`.
+
+        Returns:
+            The description libmagic reports.
+        """
+        description = polyfile.magic.TextEncodingDescription.detect(data)
+        self.assertIsNotNone(description, f"{data!r} was not classified as text")
+        return description.describe(message)
+
+    def test_a_message_with_no_text_suffix_gets_a_separator(self):
+        """Tests that a message that ends in neither suffix is joined with `, `.
+
+        This is the `file_printf(ms, ", ")` fallback at `file/src/ascmagic.c:243`, which is what
+        turns `OpenStreetMap XML data` into `OpenStreetMap XML data, ASCII text`.
+        """
+        self.assertEqual("Netpbm image data, greymap, ASCII text",
+                         self.describe(b"MARKED\n", "Netpbm image data, greymap"))
+
+    def test_encoding_names_match_libmagics_spelling(self):
+        """Tests that the encoding is named as libmagic names it, in libmagic's case.
+
+        PolyFile used to report `ascii text`, and reported chardet's guess rather than the
+        character class verdict, so a UTF-16 file came out as `UTF-16 text` instead of
+        `Unicode text, UTF-16, little-endian text`. The names are the `code` strings of
+        `file_encoding` (`file/src/encoding.c:107-172`).
+        """
+        for data, expected in (
+                (b"hello\n", "ASCII text"),
+                ("héllo wörld\n".encode(), "Unicode text, UTF-8 text"),
+                (b"\xff\xfe" + "hi\n".encode("utf-16-le"),
+                 "Unicode text, UTF-16, little-endian text"),
+                (b"\xfe\xff" + "hi\n".encode("utf-16-be"), "Unicode text, UTF-16, big-endian text"),
+                (b"caf\xe9\n", "ISO-8859 text"),
+                (b"text\x80\x9f\n", "Non-ISO extended-ASCII text")):
+            with self.subTest(data=data):
+                self.assertEqual(expected, self.describe(data))
+
+    def test_line_terminators_are_named(self):
+        """Tests the line-terminator clause, including the LF-only case that has none.
+
+        libmagic reports terminators only when it finds one that is not LF, or none at all
+        (`file/src/ascmagic.c:284-317`), so `a\\nb\\n` is plain `ASCII text` while `hello world`
+        is `ASCII text, with no line terminators`.
+        """
+        for data, expected in (
+                (b"hello world", "ASCII text, with no line terminators"),
+                (b"a\nb\n", "ASCII text"),
+                (b"a\r\nb\r\n", "ASCII text, with CRLF line terminators"),
+                (b"a\rb\r", "ASCII text, with CR line terminators"),
+                (b"a\x85b\x85", "ASCII text, with NEL line terminators"),
+                (b"a\rb\nc\n", "ASCII text, with CR, LF line terminators"),
+                (b"a\x85b\n", "ASCII text, with LF, NEL line terminators"),
+                (b"a\r\nb\rc\nd\x85", "ASCII text, with CRLF, CR, LF, NEL line terminators")):
+            with self.subTest(data=data):
+                self.assertEqual(expected, self.describe(data))
+
+    def test_a_trailing_cr_counts_only_when_nothing_else_does(self):
+        """Tests that a CR at the end of the buffer is counted the way libmagic counts it.
+
+        libmagic raises `n_cr` when it reads the character after a CR, so a CR that ends the
+        buffer is counted only by the `seen_cr && n_cr == 0 && n_crlf == 0` fixup at
+        `file/src/ascmagic.c:208-209`. `a\\r\\nb\\r` therefore reports CRLF alone, while
+        `a\\nb\\r` reports both CR and LF.
+        """
+        self.assertEqual("ASCII text, with CRLF line terminators", self.describe(b"a\r\nb\r"))
+        self.assertEqual("ASCII text, with CR, LF line terminators", self.describe(b"a\nb\r"))
+        self.assertEqual("ASCII text, with CR line terminators", self.describe(b"abc\r"))
+
+    def test_very_long_lines_are_measured(self):
+        """Tests the long-line clause and the length libmagic reports for it.
+
+        A line counts as long once it exceeds `MAXLINELEN`, which is 300 characters
+        (`file/src/ascmagic.c:49` and `:198-203`), and libmagic reports the length of the longest
+        one rather than the number of long lines.
+        """
+        self.assertEqual("ASCII text", self.describe(b"x" * 300 + b"\n"))
+        self.assertEqual("ASCII text, with very long lines (301)",
+                         self.describe(b"x" * 301 + b"\n"))
+        self.assertEqual("ASCII text, with very long lines (350)",
+                         self.describe(b"x" * 310 + b"\n" + b"y" * 350 + b"\n"))
+        self.assertEqual("ASCII text, with very long lines (400), with no line terminators",
+                         self.describe(b"x" * 400))
+
+    def test_only_the_first_64_kilobytes_are_measured(self):
+        """Tests that the description stops at libmagic's encoding limit.
+
+        libmagic decodes at most `FILE_ENCODING_MAX`, 64KiB, into the buffer it scans
+        (`file/src/file.h:525` and `src/encoding.c:98-99`), so a file whose first line runs past
+        that point reports a 65536 character line and no line terminators at all.
+        """
+        self.assertEqual("ASCII text, with very long lines (65536), with no line terminators",
+                         self.describe(b"a" * 70000 + b"\n" + b"b" * 400 + b"\n"))
+
+    def test_escape_sequences_and_overstriking_are_reported(self):
+        """Tests the escape and backspace clauses, and the order every clause appears in.
+
+        `file/src/ascmagic.c:274-324` prints the long-line clause, then the line terminators, then
+        `, with escape sequences` and `, with overstriking`.
+        """
+        self.assertEqual("ASCII text, with no line terminators, with escape sequences",
+                         self.describe(b"hello \x1b[31mworld"))
+        self.assertEqual("ASCII text, with overstriking", self.describe(b"he\bello\n"))
+        self.assertEqual("ASCII text, with very long lines (402), with CRLF line terminators, "
+                         "with escape sequences, with overstriking",
+                         self.describe(b"x" * 400 + b"\x1b\b\r\n"))

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -29,25 +29,15 @@ KNOWN_FAILURES: Dict[str, int] = {
     # has to be fixed first, and the trailing comment names what blocks the stem after that.
     # Issue #3480 tracks the whole set.
     #
-    # Seven of the nine wait on the same thing: PolyFile never appends libmagic's text-encoding
-    # description, so it reports `OpenStreetMap XML data` where libmagic reports
-    # `OpenStreetMap XML data, ASCII text`.
-    "cmd1": 3488,           # and #3490, which is why a second, binary variant also matches
-    "cmd2": 3488,           # and #3490, as for cmd1
-    "gedcom": 3488,
-    "jpeg-text": 3488,      # needs the line-terminator clause and the upper-case encoding name
-    # This test ships two sidecars, which the harness now loads, and a `.flags` of `k`. PolyFile
-    # reports all four names as separate matches, so what is left is the joined form: #3491 for
-    # the `\012- ` separator, #3477 for the strength order the parts appear in, and #3488 for the
-    # trailer on the last one. Splitting the expected string on `\012- ` here instead would drop
+    # This test ships two sidecars, which the harness loads, and a `.flags` of `k`. PolyFile
+    # reports all four names as separate matches, each with its own text-encoding description, so
+    # what is left is the joined form: #3491 for the `\012- ` separator and #3477 for the strength
+    # order the parts appear in. Splitting the expected string on `\012- ` here instead would drop
     # #3491 from that list.
-    "multiple": 3491,       # then #3477 and #3488
-    "osm": 3488,
-    "pnm1": 3488,
-    "pnm3": 3488,
+    "multiple": 3491,       # then #3477
     # Text tests run against the raw bytes, so the SVG test never matches a UTF-16 file and
-    # PolyFile reports only `UTF-16 text`.
-    "utf16xmlsvg": 3489,    # then #3488
+    # PolyFile reports only the text-encoding description.
+    "utf16xmlsvg": 3489,
 }
 """Corpus stems that cannot pass yet, each mapped to the issue that has to be fixed first."""
 
@@ -125,13 +115,10 @@ def corpus_result_matches(expected: str, matches: Set[str]) -> bool:
     Returns:
         True if one of `matches` corresponds to `expected`.
     """
-    if expected == "ASCII text" and expected not in matches:
-        # PolyFile emits "ascii text" in lower case; part of issue #3488.
-        return expected.lower() in matches
     expected = expected.rstrip().lower()
     lowered = {match.rstrip().lower() for match in matches}
     if "00000000" in expected and expected not in lowered:
-        # Technically correct, but PolyFile formats a zero as "0x000000"; part of issue #3488.
+        # Technically correct, but PolyFile formats a `%#8.8x` zero as "0x000000".
         return expected.replace("00000000", "0x000000") in lowered
     if expected.startswith("hancom hwp"):
         return any(match.endswith(expected) for match in lowered)
@@ -429,7 +416,7 @@ class MagicTest(TestCase):
         messages = self.messages(MagicMatcher.DEFAULT_INSTANCE, b"{}\n[]\n")
         self.assertNotIn("New Line Delimited JSON text data", messages)
         self.assertNotIn("JSON text data", messages)
-        self.assertIn("ascii text", messages)
+        self.assertIn("ASCII text", messages)
 
     def test_bare_json_scalar_is_not_json(self):
         """Tests that a bare top-level scalar is not JSON.
@@ -734,7 +721,9 @@ class RegexSemanticsTest(TestCase):
             data: The bytes to classify.
 
         Returns:
-            The message of every match.
+            The message of every match. A level 0 `regex` is a text test, so each message carries
+            the text-encoding description that `TextEncodingDescription` appends, exactly as
+            `file -b -m <definition>` prints it.
         """
         with TemporaryDirectory() as tmp_dir:
             path = Path(tmp_dir) / "regex_semantics"
@@ -765,14 +754,14 @@ class RegexSemanticsTest(TestCase):
         self.assertEqual(b"123", match.raw_match)
         self.assertEqual("123", match.value)
         self.assertEqual(2, match.initial_offset)
-        self.assertEqual({"digits 123"},
+        self.assertEqual({"digits 123, ASCII text, with no line terminators"},
                          self.messages("0\tregex\t=[0-9]{1,3}\tdigits %s\n", self.DATA))
 
     def test_regex_relative_offset_resolves_from_the_match_end(self):
         """A `&` offset after a plain `regex` reads from the end of the match, at offset 5."""
-        self.assertEqual({"digits then"},
+        self.assertEqual({"digits then, ASCII text, with no line terminators"},
                          self.messages(self.relative_offset_definition("", "bb"), self.DATA))
-        self.assertEqual({"digits"},
+        self.assertEqual({"digits, ASCII text, with no line terminators"},
                          self.messages(self.relative_offset_definition("", "123"), self.DATA))
 
     def test_regex_s_relative_offset_resolves_from_the_match_start(self):
@@ -782,9 +771,9 @@ class RegexSemanticsTest(TestCase):
         resolve from the start of the match, at offset 2 rather than offset 5
         (`file/src/softmagic.c:959-963`).
         """
-        self.assertEqual({"digits then"},
+        self.assertEqual({"digits then, ASCII text, with no line terminators"},
                          self.messages(self.relative_offset_definition("/s", "123"), self.DATA))
-        self.assertEqual({"digits"},
+        self.assertEqual({"digits, ASCII text, with no line terminators"},
                          self.messages(self.relative_offset_definition("/s", "bb"), self.DATA))
 
 
@@ -881,7 +870,8 @@ class StringDataTypeTest(TestCase):
         `GEDCOM genealogy text version 2 VERS 2.x`.
         """
         definition = "0\tsearch/16\tVERS\tversion\n>&1\tstring\tx\t%s\n"
-        self.assertEqual({"version 5.5"}, self.messages(definition, b"xxx VERS 5.5\nnext line\n"))
+        self.assertEqual({"version 5.5, ASCII text"},
+                         self.messages(definition, b"xxx VERS 5.5\nnext line\n"))
 
     def test_wildcard_string_stops_at_a_line_break(self):
         """A wildcard value ran to the first null byte, so a `%s` leaked the rest of the file.
@@ -897,16 +887,12 @@ class StringDataTypeTest(TestCase):
         self.assertEqual(b"a" * 128, wildcard.matches(b"a" * 300).raw_match)
 
     def test_gedcom_reports_one_version_and_not_four_lines(self):
-        """`magic_defs/scientific`'s `%s` reported four lines of `gedcom.testfile`.
-
-        `gedcom` still fails the corpus check because its message needs the encoding trailer
-        (trailofbits/polyfile#3488), so the corpus check does not pin what this fixes.
-        """
+        """`magic_defs/scientific`'s `%s` reported four lines of `gedcom.testfile`."""
         self.assertTrue(FILE_TEST_DIR.exists(),
                         "Run `git submodule init && git submodule update` in the repository root.")
         data = (FILE_TEST_DIR / "gedcom.testfile").read_bytes()
         messages = {str(match) for match in MagicMatcher.DEFAULT_INSTANCE.match(data)}
-        self.assertEqual({"GEDCOM genealogy text version 5.5"}, messages)
+        self.assertEqual({"GEDCOM genealogy text version 5.5, ASCII text"}, messages)
 
     def test_pstring_forwards_its_string_flags(self):
         """`PascalStringType` dropped every string flag, and rejected a declaration carrying one.
@@ -1017,6 +1003,32 @@ class TextEncodingDescriptionTest(TestCase):
     libmagic 5.48 built from the `file` submodule.
     """
 
+    TEXT_SUFFIX_DEFINITION: str = "0\tstring/t\tMARK\tMarked file text\n"
+    """A text test whose message ends in the ` text` that libmagic splices out."""
+
+    EXECUTABLE_DEFINITION: str = "0\tstring/t\tMARK\tMarked file text executable\n"
+    """A text test whose message ends in the ` text executable` that libmagic splices out."""
+
+    BINARY_DEFINITION: str = "0\tstring\tMARK\tMarked file text\n"
+    """The same test without `t`, which libmagic runs in its binary pass and never describes."""
+
+    @staticmethod
+    def messages(definition: str, data: bytes) -> Set[str]:
+        """Runs a single magic definition against `data`.
+
+        Args:
+            definition: The text of a magic definition file, with tab-separated columns.
+            data: The bytes to classify.
+
+        Returns:
+            The message of every match.
+        """
+        with TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "text_encoding"
+            path.write_text(definition)
+            matcher = MagicMatcher.parse(path)
+        return {str(match) for match in matcher.match(data)}
+
     def describe(self, data: bytes, message: str = "") -> str:
         """Describes `data` the way libmagic describes a match on it.
 
@@ -1031,6 +1043,26 @@ class TextEncodingDescriptionTest(TestCase):
         self.assertIsNotNone(description, f"{data!r} was not classified as text")
         return description.describe(message)
 
+    def test_a_text_suffix_is_replaced_by_the_encoding(self):
+        """Tests that a message ending in ` text` loses it before the encoding is appended.
+
+        libmagic rewrites its output buffer with `file_replace(ms, " text$", ", ")`
+        (`file/src/ascmagic.c:238`), so `Marked file text` becomes `Marked file, ASCII text` and
+        not `Marked file text, ASCII text`.
+        """
+        self.assertEqual({"Marked file, ASCII text"},
+                         self.messages(self.TEXT_SUFFIX_DEFINITION, b"MARKED\n"))
+
+    def test_a_text_executable_suffix_keeps_its_executable(self):
+        """Tests that ` text executable` is spliced out and the `executable` printed again.
+
+        libmagic falls back to `file_replace(ms, " text executable$", ", ")` and remembers to
+        print ` executable` after the encoding (`file/src/ascmagic.c:240-268`), so
+        `POSIX shell script text executable` becomes `POSIX shell script, ASCII text executable`.
+        """
+        self.assertEqual({"Marked file, ASCII text executable"},
+                         self.messages(self.EXECUTABLE_DEFINITION, b"MARKED\n"))
+
     def test_a_message_with_no_text_suffix_gets_a_separator(self):
         """Tests that a message that ends in neither suffix is joined with `, `.
 
@@ -1039,6 +1071,26 @@ class TextEncodingDescriptionTest(TestCase):
         """
         self.assertEqual("Netpbm image data, greymap, ASCII text",
                          self.describe(b"MARKED\n", "Netpbm image data, greymap"))
+
+    def test_a_binary_test_is_not_described(self):
+        """Tests that a definition libmagic runs in its binary pass gets no description.
+
+        `file_buffer` reaches `file_ascmagic` only when the binary soft magic pass printed nothing
+        (`file/src/funcs.c:479-503`), and `set_test_type` puts a `string` with no `t` flag in that
+        pass (`file/src/apprentice.c:1255-1275`). `file -b` reports `Marked file text` for this
+        input, with no encoding appended.
+        """
+        self.assertEqual({"Marked file text"}, self.messages(self.BINARY_DEFINITION, b"MARKED\n"))
+
+    def test_json_is_not_described(self):
+        """Tests that PolyFile's JSON test keeps libmagic's undecorated verdict.
+
+        `file_is_json` runs ahead of soft magic in `file_buffer` and its match ends the run
+        (`file/src/funcs.c:410-418`), so `file` reports `JSON text data` rather than
+        `JSON text data, ASCII text`.
+        """
+        messages = {str(match) for match in MagicMatcher.DEFAULT_INSTANCE.match(b'{"a": 1}\n')}
+        self.assertIn("JSON text data", messages)
 
     def test_encoding_names_match_libmagics_spelling(self):
         """Tests that the encoding is named as libmagic names it, in libmagic's case.
@@ -1127,3 +1179,48 @@ class TextEncodingDescriptionTest(TestCase):
         self.assertEqual("ASCII text, with very long lines (402), with CRLF line terminators, "
                          "with escape sequences, with overstriking",
                          self.describe(b"x" * 400 + b"\x1b\b\r\n"))
+
+    def test_a_description_belongs_to_one_match_only(self):
+        """Tests that one matcher describes each buffer on its own terms.
+
+        Test objects are shared across calls to `MagicMatcher.match`, so a description stored on a
+        test would leak into every later match. PolyFile used to assign `PlainTextTest.message`
+        during a match for exactly this reason, and only got away with it because
+        `MagicMatcher.match` built a fresh instance every call.
+        """
+        with TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "text_encoding"
+            path.write_text(self.TEXT_SUFFIX_DEFINITION)
+            matcher = MagicMatcher.parse(path)
+        crlf = "Marked file, ASCII text, with CRLF line terminators"
+        for data, expected in ((b"MARKED\r\n", crlf),
+                               (b"MARKED\n", "Marked file, ASCII text"),
+                               (b"MARKED\r\n", crlf),
+                               (b"MARKED", "Marked file, ASCII text, with no line terminators")):
+            with self.subTest(data=data):
+                self.assertEqual({expected}, {str(match) for match in matcher.match(data)})
+
+    def test_only_match_mime_reports_the_same_types(self):
+        """Tests that the description does not disturb which MIME types a match reports.
+
+        `MagicTest._match` prunes subtrees that cannot report a MIME type when
+        `MatchContext.only_match_mime` is set, and the description is appended to a match's
+        message rather than to its results, so both modes report the types they did before.
+        """
+        self.assertTrue(FILE_TEST_DIR.exists(),
+                        "Run `git submodule init && git submodule update` in the repository root.")
+        for stem, expected in (("osm", {"text/xml"}),
+                               ("gedcom", {"text/vnd.familysearch.gedcom"}),
+                               ("pnm1", {"image/x-portable-graymap"}),
+                               ("json1", {"application/json"}),
+                               ("jpeg-text", {"text/plain"})):
+            data = (FILE_TEST_DIR / f"{stem}.testfile").read_bytes()
+            for only_match_mime in (False, True):
+                with self.subTest(test=stem, only_match_mime=only_match_mime):
+                    context = MatchContext(data, only_match_mime=only_match_mime)
+                    self.assertEqual(expected, {
+                        mimetype
+                        for match in MagicMatcher.DEFAULT_INSTANCE.match(context)
+                        for mimetype in match.mimetypes
+                        if mimetype is not None
+                    })


### PR DESCRIPTION
Closes #3488.

`file` describes a text file by taking whatever soft magic reported, rewriting its tail, and
appending the character encoding plus a set of clauses about the shape of the text. PolyFile had the
encoding classifier but nothing that appended the description, so it stopped at the type
description.

## What this reports now

| input | before | after (and `file -b`) |
| --- | --- | --- |
| `file/tests/cmd1.testfile` | `a /usr/bin/cmd1 script text executable` | `a /usr/bin/cmd1 script, ASCII text executable` |
| `file/tests/cmd2.testfile` | `a /usr/bin/cmd2 script text executable` | `a /usr/bin/cmd2 script, ASCII text executable` |
| `file/tests/gedcom.testfile` | `GEDCOM genealogy text version 5.5` | `GEDCOM genealogy text version 5.5, ASCII text` |
| `file/tests/jpeg-text.testfile` | `ascii text` | `ASCII text, with no line terminators` |
| `file/tests/osm.testfile` | `OpenStreetMap XML data` | `OpenStreetMap XML data, ASCII text` |
| `file/tests/pnm1.testfile` | `Netpbm image data, size = 2 x 2, greymap` | `Netpbm image data, size = 2 x 2, greymap, ASCII text` |
| `file/tests/pnm3.testfile` | `Netpbm image data, size = 10 x 20, pixmap` | `Netpbm image data, size = 10 x 20, pixmap, ASCII text` |

`cmd1` and `cmd2` still report a second, binary variant, `a /usr/bin/cmd1 script executable (binary
data)`, because the `t` and `b` string flags do not yet select a pass (#3490). `osm` also reports
`XML document, ASCII text` and `XML 1.0 document, ASCII text`, which are the other two groups that
match it; `file -k` reports the same three descriptions.

## Design

`TextEncodingDescription` holds one buffer's encoding name and line shape, and `describe` applies it
to one match's message. `Match` carries an optional description, and `Match.message` applies it
after it concatenates its results. `MagicMatcher.match` classifies the buffer once per call and
hands the description to each level 0 test that needs it.

Of the three shapes the issue sketched, this is the first: an optional field on `Match`, applied in
`Match.message` after the concatenation loop. It fits because the description is not a match of its
own. libmagic accumulates into one output buffer that a later pass rewrites in place; a match's
message is PolyFile's equivalent of that buffer, and nothing else about a match changes. The other
two shapes would either introduce a wrapper type that every consumer of `Match` has to know about,
or put buffer-wide state on `MatchContext`, which is shared by the recursive `MagicMatcher.match`
calls that `IndirectResult` makes.

Two things fall out of that choice:

- **No shared `MagicTest` state.** The description lives on the `Match`, and `MagicMatcher.match`
  builds a fresh one per call. `PlainTextTest` no longer assigns `self.message` during a match, so
  it holds no per-match state at all and the "construct a new one for each call" guard is gone.
  `test_a_description_belongs_to_one_match_only` matches four buffers through one matcher and
  asserts each gets its own description.
- **`only_match_mime` untouched.** Nothing in `MagicTest._match`, `can_match_mime`, or
  `Match.mimetypes` changed; the description is appended to the message only. Checked empirically:
  the MIME types PolyFile reports for all 88 corpus test files, with and without
  `only_match_mime`, are byte for byte identical before and after.
  `test_only_match_mime_reports_the_same_types` pins five of them.

One subtlety worth review: the description is attached *after* a match's own tests decide whether it
matched. Attaching it first turns a definition that matched structurally but printed nothing into a
match whose whole message is the description, which is not what libmagic does — a group that prints
nothing never raises `returnval` (`file/src/softmagic.c:323`).

### Which matches get a description

This is the part of the diagnosis in the issue that needed correcting. The issue and the task both
assumed the description belongs to whatever PolyFile's *text pass* produced. It does not.

libmagic reaches `file_ascmagic` only when its `BINTEST` soft magic pass printed nothing
(`file/src/funcs.c:479-503`), and the description lands on whatever the `TEXTTEST` pass printed.
Which pass a definition runs in comes from `set_test_type` (`file/src/apprentice.c:1200-1288`),
which — I checked the call site, `set_text_binary`, whose `do`/`while` runs exactly once — reads the
type and flags of the **level 0 test alone**. `MagicTest.subtest_type` is PolyFile's port of exactly
that rule.

`MagicTest.test_type`, which picks the pass PolyFile itself runs a test in, is a different and
weaker rule: it reports a group as binary if any of its subtests is binary. So PolyFile runs
`0 search/1 P2` (`magic_defs/images:210`) in its *binary* pass, because of the `>>0 string x`
beneath it, while libmagic runs it in the text pass. Five of the seven stems here are like that:
their matches come out of PolyFile's binary pass. Keying the description on which pass produced the
match would have left them alone and would have wrongly described `regex-eol` and `searchbug`,
whose `0 string` roots libmagic runs in the binary pass. `MagicTest.appends_text_encoding` therefore
reads `subtest_type`, and per the task's instruction `test_type` is not touched.

`JSONTest` and `CSVTest` override the property. They stand in for libmagic's built-in `file_is_json`
and `file_is_csv`, which run before soft magic in `file_buffer` and end the run, so `file` reports
`JSON text data` and never `JSON text data, ASCII text`.

### The clauses, and where each comes from

Each is checked against `file` 5.48 built from the `file` submodule, with a purpose-built magic file
where the default definitions could not produce the case.

| clause | libmagic | note |
| --- | --- | --- |
| `file_replace(ms, " text$", ", ")` | `ascmagic.c:238` | `GEDCOM genealogy text` becomes `GEDCOM genealogy, ASCII text` |
| `file_replace(ms, " text executable$", ", ")`, then ` executable` after the encoding | `ascmagic.c:240` and `:266-268` | `POSIX shell script text executable` becomes `POSIX shell script, ASCII text executable` |
| `file_printf(ms, ", ")` fallback | `ascmagic.c:243` | and no separator at all when soft magic printed nothing |
| the encoding name and ` text` | `ascmagic.c:258-264`, names from `encoding.c:107-172` | `ASCII`, `Unicode text, UTF-8`, `Unicode text, UTF-16, little-endian`, `ISO-8859`, `Non-ISO extended-ASCII` |
| `", with very long lines (%zu)"` | `ascmagic.c:198-203` and `:274-278` | longer than `MAXLINELEN`, 300 characters; reports the longest line, not a count |
| the line terminator clause | `ascmagic.c:284-317` | `, with no line terminators`, or the comma-joined `CRLF`, `CR`, `LF`, `NEL`; nothing at all for LF alone |
| `", with escape sequences"` and `", with overstriking"` | `ascmagic.c:319-324` | |
| the 64KiB decode limit | `file.h:525`, `encoding.c:98-99` | `a * 70000 + "\n" + b * 400 + "\n"` is `ASCII text, with very long lines (65536), with no line terminators` in both |

Two counting details are easy to get wrong and are pinned by their own tests:

- A CR that ends the buffer is counted only by the `seen_cr && n_cr == 0 && n_crlf == 0` fixup at
  `ascmagic.c:208-209`, because `n_cr` rises when libmagic reads the character *after* a CR. So
  `a\r\nb\r` reports CRLF alone, while `a\nb\r` reports both CR and LF.
- `has_long_lines` starts from `last_line_end = (size_t)-1`, so an unterminated file's first line
  measures `i + 1` rather than `i`. 400 `x` with no newline is `very long lines (400)`.

`PlainTextTest` no longer names the encoding itself, which removes the chardet statistical guess the
issue flagged: it reported `UTF-16 text` where libmagic reports
`Unicode text, UTF-16, little-endian text`, and it was the reason the name came out in lower case.
chardet was PolyFile's only use of that library, so the dependency goes too.

## Verification

**Corpus differential** (the harness's own normalization, run over every stem):

```
NEWLY PASSING (12): ['JW07022A.mp3', 'cmd1', 'cmd2', 'cmd3', 'cmd4', 'gedcom', 'jpeg-text', 'jsonlines1', 'osm', 'pnm1', 'pnm2', 'pnm3']
STILL FAILING (2): ['multiple', 'utf16xmlsvg']
REGRESSIONS   (0):
```

`NEWLY PASSING` is measured against the original 14 stems, five of which were already fixed on
master. The seven this change owns are `cmd1`, `cmd2`, `gedcom`, `jpeg-text`, `osm`, `pnm1` and
`pnm3`.

**Tests:** 1045 passed, 8 skipped, 400 subtests. Master is 1032 passed, 8 skipped, 372 subtests, so
this adds 13 tests and 28 subtests and loses none. `test_text_tests`'s count is unchanged, because
`test_type` is untouched. Six existing tests changed their expected string: they build a one-line
`regex` or `search` definition, which libmagic runs in its text pass, so `file` appends the
description to their output too. Each new expectation is what `file -b -m <definition>` prints.

Per the repo's testing rules, each new test was checked by breaking the part of the fix it covers
and confirming it fails. Thirteen mutations, thirteen caught: the ` text` splice, the
` text executable` splice, the `, ` fallback, `appends_text_encoding` returning True for a binary
test, the same on `JSONTest`, a lower-case encoding name, dropping the no-terminator clause, dropping
the trailing-CR fixup, an off-by-one long-line threshold, dropping the 64KiB limit, dropping the
escape and overstriking clauses, caching the description on the shared test object, and breaking
`_match`'s `only_match_mime` pruning.

**flake8:** 232 findings with `--max-complexity=10 --max-line-length=127`, against 233 on master —
one fewer, an `F541` that went with the deleted `PlainTextTest` guard. None in the files this
touches. The `--select=E9,F63,F7,F82` selection is 0.

**Broad oracle comparison.** 63 files of mixed type: repository sources (Python, Markdown, YAML,
HTML templates, a magic definition), `file`'s own sources and build output, a Mach-O binary, a gzip
stream, a PNG, and crafted text in ASCII, UTF-8, UTF-16LE, UTF-16BE, ISO-8859 and 8-bit extended,
with every combination of line terminator, long line, escape and backspace. The check is whether
`file -b`'s description appears among PolyFile's matches: **15 of 63 before, 54 of 63 after, with no
file going the other way.**

## Left undone

The nine remaining oracle differences, none of which this change caused:

1. **`StringMatch.is_always_text` misreads octal and hex escapes** — the largest one. It answers
   False whenever the raw pattern contains the characters `\x` or `\0`, which catches `\040`, an
   escaped space. So `0 search/1 Common\040subdirectories:\040` (`magic_defs/diff:13`) and
   `0 search/10/w #!\040/usr/bin/env\040python` (`magic_defs/python:256`) are classified binary,
   and PolyFile reports `diff output text` and `Python script text executable` where `file` reports
   `diff output, ASCII text` and `Python script, ASCII text executable`. libmagic's rule is
   `file_looks_utf8` over the *unescaped* value (`apprentice.c:1281-1287`). I measured the fix —
   `_looks_like_utf8(self.string)` — out of tree: it is corpus-clean, takes the oracle comparison
   from 54 to 56 of 63, and moves 17 level 0 tests from the binary pass to the text pass, which
   means regenerating `test_text_tests`'s expected set. That is a defect in the pass split rather
   than in the description, so it wants its own issue and its own change.
2. **`t` and `b` on `regex` and `search` are dropped** (#3478, #3490). `0 regex/t` and `0 regex/b`
   parse identically, so `magic_defs/varied.script:22`'s binary variant is classified as text and
   PolyFile reports `a python3 script executable (binary data), ASCII text`. libmagic skips that
   entry for text input.
3. **`trim_nuls` is not ported.** `file_ascmagic` strips trailing NUL bytes before classifying
   (`ascmagic.c:60-67`), so `file` calls `"hi\n\0\0\0\0"` `ASCII text` while PolyFile calls it
   `data`. Porting it changes `detect_text_encoding`'s verdict, and with it which tests run at all,
   so it belongs with the other `file_encoding` fidelity gaps rather than here.
4. **The 64KiB limit applies to the line shape but not to the classification.** libmagic caps both
   at `FILE_ENCODING_MAX`. Capping the classification too would need `_looks_like_utf8` to tolerate
   a multi-byte character the limit cut in half, the way `file_looks_utf8` does, or a large UTF-8
   file would be misclassified as 8-bit.
5. **`; charset=` is not emitted.** `--format mime` prints one MIME type per line rather than
   libmagic's single `type; charset=name`, so there is nowhere to put it without redesigning that
   output, and no corpus stem needs it. `detect_text_encoding` already returns the name it would
   use.
6. **`file_default` is not ported.** A one-byte file is `very short file (no magic)` to `file` and
   `data` to PolyFile.
7. **`CSV text` does not name the encoding.** `file_is_csv` builds `CSV ASCII text` itself from
   `code` (`is_csv.c:160-161`); PolyFile's `magic_defs/csv` message is fixed text.
8. **`multiple` and `utf16xmlsvg` still fail**, as #3491 and #3489 say. Both now carry the
   description — `ABCD File, ASCII text, with no line terminators` and
   `Unicode text, UTF-16, little-endian text` — so what is left for each is the part its own issue
   names.
9. Pre-existing and unrelated: `POSIX shell script` loses to the generic `varied.script` entry, a
   Mach-O universal binary drops its per-architecture descriptions (#3491), and a PNG reports
   `data`.

Removing the dead `ASCII text` branch of `corpus_result_matches` addresses half of #3501; the
unexplained `hancom hwp` branch beside it is still there, so that issue stays open. The `00000000`
branch's comment pointed at #3488, which is a number formatting difference and nothing to do with
this, so the comment now says what it is instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VS8hTTRQeG8ZCmCZ9KLHiV
