### PR TITLE
Order the level 0 tests deterministically, by libmagic's own priority

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -639,8 +639,8 @@ class IndirectOffset(Offset):
 
 
 class SourceInfo:
-    def __init__(self, path: Path, line: int, original_line: Optional[str] = None):
-        self.path: Path = path
+    def __init__(self, path: Union[str, Path], line: int, original_line: Optional[str] = None):
+        self.path: Path = Path(path)
         self.line: int = line
         self.original_line: Optional[str] = original_line
 

--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -25,8 +25,8 @@ import struct
 import sys
 from time import gmtime, localtime, strftime
 from typing import (
-    Any, BinaryIO, Callable, Dict, FrozenSet, Generic, Iterable, Iterator, List, NamedTuple,
-    Optional, Set, Tuple, Type, TypeVar, Union
+    Any, BinaryIO, Callable, Dict, FrozenSet, Generic, Iterable, Iterator, KeysView, List,
+    NamedTuple, Optional, Set, Tuple, Type, TypeVar, Union
 )
 from uuid import UUID
 
@@ -318,6 +318,88 @@ operators that still read a value, so it loses two.
 
 UNSELECTIVE_RELATIONS: FrozenSet[str] = frozenset({"x", "!"})
 """The relations libmagic zeroes the strength for, because they match anything or almost anything."""
+
+LIBMAGIC_TYPE_CODES: Dict[str, int] = {
+    "invalid": 0, "byte": 1, "short": 2, "default": 3, "long": 4, "string": 5, "date": 6,
+    "beshort": 7, "belong": 8, "bedate": 9, "leshort": 10, "lelong": 11, "ledate": 12,
+    "pstring": 13, "ldate": 14, "beldate": 15, "leldate": 16, "regex": 17, "bestring16": 18,
+    "lestring16": 19, "search": 20, "medate": 21, "meldate": 22, "melong": 23, "quad": 24,
+    "lequad": 25, "bequad": 26, "qdate": 27, "leqdate": 28, "beqdate": 29, "qldate": 30,
+    "leqldate": 31, "beqldate": 32, "float": 33, "befloat": 34, "lefloat": 35, "double": 36,
+    "bedouble": 37, "ledouble": 38, "beid3": 39, "leid3": 40, "indirect": 41, "qwdate": 42,
+    "leqwdate": 43, "beqwdate": 44, "name": 45, "use": 46, "clear": 47, "der": 48, "guid": 49,
+    "leguid": 50, "beguid": 51, "offset": 52, "bevarint": 53, "levarint": 54, "msdosdate": 55,
+    "lemsdosdate": 56, "bemsdosdate": 57, "msdostime": 58, "lemsdostime": 59, "bemsdostime": 60,
+    "octal": 61,
+}
+"""libmagic's ``FILE_*`` type number for each type name a definition can declare.
+
+The number, not the name, is what orders two tests of equal strength, because libmagic compares
+their raw ``struct magic`` bytes (``file/src/apprentice.c:216-283`` and
+``file/src/file.h:245-306``).
+"""
+
+TYPE_MODIFIER: Pattern[str] = re.compile(r"[/&|^+\-*%]")
+"""The characters that start the modifiers a type declaration can carry after its name."""
+
+FLAG_INDIR: int = 0x01
+FLAG_UNSIGNED: int = 0x08
+FLAG_NOSPACE: int = 0x10
+FLAG_OFFNEGATIVE: int = 0x80
+"""The ``struct magic`` flag bits a level 0 test can carry (``file/src/file.h:225-235``).
+
+``OFFADD`` and ``INDIROFFADD`` are missing because libmagic rejects a relative offset at level 0
+(``file/src/apprentice.c:2132-2137``), and ``BINTEST`` and ``TEXTTEST`` because they only record
+which of `MagicMatcher.match`'s two passes a test belongs to.
+"""
+
+STRING_DEFAULT_RANGE: int = 100
+"""The ``str_range`` libmagic gives a ``search`` that declared none (``file/src/file.h:433``)."""
+
+STRING_FLAG_BITS: Tuple[Tuple[str, int], ...] = (
+    ("compact_whitespace", 0x0001),
+    ("optional_blanks", 0x0002),
+    ("case_insensitive_lower", 0x0004),
+    ("case_insensitive_upper", 0x0008),
+    ("match_to_start", 0x0010),
+    ("force_text", 0x0020),
+    ("trim", 0x2000),
+    ("full_word_match", 0x4000),
+)
+"""Each string modifier PolyFile records, with the ``str_flags`` bit libmagic sets for it.
+
+See ``file/src/file.h:414-432`` for the bit numbering and ``file/src/apprentice.c:1946-1980`` for
+the modifier characters they come from.
+"""
+
+
+def libmagic_field(value: int, num_bytes: int) -> bytes:
+    """Lays `value` out the way ``memcmp`` reads an integer field of ``struct magic``.
+
+    Args:
+        value: The number the field holds.
+        num_bytes: The width of the field.
+
+    Returns:
+        The field's bytes, least significant first, because libmagic runs on little endian
+        hardware.
+    """
+    return (value & ((1 << (8 * num_bytes)) - 1)).to_bytes(num_bytes, "little")
+
+
+def libmagic_base_type(declaration: str) -> str:
+    """Strips a type declaration down to the name libmagic's type table holds.
+
+    Args:
+        declaration: A type as a definition wrote it, such as ``ubelong&0x00ffffff``.
+
+    Returns:
+        A key of `LIBMAGIC_TYPE_CODES`.
+    """
+    name = TYPE_MODIFIER.split(declaration, maxsplit=1)[0]
+    if name.startswith("u") and name[1:] in LIBMAGIC_TYPE_CODES:
+        return name[1:]
+    return name
 
 
 def parse_numeric(text: Union[str, bytes]) -> int:
