### PR TITLE
Refresh the corkami known-bad list against file 5.48

### DIFF
--- a/tests/test_corkami.py
+++ b/tests/test_corkami.py
@@ -20,30 +20,20 @@ FILE_PATH = FILE_DIR / "src" / "file"
 MAGIC_FILE_PATH = SCRIPT_DIR / "magic.mgc"
 
 KNOWN_BAD_FILES = {
-    "4789632eef115af5e901b30d220c6e1c",  # arj.bin
-                                         # `file` incorrectly classifies this as `text/plain`
-                                         # while PolyFile more correctly classifies it as application/octet-stream
     "79f509d30245f6c7574a1ace1696be1a",  # card.bin
-                                         # `file` incorrectly classifies this as `text/plain`
-                                         # while PolyFile more correctly classifies it as application/octet-stream
-    "cef57430e7dcc950f3582285f1307521",  # dex035.bin
-                                         # `file` incorrectly classifies this as `text/plain`
-                                         # while PolyFile more correctly classifies it as application/octet-stream
+                                         # `file` trims the trailing NULs before classifying the
+                                         # encoding, reads the rest as ISO-8859 text, and reports
+                                         # `text/plain`. PolyFile does not trim, so it reports
+                                         # `application/octet-stream`. See #3506
     "d1531b1622de54fe3a0187c3344600e9",  # elf.bin
-                                         # `file` incorrectly classifies this as `text/plain`
-                                         # while PolyFile more correctly classifies it as application/octet-stream
-    "c0f44879dc0d4eae7b3f0b3e801e373c",  # id3v2.bin
-                                         # `file` incorrectly classifies this as `text/plain`
-                                         # while PolyFile more correctly classifies it as application/octet-stream
-    "1d52f82b2a240cb618effe344bb1e579",  # jpg.bin
-                                         # `file` incorrectly classifies this as `text/plain`
-                                         # while PolyFile more correctly classifies it as application/octet-stream
-    "e9dd2797018cad79186e03e8c5aec8dc",  # png.bin
-                                         # `file` incorrectly classifies this as `text/plain`
-                                         # while PolyFile more correctly classifies it as application/octet-stream
+                                         # `file` reads this as International EBCDIC text and
+                                         # reports `text/plain`. PolyFile has no EBCDIC detection,
+                                         # so it reports `application/octet-stream`. See #3507
     "bdb7963176bdaa12a17d98db9cbf384b",  # make.py
-                                         # `file` correctly classifies this as `text/x-script.python`
-                                         # while PolyFile incorrectly classifies this as `text/plain` (investigating)
+                                         # `file` reports both `text/x-script.python` and
+                                         # `text/plain`. PolyFile reports only
+                                         # `text/x-script.python`, because it emits the plain text
+                                         # match only when no other test matched. See #3488
 }
 
 FILE_MIMETYPE_PATTERN = re.compile(rb"^(.*?:|-)\s*(?P<mime>[^/\s]+/[^/;\s]+)\s*(;.*?$|$)(?P<remainder>.*)",


### PR DESCRIPTION
Revisits the eight entries in `KNOWN_BAD_FILES` now that the libmagic implementation has moved
closer to `file` 5.48, and gives every retained entry a tracked cause.

Each entry was re-tested against the built `file/src/file` (5.48) and the current matcher,
reproducing the harness comparison in `tests/test_corkami.py`.

| entry | `file` 5.48 | PolyFile | outcome |
| --- | --- | --- | --- |
| `arj.bin` | `text/plain; charset=iso-8859-1` | `text/plain` | passes, removed |
| `jpg.bin` | `text/plain; charset=iso-8859-1` | `text/plain` | passes, removed |
| `id3v2.bin` | `text/plain; charset=us-ascii` | `text/plain` | passes, removed |
| `dex035.bin` | `text/plain; charset=us-ascii` | `text/plain` | passes, removed |
| `png.bin` | `text/plain; charset=unknown-8bit` | `text/plain` | passes, removed |
| `card.bin` | `text/plain; charset=binary` | `application/octet-stream` | fails, #3506 |
| `elf.bin` | `text/plain; charset=ebcdic` | `application/octet-stream` | fails, #3507 |
| `make.py` | `text/x-script.python` and `text/plain` | `text/x-script.python` | fails, #3488 |

## The five removals

After #3468 pinned the character class table to libmagic's `text_chars`, PolyFile reports
`text/plain` for all five. Their comments claimed PolyFile was the more accurate of the two, which
is no longer what happens, so the skips are stale rather than justified.

## The three that remain

All three miss the same MIME type, `text/plain`, through `polyfile/magic.py:3453-3456`: the
plain-text match is yielded only when no other test matched, and otherwise the fallback is
`OctetStreamTest`. The causes differ.

- **`card.bin`** — `detect_text_encoding` never applies libmagic's `trim_nuls`
  (`file/src/ascmagic.c:82-89`), so the four trailing NULs make the buffer binary. Trimming them
  flips the classifier from `None` to `iso-8859-1`. Filed as #3506.
- **`elf.bin`** — no EBCDIC branch (`file/src/encoding.c:159-169`). Filed as #3507.
- **`make.py`** — a text test matched, so the plain-text match is suppressed. This is #3488, with
  #3491 covering how the two records are joined. **The old comment described the inverse**: it said
  PolyFile reported `text/plain` and missed `text/x-script.python`.

Both #3506 and #3507 are independent of #3488, which changes when the plain-text result is emitted
rather than whether these buffers count as text.

## Not addressed here

`make.py` currently passes, because it is the only one of the eight whose `file` output has more
than one record and `FILE_MIMETYPE_PATTERN` cannot parse the literal `\012-` separator, yielding an
empty MIME set. It stays skipped rather than removed. That parser belongs to #3488 / #3491; for
scale, 683 of the 943 corpus files produce multi-record output today, and 145 would fail once it is
fixed.

For the same reason this does not add the "known failures must still fail" guard that
`tests/test_magic.py` uses for `KNOWN_FAILURES`, which would trip on `make.py` today. That guard is
what would have caught these five going stale, and it fits naturally alongside the parser fix.

## Verification

- `pytest tests` — 1034 passed, 6 skipped, 183 subtests passed.
- The five removed entries pass by name; the three retained skip; nothing lands in
  `tests/failed_corkami_files/`.
- `flake8` and `pip-audit` report only pre-existing findings. The single hit in this file
  (`C901 '_init_tests' is too complex (15)`) is present identically on `master` and outside the
  `flake8 polyfile polymerge` scope in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