@@ -636,6 +718,63 @@ class IndirectOffset(Offset):
         else:
             num_bytes = str(self.num_bytes)
         return f"({self.offset!s}{['.', ','][self.signed]}{num_bytes}{self.endianness.value})"
+
+
+INDIRECT_OFFSET_TYPES: Dict[Tuple[int, Endianness], str] = {
+    (1, Endianness.LITTLE): "byte", (1, Endianness.BIG): "byte",
+    (2, Endianness.LITTLE): "leshort", (2, Endianness.BIG): "beshort",
+    (4, Endianness.LITTLE): "lelong", (4, Endianness.BIG): "belong",
+    (8, Endianness.LITTLE): "lequad", (8, Endianness.BIG): "bequad",
+}
+"""The type libmagic reads an indirect offset through, by width and byte order.
+
+See the character it comes from in ``file/src/apprentice.c:2158-2215``.
+"""
+
+
+def libmagic_indirect_type(offset: IndirectOffset) -> str:
+    """Names the type libmagic stores in ``in_type`` for `offset`.
+
+    Args:
+        offset: An indirect offset.
+
+    Returns:
+        A key of `LIBMAGIC_TYPE_CODES`.
+    """
+    if offset.is_id3:
+        return "leid3" if offset.endianness is Endianness.LITTLE else "beid3"
+    elif offset.num_bytes == IndirectOffset.OctalIndirectOffset:
+        return "octal"
+    return INDIRECT_OFFSET_TYPES.get((offset.num_bytes, offset.endianness), "long")
+
+
+def libmagic_offset_fields(offset: Offset) -> Tuple[int, int, str]:
+    """The ``struct magic`` fields that `offset` decides.
+
+    libmagic steps over the sign of a negative offset before it reads the number, so the field
+    holds the magnitude and the sign lives in a flag bit
+    (``file/src/apprentice.c:2140-2144``).
+
+    Args:
+        offset: The offset a definition declared.
+
+    Returns:
+        The flag bits `offset` sets, the number libmagic stores in the ``offset`` field, and the
+        name of the type an indirect offset reads through, which is ``"invalid"`` for a direct
+        offset.
+    """
+    if isinstance(offset, RelativeOffset):
+        offset = offset.relative_to
+    if isinstance(offset, IndirectOffset):
+        base = offset.offset
+        return (FLAG_INDIR,
+                base.offset if isinstance(base, AbsoluteOffset) else 0,
+                libmagic_indirect_type(offset))
+    elif isinstance(offset, NegativeOffset):
+        return FLAG_OFFNEGATIVE, offset.magnitude, "invalid"
+    elif isinstance(offset, AbsoluteOffset):
+        return 0, offset.offset, "invalid"
+    return 0, 0, "invalid"
 
 
 class SourceInfo:
@@ -967,6 +1106,68 @@ class MagicTest(ABC):
         if not str(self.message).strip():
             val += 1
         return val
+
+    def libmagic_type(self) -> str:
+        """Names the type libmagic stores in this test's ``struct magic``.
+
+        Returns:
+            A key of `LIBMAGIC_TYPE_CODES`.
+        """
+        return "invalid"
+
+    def libmagic_flag(self) -> int:
+        """The ``flag`` word libmagic would give this test.
+
+        Returns:
+            The bits named in `FLAG_INDIR` and its neighbors.
+        """
+        flag, _, _ = libmagic_offset_fields(self.offset)
+        if str(self.message).startswith("\b"):
+            flag |= FLAG_NOSPACE
+        return flag
+
+    def libmagic_value_fields(self) -> Tuple[int, bytes, bytes]:
+        """The fields of libmagic's ``struct magic`` that hold this test's value.
+
+        Returns:
+            The value's length in bytes, the eight bytes that carry ``str_range`` and
+            ``str_flags``, and the value itself.
+        """
+        return 0, bytes(8), b""
+
+    def libmagic_sort_key(self) -> Tuple[Any, ...]:
+        """The key that orders this test the way libmagic's ``apprentice_sort`` would.
+
+        libmagic sorts by descending strength and settles a tie by comparing the two entries'
+        ``struct magic`` bytes with ``memcmp``, putting the greater one first
+        (``file/src/apprentice.c:1126-1152``). This key repeats that comparison over the fields
+        that decide it, in the order they sit in memory, so a descending sort by the key
+        reproduces libmagic's order.
+
+        The key stops at the value. ``desc``, ``mimetype``, ``apple``, and ``ext`` follow it in
+        the struct, but libmagic writes a definition file's name into an empty ``desc``
+        (``file/src/apprentice.c:2438``) and PolyFile has already unescaped the description, so
+        neither compares byte for byte. ``in_op``, ``mask_op``, and ``in_offset`` are skipped
+        because PolyFile folds each of them into a callable instead of keeping the number.
+
+        Returns:
+            A tuple to sort by in descending order.
+        """
+        value_length, string_flags, value = self.libmagic_value_fields()
+        _, offset, indirect_type = libmagic_offset_fields(self.offset)
+        return (
+            self.compute_strength(),
+            libmagic_field(self.libmagic_flag(), 2),
+            libmagic_field(self.strength_factor, 1),
+            libmagic_field(ord(self.relation()), 1),
+            libmagic_field(value_length, 1),
+            libmagic_field(LIBMAGIC_TYPE_CODES[self.libmagic_type()], 1),
+            libmagic_field(LIBMAGIC_TYPE_CODES[indirect_type], 1),
+            libmagic_field(ord(self.strength_op.value or "\0"), 1),
+            libmagic_field(offset, 4),
+            string_flags,
+            value.ljust(MAX_STRING_BYTES, b"\0")[:MAX_STRING_BYTES],
+        )
 
     @property
     def parent(self) -> Optional["MagicTest"]:
@@ -2695,6 +2896,87 @@ class NumericDataType(DataType[NumericValue]):
         )
 
 
+def libmagic_string_flags(data_type: DataType) -> bytes:
+    """The ``str_range`` and ``str_flags`` word libmagic gives a string type.
+
+    Args:
+        data_type: The type a definition declared.
+
+    Returns:
+        Eight bytes, which are zero for a type that carries no string modifiers.
+    """
+    if not isinstance(data_type, (StringType, PascalStringType, RegexType, UTF16Type)):
+        return bytes(8)
+    string_range = getattr(data_type, "num_bytes", None) or 0
+    if isinstance(data_type, SearchType) and string_range == 0:
+        string_range = STRING_DEFAULT_RANGE
+    flags = 0
+    for attribute, bit in STRING_FLAG_BITS:
+        if getattr(data_type, attribute, False):
+            flags |= bit
+    return libmagic_field(string_range, 4) + libmagic_field(flags, 4)
+
+
+def libmagic_string_value(constant: StringTest) -> bytes:
+    """The bytes libmagic would copy into ``value.s`` for a string test.
+
+    Args:
+        constant: The parsed value of a string, search, or Pascal string test.
+
+    Returns:
+        The unescaped value, which is empty for a test that declared none.
+    """
+    if isinstance(constant, NegatedStringTest):
+        return libmagic_string_value(constant.parent)
+    elif isinstance(constant, StringMatch):
+        return constant.string
+    elif isinstance(constant, StringLengthTest):
+        return unescape(constant.raw_pattern)
+    return b""
+
+
+def libmagic_numeric_value(data_type: DataType, value: Union[int, float]) -> bytes:
+    """The bytes libmagic would copy into a numeric test's value union.
+
+    Args:
+        data_type: The type a definition declared, which sizes a floating point value.
+        value: The parsed value.
+
+    Returns:
+        The value's little endian bytes.
+    """
+    if isinstance(value, float):
+        base_type = getattr(data_type, "base_type", None)
+        if getattr(base_type, "num_bytes", 8) == 4:
+            return struct.pack("<f", value)
+        return struct.pack("<d", value)
+    return libmagic_field(value, 8)
+
+
+def libmagic_value(data_type: DataType, constant: Any) -> Tuple[int, bytes]:
+    """The ``vallen`` and value bytes libmagic would store for a parsed test value.
+
+    libmagic reads no value at all for the ``x`` relation, so a wildcard leaves both zeroed
+    (``file/src/apprentice.c:2407-2412``).
+
+    Args:
+        data_type: The type a definition declared.
+        constant: The value the type parsed.
+
+    Returns:
+        The value's declared length and its bytes.
+    """
+    if isinstance(constant, StringTest):
+        return constant.value_length, libmagic_string_value(constant)
+    elif isinstance(constant, MagicRegex):
+        return len(constant.pattern), constant.pattern
+    elif isinstance(constant, bytes):
+        return len(constant), constant
+    elif isinstance(constant, NumericValue) and not isinstance(constant, NumericWildcard):
+        return 0, libmagic_numeric_value(data_type, constant.value)
+    return 0, b""
+
+
 class ConstantMatchTest(MagicTest, Generic[T]):
     def __init__(
             self,
@@ -2709,6 +2991,19 @@ class ConstantMatchTest(MagicTest, Generic[T]):
         super().__init__(offset=offset, mime=mime, extensions=extensions, message=message, parent=parent)
         self.data_type: DataType[T] = data_type
         self.constant: T = constant
+
+    def libmagic_type(self) -> str:
+        return libmagic_base_type(self.data_type.name)
+
+    def libmagic_flag(self) -> int:
+        flag = super().libmagic_flag()
+        if isinstance(self.data_type, NumericDataType) and self.data_type.unsigned:
+            flag |= FLAG_UNSIGNED
+        return flag
+
+    def libmagic_value_fields(self) -> Tuple[int, bytes, bytes]:
+        value_length, value = libmagic_value(self.data_type, self.constant)
+        return value_length, libmagic_string_flags(self.data_type), value
 
     def type_strength(self) -> int:
         return self.data_type.strength_term(self.constant)
@@ -2809,6 +3104,9 @@ class OffsetMatchTest(MagicTest):
         self.subtraction: int = subtraction
         self.modulo: int = modulo
 
+    def libmagic_type(self) -> str:
+        return "offset"
+
     def type_strength(self) -> int:
         """``offset`` is an eight-byte quantity (``file/src/apprentice.c:906-908``)."""
         return 8 * STRENGTH_MULT
@@ -2873,6 +3171,9 @@ class IndirectTest(MagicTest):
             p._type = TestType.BINARY
             p = p.parent
 
+    def libmagic_type(self) -> str:
+        return "indirect"
+
     def subtest_type(self) -> TestType:
         return TestType.BINARY
 
@@ -2918,6 +3219,9 @@ class NamedTest(MagicTest):
         self.name: str = name
         self.named_test = self
         self.used_by: Set[UseTest] = set()
+
+    def libmagic_type(self) -> str:
+        return "name"
 
     def subtest_type(self) -> TestType:
         return TestType.UNKNOWN
@@ -2977,6 +3281,9 @@ class UseTest(MagicTest):
         self.flip_endianness: bool = flip_endianness
         self.late_binding: bool = late_binding
         referenced_test.used_by.add(self)
+
+    def libmagic_type(self) -> str:
+        return "use"
 
     def subtest_type(self) -> TestType:
         return self.referenced_test.test_type
@@ -3215,6 +3522,9 @@ class CSVTest(MagicTest):
 
 
 class DefaultTest(MagicTest):
+    def libmagic_type(self) -> str:
+        return "default"
+
     def subtest_type(self) -> TestType:
         return TestType.UNKNOWN
 
@@ -3240,6 +3550,9 @@ class DefaultTest(MagicTest):
 
 
 class ClearTest(MagicTest):
+    def libmagic_type(self) -> str:
+        return "clear"
+
     def subtest_type(self) -> TestType:
         return TestType.UNKNOWN
 
@@ -3276,6 +3589,9 @@ class DERTest(MagicTest):
         super().__init__(offset=offset, mime=mime, extensions=extensions, message=message,
                          parent=parent, comments=comments)
         self.specification: DERSpecification = specification
+
+    def libmagic_type(self) -> str:
+        return "der"
 
     def type_strength(self) -> int:
         """One flat unit, whatever the specification says (``file/src/apprentice.c:1024-1026``)."""
@@ -3851,8 +4167,8 @@ class MagicMatcher:
         self._tests_by_mime: Dict[str, Set[MagicTest]] = defaultdict(set)
         self._tests_by_ext: Dict[str, Set[MagicTest]] = defaultdict(set)
         self._tests_that_can_be_indirect: Set[MagicTest] = set()
-        self._non_text_tests: Set[MagicTest] = set()
-        self._text_tests: Set[MagicTest] = set()
+        self._non_text_tests: Dict[MagicTest, None] = {}
+        self._text_tests: Dict[MagicTest, None] = {}
         self._dirty: bool = True
         for test in tests:
             self.add(test)
@@ -3873,14 +4189,16 @@ class MagicMatcher:
         return self._tests_that_can_be_indirect
 
     @property
-    def non_text_tests(self) -> Set[MagicTest]:
+    def non_text_tests(self) -> KeysView[MagicTest]:
+        """The level 0 tests of `MagicMatcher.match`'s binary pass, in the order it runs them."""
         self._reassign_test_types()
-        return self._non_text_tests
+        return self._non_text_tests.keys()
 
     @property
-    def text_tests(self) -> Set[MagicTest]:
+    def text_tests(self) -> KeysView[MagicTest]:
+        """The level 0 tests of `MagicMatcher.match`'s text pass, in the order it runs them."""
         self._reassign_test_types()
-        return self._text_tests
+        return self._text_tests.keys()
 
     def add(self, test: Union[MagicTest, Path], test_type: TestType = TestType.UNKNOWN) -> List[MagicTest]:
         if not isinstance(test, MagicTest):
@@ -3912,20 +4230,35 @@ class MagicMatcher:
 
         return [test]
 
+    def _sort_tests(self):
+        """Puts the level 0 tests in the order libmagic would run them.
+
+        libmagic sorts strongest first and settles a tie with `MagicTest.libmagic_sort_key`. A tie
+        that key cannot settle keeps the order the definitions were read in, which is the order
+        libmagic itself hands its entries to ``qsort``: by definition file name
+        (``file/src/apprentice.c:1593``) and then by line.
+        """
+        self._tests.sort(key=lambda test: (
+            "" if test.source_info is None else test.source_info.path.name,
+            0 if test.source_info is None else test.source_info.line
+        ))
+        self._tests.sort(key=lambda test: test.libmagic_sort_key(), reverse=True)
+
     def _reassign_test_types(self):
         if not self._dirty:
             return
         self._dirty = False
-        self._text_tests = set()
-        self._non_text_tests = set()
+        self._sort_tests()
+        self._text_tests = {}
+        self._non_text_tests = {}
         self._tests_that_can_be_indirect = set()
         self._tests_by_ext = defaultdict(set)
         self._tests_by_mime = defaultdict(set)
         for test in self._tests:
             if test.test_type == TestType.TEXT:
-                self._text_tests.add(test)
+                self._text_tests[test] = None
             else:
-                self._non_text_tests.add(test)
+                self._non_text_tests[test] = None
             if test.can_be_indirect:
                 self._tests_that_can_be_indirect.add(test)
             for mime in test.mimetypes:
@@ -3964,6 +4297,8 @@ class MagicMatcher:
         return MagicMatcher(tests | required_named_tests)
 
     def __iter__(self) -> Iterator[MagicTest]:
+        """Yields the level 0 tests in the order `MagicMatcher.match` runs them."""
+        self._reassign_test_types()
         return iter(self._tests)
 
     @property
@@ -4299,8 +4634,6 @@ class MagicMatcher:
             assert test.can_match_mime
             for ancestor in test.ancestors():
                 ancestor.can_be_indirect = True
-        # Sort tests by strength (descending) for proper priority matching like libmagic
-        zero_level_tests.sort(key=lambda t: t.compute_strength(), reverse=True)
         for test in zero_level_tests:
             matcher.add(test)
         return matcher

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -33,10 +33,11 @@ KNOWN_FAILURES: Dict[str, int] = {
     #
     # This test ships two sidecars, which the harness loads, and a `.flags` of `k`. PolyFile
     # reports all four names as separate matches, each with its own text-encoding description, so
-    # what is left is the joined form: #3491 for the `\012- ` separator and #3477 for the strength
-    # order the parts appear in. Splitting the expected string on `\012- ` here instead would drop
-    # #3491 from that list.
-    "multiple": 3491,       # then #3477
+    # what is left is the joined form that #3491 covers: the `\012- ` separator, and one
+    # text-encoding description for the join rather than one per part. The order of the parts is
+    # already right, which `MatchOrderTest` checks directly. Splitting the expected string on
+    # `\012- ` here instead would drop #3491 from that list.
+    "multiple": 3491,
     # Text tests run against the raw bytes, so the SVG test never matches a UTF-16 file and
     # PolyFile reports only the text-encoding description.
     "utf16xmlsvg": 3489,

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1,12 +1,14 @@
 import base64
 import gzip
+import os
 import subprocess
 import sys
 import time
 import zlib
+from itertools import chain
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Callable, Dict, Iterator, List, Optional, Set, Tuple
+from typing import Callable, Dict, Iterable, Iterator, List, Optional, Set, Tuple
 from unittest import TestCase
 from uuid import UUID
 
@@ -1443,3 +1445,137 @@ class TextEncodingDescriptionTest(TestCase):
                         for mimetype in match.mimetypes
                         if mimetype is not None
                     })
+
+
+ORDER_SCRIPT: str = """
+import sys
+from polyfile.magic import MagicMatcher
+for path in sys.argv[1:]:
+    with open(path, "rb") as f:
+        data = f.read()
+    print(path, "\t".join(str(match) for match in MagicMatcher.DEFAULT_INSTANCE.match(data)))
+"""
+
+HASH_SEEDS: Tuple[str, ...] = ("0", "1", "12345")
+
+
+class MatchOrderTest(TestCase):
+    """Regression tests for the match order reported in issue #3509.
+
+    `MagicMatcher` used to hold its level 0 tests in sets, so `MagicMatcher.match` reported them
+    in set-iteration order and threw away the sort `MagicMatcher.parse` had applied. `MagicTest`
+    inherits identity hashing, which ties that order to allocation order and therefore to
+    Python's per-process hash seed, so the same input could name a different primary type on a
+    later run.
+    """
+
+    MULTI_MATCH_STEMS: Tuple[str, ...] = (
+        "HWP2016.hwpx.zip", "keyman-2", "escapevel", "issue311docx", "issue359xlsx", "osm",
+    )
+    """Corpus stems that PolyFile reports more than one match for, so their order is observable."""
+
+    def assert_strongest_first(self, tests: Iterable[polyfile.magic.MagicTest], label: str):
+        """Asserts that `tests` arrive in non-increasing order of strength.
+
+        Args:
+            tests: The level 0 tests to check, in the order something reported them.
+            label: What is being checked, for the failure message.
+        """
+        previous: Optional[polyfile.magic.MagicTest] = None
+        for test in tests:
+            if previous is not None:
+                self.assertLessEqual(
+                    test.compute_strength(), previous.compute_strength(),
+                    f"{label}: {test.source_info} has strength {test.compute_strength()}, above "
+                    f"the {previous.compute_strength()} of the {previous.source_info} before it"
+                )
+            previous = test
+
+    def test_each_pass_runs_its_tests_strongest_first(self):
+        """Tests that both of `MagicMatcher.match`'s passes are ordered, not just the test list.
+
+        This is the assertion a set cannot satisfy: over thousands of tests, an order that came
+        from hashing is not going to be non-increasing by accident.
+        """
+        matcher = MagicMatcher.DEFAULT_INSTANCE
+        self.assert_strongest_first(matcher, "the level 0 tests")
+        self.assert_strongest_first(matcher.non_text_tests, "the binary pass")
+        self.assert_strongest_first(matcher.text_tests, "the text pass")
+
+    def test_only_match_orders_the_tests_it_keeps(self):
+        """Tests that a matcher `MagicMatcher.only_match` narrowed is ordered too.
+
+        `only_match` collects its tests out of `MagicMatcher.tests_by_mime`, which holds sets, so
+        the order has to be established where the matcher stores the tests rather than where
+        `MagicMatcher.parse` reads them.
+        """
+        matcher = MagicMatcher.DEFAULT_INSTANCE.only_match(
+            mimetypes=["application/zip", "application/pdf", "image/jpeg", "text/plain"])
+        self.assert_strongest_first(matcher, "only_match")
+        self.assert_strongest_first(matcher.non_text_tests, "only_match's binary pass")
+        self.assert_strongest_first(matcher.text_tests, "only_match's text pass")
+
+    def test_matches_follow_the_order_of_the_tests_that_produced_them(self):
+        """Tests that a file's matches arrive in the order the matcher runs the tests.
+
+        The binary pass runs before the text pass, so the reported matches are not globally
+        ordered by strength; what has to hold is that they are a subsequence of the two passes.
+        """
+        self.assertTrue(FILE_TEST_DIR.exists(),
+                        "Run `git submodule init && git submodule update` in the repository root.")
+        matcher = MagicMatcher.DEFAULT_INSTANCE
+        position = {
+            test: index
+            for index, test in enumerate(chain(matcher.non_text_tests, matcher.text_tests))
+        }
+        for stem in self.MULTI_MATCH_STEMS:
+            with self.subTest(test=stem):
+                data = (FILE_TEST_DIR / f"{stem}.testfile").read_bytes()
+                tests = [match[0].test for match in matcher.match(data)]
+                self.assertGreater(len(tests), 1, f"{stem} no longer reports several matches")
+                missing = [test for test in tests if test not in position]
+                self.assertEqual([], missing, f"{stem} matched a test the matcher does not hold")
+                indices = [position[test] for test in tests]
+                self.assertEqual(sorted(indices), indices)
+
+    def test_equal_strengths_break_the_way_libmagic_breaks_them(self):
+        """Tests the tie-break `apprentice_sort` applies, over `file/tests/multiple`'s sidecars.
+
+        Those two definition files declare two tests of strength 40 and two of 38, and
+        `file/tests/multiple.result` requires `Viva File 2.0`, `RTF1.0`, `Test File 1.0`,
+        `ABCD File`. Strength does not decide either pair. libmagic compares the two entries'
+        `struct magic` bytes and takes the greater one first
+        (`file/src/apprentice.c:1132-1149`), and for both pairs the first field that differs is
+        `offset`, so the test that reads further into the file wins.
+        """
+        self.assertTrue(FILE_TEST_DIR.exists(),
+                        "Run `git submodule init && git submodule update` in the repository root.")
+        matcher = MagicMatcher.parse(FILE_TEST_DIR / "multiple-A.magic",
+                                     FILE_TEST_DIR / "multiple-B.magic")
+        self.assertEqual([40, 40, 38, 38], [test.compute_strength() for test in matcher])
+        self.assertEqual(["Viva File 2.0", "RTF1.0", "Test File 1.0", "ABCD File"],
+                         [str(test.message) for test in matcher])
+
+    def test_match_order_does_not_depend_on_the_hash_seed(self):
+        """Tests that separate processes report a file's matches in the same order.
+
+        Python randomizes the hash seed per process unless `PYTHONHASHSEED` is set, so this is
+        what made the old behavior reach users rather than only showing up under a debugger.
+        """
+        self.assertTrue(FILE_TEST_DIR.exists(),
+                        "Run `git submodule init && git submodule update` in the repository root.")
+        paths = [str(FILE_TEST_DIR / f"{stem}.testfile") for stem in self.MULTI_MATCH_STEMS]
+        command = [sys.executable, "-c", ORDER_SCRIPT, *paths]
+        reported: Dict[str, str] = {}
+        for seed in HASH_SEEDS:
+            environment = dict(os.environ, PYTHONHASHSEED=seed)
+            try:
+                result = subprocess.run(command, capture_output=True, check=True,
+                                        env=environment, timeout=MATCH_TIMEOUT_SECONDS)
+            except subprocess.CalledProcessError as e:
+                self.fail(f"PYTHONHASHSEED={seed} failed: {e.stderr.decode('utf-8', 'replace')}")
+            reported[seed] = result.stdout.decode("utf-8")
+        detail = "".join(f"PYTHONHASHSEED={seed}:\n{output}"
+                         for seed, output in reported.items())
+        self.assertEqual(1, len(set(reported.values())),
+                         f"the match order differs between hash seeds:\n{detail}")


### PR DESCRIPTION
Closes #3509

`MagicMatcher.parse` sorted the level 0 tests by descending strength and then threw that order
away, because the matcher stored them in `set`s and `MagicMatcher.match` iterated those.
`MagicTest` inherits identity hashing, so iteration followed allocation order, which Python's
per-process hash seed perturbs. The first line of the `file`-style output, which a reader takes as
the primary type, could therefore differ between runs of the same input.

## The structure

`_non_text_tests` and `_text_tests` become `Dict[MagicTest, None]`, used as insertion-ordered
sets, and the properties return their `.keys()`. A `KeysView` still supports `&`, `|`, `in` and
`len`, so every existing caller keeps working unchanged, and it also has a defined iteration
order.

The sort moved out of `MagicMatcher.parse` and into `_reassign_test_types`, which is where the
matcher builds its derived collections. That way every construction path is ordered, not just
`parse`: `MagicMatcher.only_match` collects its tests out of `tests_by_mime`, which holds sets, so
a sort in `parse` alone would have left a narrowed matcher unordered. `__iter__` now establishes
the same order before yielding.

## The tie-break

`apprentice_sort` (`file/src/apprentice.c:1126-1152`) sorts by descending strength, and on a tie
compares the two entries' raw `struct magic` bytes with `memcmp` — `lineno` zeroed first — taking
the greater one first.

The `@N` in `file -l`'s output is **not** a rank or a tie-break input. `apprentice_list` prints
`ml->magic[lineindex].lineno` (`file/src/apprentice.c:1447`), so it is just the entry's line number
in its definition file. What actually orders `Viva File 2.0` before `RTF1.0`, and `Test File 1.0`
before `ABCD File`, is the `offset` field: it is the first place those pairs' structs differ (16 vs
0, and 10 vs 6), and it is compared as little-endian bytes, descending. So for both pairs the test
that reads further into the file wins, and their line numbers agreeing with that is a coincidence
of these two files.

`MagicTest.libmagic_sort_key` repeats that comparison over the fields that decide it, in memory
order: `flag`, `factor`, `reln`, `vallen`, `type`, `in_type`, `factor_op`, `offset`, the
`str_range`/`str_flags` word, and the value. It stops there. `desc`, `mimetype`, `apple` and `ext`
follow in the struct, but libmagic writes a definition file's *name* into an empty `desc`
(`file/src/apprentice.c:2438`) and PolyFile has already unescaped the description, so neither
compares byte for byte. `in_op`, `mask_op` and `in_offset` are skipped because PolyFile folds each
of them into a callable rather than keeping the number, and `BINTEST`/`TEXTTEST` are left out of
`flag` because they only record which of `match`'s two passes a test belongs to, which is constant
for any pair whose relative order is observable. A tie the key cannot settle keeps the order the
definitions were read in, which is the order libmagic itself hands its entries to `qsort`
(`file/src/apprentice.c:1593`), so the result is a total order either way.

`LIBMAGIC_TYPE_CODES` is a copy of libmagic's `type_tbl` (`file/src/apprentice.c:216-283`), because
the tie-break compares the type's *number*, not its name.

## Evidence

`test_file_corpus` asserts the expected description is *among* the matches, not that it is first,
so the corpus differential cannot see an ordering change. These measurements are the actual safety
net.

**Agreement with libmagic's own order.** For each of the 361 bundled definition files, `file -l -m
<file>` prints that file's level 0 tests in libmagic's sorted order. Comparing PolyFile's order for
the same tests, over the 250 listings that hold more than one test (3710 tests):

| sort key | listings in exactly libmagic's order | equal-strength pairs ordered as libmagic does |
| --- | --- | --- |
| strength only | 91/250 | 11661/28067 (41.5%) |
| `libmagic_sort_key` | **233/250** | **27797/28067 (99.0%)** |

The 17 listings that still differ are cases the emulated prefix does not reach, mostly ties that
libmagic settles on `desc` or on a numeric mask. One unrelated strength mismatch showed up in the
same sweep: `ctf:22` scores 100 in PolyFile against libmagic's 105.

**Determinism.** Ten multi-match inputs, each matched in six separate processes with
`PYTHONHASHSEED` set to 0, 1, 2, 7, 12345 and `random`:

| | stable | unstable |
| --- | --- | --- |
| before | 2/10 | 8/10 |
| after | **10/10** | 0 |

`polymocks/multi` from the Corkami corpus reports 44 matches and gave a different order under all
six seeds before; it now gives one. `file/tests/HWP2016.hwpx.zip.testfile` gave four different
orders and now gives one.

**Strength ordering.** `MatchOrderTest` asserts the strengths are non-increasing across the level 0
tests, across each of the two passes, and across a matcher `only_match` narrowed. Over thousands of
tests that is an assertion a hash-derived order will not satisfy by accident, which is what makes it
a guard against the sets coming back.

**Primary-type agreement.** For each libmagic corpus test whose `.result` names a single type (no
`\012- ` join), does PolyFile's *first* reported match correspond to it? Counting only the 86 files
where PolyFile reports that type at all:

| | first line agrees |
| --- | --- |
| before, `PYTHONHASHSEED=0` | 82/86 |
| before, `PYTHONHASHSEED=1` | 79/86 |
| before, `PYTHONHASHSEED=2` | 78/86 |
| before, `PYTHONHASHSEED=7` | 80/86 |
| before, `PYTHONHASHSEED=12345` | 77/86 |
| after, every seed | **83/86** |

So the change fixes `gpkg-1-zst`, `escapevel`, `issue311docx`, `issue359xlsx` and `keyman-2`
depending on which seed you compare against, and moves nothing the other way: 83 is at or above
every "before" figure. The three that still disagree are not ordering problems. `cmd3` and `cmd4`
differ on the text/binary classification (#3490, #3511). `HWP2016.hwpx.zip` reports a `Microsoft
OOXML` match of strength 81 that libmagic does not report at all, so PolyFile's strongest match is
one libmagic never considers.

**The `multiple` sidecars.** `file/tests/multiple-A.magic` and `multiple-B.magic` now come out in
libmagic's order:

```
40 multiple-A.magic:2 Viva File 2.0
40 multiple-A.magic:1 RTF1.0
38 multiple-B.magic:2 Test File 1.0
38 multiple-B.magic:1 ABCD File
```

which is what `file -l -m "multiple-A.magic:multiple-B.magic"` prints and the order
`multiple.result` requires. The stem stays in `KNOWN_FAILURES`: #3491 still owes the `\012- `
separator and one text-encoding description for the join rather than one per part. Its note in
`KNOWN_FAILURES` no longer names #3477, since the order is no longer what blocks it.

## Verification

```
corpus_diff.py                     NEWLY PASSING (12), STILL FAILING (2), REGRESSIONS (0)
pytest tests                       1082 passed, 3 skipped, 785 subtests, 3 warnings, 1:46
flake8 (project settings)          226 findings, unchanged from d5eac81
flake8 --select=E9,F63,F7,F82      0
```

The 3 warnings are the pre-existing `SyntaxWarning`s from generated Kaitai parsers (#3462). The
five new tests account for the 1077 → 1082 and 779 → 785 counts.

Each new test was checked against a deliberately broken fix: returning the two passes as sets fails
three of them, dropping the sort fails three, replacing the tie-break with a strength-only key fails
the `multiple` case, and reversing the binary pass fails the subsequence check.

**Timing.** Building the key for all 3868 tests and sorting them costs about 17 ms, paid once per
matcher when its derived collections are first built (28 ms → 45 ms for that step). `only_match`
now sorts the matcher it returns, which takes it from 2 ms to 18 ms. Matching itself is unchanged
(20 ms for the 44-match input, before and after), and `only_match`'s membership tests are untouched
because `tests_by_mime`, `tests_by_ext` and `tests_that_can_be_indirect` are still sets. `pytest
tests` is 1:46 against a 1:48 baseline, which is noise.

## A latent bug found on the way

`MagicMatcher.parse` and `add` both accept a `str` for a definition file and hand it straight to
`SourceInfo`, whose annotation claims `Path`. Every reader reaches for `.path.name` — the debugger's
breakpoint matching, `MagicTest.write`, the repr — so passing a `str` raised `AttributeError` in
those paths. `SourceInfo` now coerces, in its own commit.

## Merge order and conflicts

- This unblocks #3491: the `\012- ` join needs a defined order to join in, and now has one.
- #3489 (`utf16xmlsvg`) is independent of this and can land in either order.
- #3511 touches `StringMatch.is_always_text` and regenerates `test_text_tests`'s expected set. This
  branch touches neither: it does not read `is_always_text`, and the only reason it could have
  touched `test_text_tests` was the `matcher.text_tests & matcher.non_text_tests` set operations in
  it, which is exactly why the passes return `KeysView`s rather than lists. The one shared file is
  `tests/test_magic.py`, where this branch appends a class at the end and edits the `multiple` note
  in `KNOWN_FAILURES`; #3511's edits are in `test_text_tests` around line 212.
- #3511 will change which pass some tests run in. That moves tests between the two ordered
  collections but cannot disturb the order within either, because `libmagic_sort_key` deliberately
  omits the `BINTEST`/`TEXTTEST` bits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VS8hTTRQeG8ZCmCZ9KLHiV
