### PR TITLE
Join matches the way file -k joins them

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -4176,6 +4176,69 @@ class Match:
     __str__ = message
 
 
+MATCH_SEPARATOR: str = "\n- "
+"""What libmagic puts between the matches it joins.
+
+``FILE_SEPARATOR`` in ``src/funcs.c``, printed by ``file_separator`` after every check that
+matched and trimmed off the end again by ``trim_separator``.
+"""
+
+
+def octal_escape(description: str) -> str:
+    """Escapes the characters `file` escapes when it is not run with ``-r``.
+
+    ``file_getbuffer`` in libmagic's ``src/funcs.c`` copies its output buffer verbatim when
+    ``MAGIC_RAW`` is set, and otherwise replaces every character it cannot print with a
+    backslash and three octal digits per byte. That is why ``file/tests/multiple.result`` holds
+    the separator's line feed as ``\\012``.
+
+    Args:
+        description: the description to escape.
+
+    Returns:
+        `description` with each unprintable character replaced by the octal escape of its UTF-8
+        bytes.
+    """
+    escaped: List[str] = []
+    for character in description:
+        if character.isprintable():
+            escaped.append(character)
+        else:
+            escaped.extend(f"\\{byte:03o}" for byte in character.encode("utf-8"))
+    return "".join(escaped)
+
+
+def join_matches(matches: Iterable[Match], raw: bool = False) -> str:
+    """Describes several matches the way ``file -k`` describes them, in one string.
+
+    ``MAGIC_CONTINUE`` does not change which checks libmagic runs; it changes how their messages
+    reach the one output buffer libmagic prints. Every check that matched appends its message and
+    a `MATCH_SEPARATOR`, ``file_ascmagic`` then rewrites the tail of that whole buffer, and
+    ``file_getbuffer`` escapes it. So the text-encoding description lands once, after the last
+    match, rather than once per match, and this consumes the matches `MagicMatcher.match` yields
+    without changing them.
+
+    Args:
+        matches: the matches to describe, in the order `MagicMatcher.match` reported them.
+        raw: whether to skip the escaping, as libmagic's ``MAGIC_RAW`` does.
+
+    Returns:
+        The joined description, which is empty when `matches` is.
+    """
+    text_encoding: Optional[TextEncodingDescription] = None
+    parts: List[str] = []
+    for match in matches:
+        parts.append(match._soft_magic_message())
+        if match.text_encoding is not None:
+            text_encoding = match.text_encoding
+    joined = MATCH_SEPARATOR.join(parts)
+    if text_encoding is not None:
+        joined = text_encoding.describe(joined)
+    if raw:
+        return joined
+    return octal_escape(joined)
+
+
 class DefaultMagicMatcher:
     _DEFAULT_INSTANCE: Optional["MagicMatcher"] = None
 

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -31,13 +31,6 @@ KNOWN_FAILURES: Dict[str, int] = {
     # has to be fixed first, and the trailing comment names what blocks the stem after that.
     # Issue #3480 tracks the whole set.
     #
-    # This test ships two sidecars, which the harness loads, and a `.flags` of `k`. PolyFile
-    # reports all four names as separate matches, each with its own text-encoding description, so
-    # what is left is the joined form that #3491 covers: the `\012- ` separator, and one
-    # text-encoding description for the join rather than one per part. The order of the parts is
-    # already right, which `MatchOrderTest` checks directly. Splitting the expected string on
-    # `\012- ` here instead would drop #3491 from that list.
-    "multiple": 3491,
     # Text tests run against the raw bytes, so the SVG test never matches a UTF-16 file and
     # PolyFile reports only the text-encoding description.
     "utf16xmlsvg": 3489,
@@ -90,8 +83,8 @@ def corpus_flags(test: str) -> str:
     Upstream's runner appends the contents of `<stem>.flags` to the flags it hands to
     `magic_open` (`file/tests/Makefile.am` and `file/tests/test.c`). `k` is `MAGIC_CONTINUE`,
     which makes `file` report every match instead of only the strongest one, joining them with
-    `\\012- `. PolyFile always reports every match and never builds that join (issue #3491), so
-    the harness only reports the flags rather than emulating them.
+    `\\012- `. PolyFile always reports every match, so `check_corpus_test` renders that join with
+    `polyfile.magic.join_matches` for the tests whose flags ask for it.
 
     Args:
         test: The stem shared by the test's `.testfile`, `.result` and `.flags` files.
@@ -524,7 +517,10 @@ class MagicTest(TestCase):
         print(f"\tExpected: {expected!r}")
 
         with open(testfile, "rb") as f:
-            matches = {str(match) for match in matcher.match(f.read())}
+            reported = list(matcher.match(f.read()))
+        matches = {str(match) for match in reported}
+        if "k" in flags:
+            matches.add(polyfile.magic.join_matches(reported))
         for actual in sorted(matches):
             print(f"\tActual:   {actual!r}")
 

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1721,3 +1721,136 @@ class MatchOrderTest(TestCase):
                          for seed, output in reported.items())
         self.assertEqual(1, len(set(reported.values())),
                          f"the match order differs between hash seeds:\n{detail}")
+
+
+class MatchJoinTest(TestCase):
+    """Tests for the joined description reported in issue #3491.
+
+    `file -k` renders every match into one description rather than reporting only the strongest,
+    and `file/tests/multiple.result` is the corpus expectation that records the format. Every
+    string these tests expect is what `file -b -k` prints for the same input, checked against
+    libmagic 5.48 built from the `file` submodule.
+    """
+
+    TWO_TEXT_TESTS: str = "0\tstring/t\tMARKED\tFirst file text\n0\tstring/t\tMARK\tSecond\n"
+    """Two text tests that both match `MARKED`.
+
+    Their strings are 6 and 4 bytes long, so their strengths differ and the order of the join
+    does not rest on the tie-break issue #3509 settled. The first message ends in the ` text`
+    that libmagic splices out, which it must keep because the splice lands on the last part.
+    """
+
+    ONE_TEXT_TEST: str = "0\tstring/t\tMARK\tOnly file text\n"
+    """A single text test, so there is nothing to separate."""
+
+    CONTROL_CHARACTER_TEST: str = "0\tstring\tMARK\tMarked\n>4\tbyte\tx\t, code %c\n"
+    """A binary test that prints a byte of the file as a character, as libmagic's tar check does
+    for `file/tests/JW07022A.mp3.testfile`."""
+
+    @staticmethod
+    def matcher(definition: str) -> MagicMatcher:
+        """Parses a single magic definition.
+
+        Args:
+            definition: The text of a magic definition file, with tab-separated columns.
+
+        Returns:
+            A matcher holding just that definition's tests.
+        """
+        with TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "match_join"
+            path.write_text(definition)
+            return MagicMatcher.parse(path)
+
+    def join(self, definition: str, data: bytes, raw: bool = False) -> str:
+        """Describes every match one definition reports for `data`, in one string.
+
+        Args:
+            definition: The text of a magic definition file, with tab-separated columns.
+            data: The bytes to classify.
+            raw: Whether to skip the escaping, as libmagic's `MAGIC_RAW` does.
+
+        Returns:
+            The joined description.
+        """
+        return polyfile.magic.join_matches(self.matcher(definition).match(data), raw=raw)
+
+    def test_two_matches_are_joined_with_an_escaped_separator(self):
+        """Tests that the join uses libmagic's separator, escaped the way `file` escapes it.
+
+        `FILE_SEPARATOR` is `\\n- ` (`file/src/funcs.c:276`), and `file_getbuffer` octal-escapes
+        the line feed unless `MAGIC_RAW` is set, which is why `file/tests/multiple.result` holds
+        `\\012- `.
+        """
+        self.assertEqual("First file text\\012- Second, ASCII text, with no line terminators",
+                         self.join(self.TWO_TEXT_TESTS, b"MARKED"))
+
+    def test_the_raw_form_keeps_the_separator_unescaped(self):
+        """Tests that `raw` reports the line feed itself, as `file -r` does."""
+        self.assertEqual("First file text\n- Second, ASCII text, with no line terminators",
+                         self.join(self.TWO_TEXT_TESTS, b"MARKED", raw=True))
+
+    def test_the_encoding_description_is_appended_once(self):
+        """Tests that only the last part carries the text-encoding description.
+
+        libmagic keeps one output buffer, so `file_ascmagic` rewrites the tail of the whole join
+        rather than each part (`file/src/ascmagic.c:235-258`). Issue #3488 attaches the
+        description to every match, which is right for one description per line, so joining those
+        strings directly would report the encoding once per part. That the first part still ends
+        in ` text` is the other half of the evidence: the splice reached only the last part.
+        """
+        joined = self.join(self.TWO_TEXT_TESTS, b"MARKED", raw=True)
+        self.assertEqual(1, joined.count("ASCII text"))
+        self.assertEqual(["First file text", "Second, ASCII text, with no line terminators"],
+                         joined.split(polyfile.magic.MATCH_SEPARATOR))
+
+    def test_joining_does_not_change_what_each_match_reports(self):
+        """Tests that the join leaves the per-match descriptions issue #3488 produces alone.
+
+        `--format file` prints one match per line, and each of those lines has to stand on its
+        own, so the join must not reach into the matches to move the description.
+        """
+        matches = list(self.matcher(self.TWO_TEXT_TESTS).match(b"MARKED"))
+        polyfile.magic.join_matches(matches)
+        self.assertEqual({"First file, ASCII text, with no line terminators",
+                          "Second, ASCII text, with no line terminators"},
+                         {str(match) for match in matches})
+
+    def test_a_single_match_is_its_own_description(self):
+        """Tests that one match joins to just its description, with no separator.
+
+        `trim_separator` (`file/src/funcs.c:284`) takes the trailing separator back off, so a
+        lone match reads exactly as it does without `-k`.
+        """
+        self.assertEqual("Only file, ASCII text, with no line terminators",
+                         self.join(self.ONE_TEXT_TEST, b"MARK"))
+
+    def test_the_parts_follow_the_order_of_the_matches(self):
+        """Tests the join against `file/tests/multiple.result`, the corpus expectation.
+
+        The four parts come out in the order `MagicMatcher.match` reports them, which issue #3509
+        made libmagic's own order. Reordering them here would hide a regression in that.
+        """
+        self.assertTrue(FILE_TEST_DIR.exists(),
+                        "Run `git submodule init && git submodule update` in the repository root.")
+        matcher = MagicMatcher.parse(FILE_TEST_DIR / "multiple-A.magic",
+                                     FILE_TEST_DIR / "multiple-B.magic")
+        data = (FILE_TEST_DIR / "multiple.testfile").read_bytes()
+        self.assertEqual(
+            "Viva File 2.0\\012- RTF1.0\\012- Test File 1.0\\012- ABCD File, ASCII text, "
+            "with no line terminators",
+            polyfile.magic.join_matches(matcher.match(data))
+        )
+
+    def test_an_unprintable_character_is_octal_escaped(self):
+        """Tests that the escaping covers more than the separator's line feed.
+
+        `file_getbuffer` escapes every character it cannot print, not just the one the separator
+        contributes, which is how the `-k` description of `file/tests/JW07022A.mp3.testfile`
+        reports the byte 2 in an ID3 field as `\\002`.
+        """
+        self.assertEqual("Marked , code \\002",
+                         self.join(self.CONTROL_CHARACTER_TEST, b"MARK\x02\x00\x00\x00rest"))
+        self.assertEqual("Marked , code \x02",
+                         self.join(self.CONTROL_CHARACTER_TEST, b"MARK\x02\x00\x00\x00rest",
+                                   raw=True))


### PR DESCRIPTION
Closes #3491

`file -k` renders every match into one description instead of reporting only the strongest.
`file/tests/multiple.result` is the corpus expectation that records the format, and it was the
last failing stem of the libmagic corpus.

## Where the join lives

`polyfile.magic.join_matches(matches, raw=False)`, a module-level function next to `Match`.

libmagic's `MAGIC_CONTINUE` is a flag on `magic_open`, but it does not change which checks run:
`checkdone` (`file/src/funcs.c:303-310`) only decides whether the run stops after a check matched,
and every check appends to the one output buffer either way. So the flag governs how matches are
rendered into a description, not which matches are found. `join_matches` matches that: it consumes
the matches `MagicMatcher.match` yields and returns a string. Nothing about matching changes, and
PolyFile still reports every match.

A method on `Match` would have to belong to one of the matches being joined, and an option on
`MagicMatcher` would put a rendering choice on the object that finds matches, which is the thing
this issue must not touch.

## How the single trailer is achieved

libmagic keeps one output buffer. Soft magic appends each match's message and a separator,
`file_ascmagic` then rewrites the tail of that whole buffer (`file/src/ascmagic.c:235-258`), so only
the last part carries the text-encoding description:

```console
$ TZ=UTC ./file/src/file -b -k -r -m "file/tests/multiple-A.magic:file/tests/multiple-B.magic" \
      file/tests/multiple.testfile
Viva File 2.0
- RTF1.0
- Test File 1.0
- ABCD File, ASCII text, with no line terminators
```

PolyFile yields independent matches, and #3488 attaches the description to each one, which is right
for `--format file`, where every line has to stand on its own. Joining `str(match)` would report the
encoding once per part. #3488 left the seam this needs: it computes the description once per context,
stores it as `Match.text_encoding`, and splits `Match.message` into `Match._soft_magic_message()`
plus the trailer. `join_matches` joins the `_soft_magic_message()` values and applies the context's
one `TextEncodingDescription.describe` to the result.

The ` text` splice is part of that. `First file text\012- Second, ASCII text` keeps the first part's
` text` because `file_replace(ms, " text$", ", ")` reaches only the end of the buffer, and applying
`describe` to the joined string reproduces that for free.

## The escaping

`file_getbuffer` (`file/src/funcs.c:562`) returns the buffer verbatim under `MAGIC_RAW` and otherwise
replaces every character it cannot print with a backslash and three octal digits per byte, which is
why `multiple.result` holds the separator's line feed as `\012`. `octal_escape` does that for the
joined description, and `join_matches(..., raw=True)` skips it.

It is not only the separator. The `-k` description of `file/tests/JW07022A.mp3.testfile` carries a
byte 2 from an ID3 field inside a tar description, and both `file` and PolyFile report it as `\002`.
That file is the only corpus test file whose PolyFile descriptions hold an unprintable character, and
none of the 88 hold a non-ASCII one.

## Before and after for `multiple`

```console
$ TZ=UTC ./file/src/file -b -k -m "file/tests/multiple-A.magic:file/tests/multiple-B.magic" \
      file/tests/multiple.testfile
Viva File 2.0\012- RTF1.0\012- Test File 1.0\012- ABCD File, ASCII text, with no line terminators
```

Before, PolyFile reported the four matches with a description each, and there was no way to express
the expectation:

```
'Viva File 2.0, ASCII text, with no line terminators'
'RTF1.0, ASCII text, with no line terminators'
'Test File 1.0, ASCII text, with no line terminators'
'ABCD File, ASCII text, with no line terminators'
```

After, those four are unchanged and `join_matches` renders them as:

```
'Viva File 2.0\012- RTF1.0\012- Test File 1.0\012- ABCD File, ASCII text, with no line terminators'
```

which is `multiple.result` exactly. The order comes from #3509 and is consumed as given.

## How the corpus harness gets the joined form

`file/tests/multiple` is the only corpus test that ships a `.flags` file, and its flag is `k`, so it
is the only test whose `.result` holds a joined description. `check_corpus_test` adds the joined form
to the set of candidate descriptions when the test's flags ask for it:

```python
matches = {str(match) for match in reported}
if "k" in flags:
    matches.add(polyfile.magic.join_matches(reported))
```

`corpus_result_matches` and `assert_corpus_verdict` are untouched. The other 87 stems ship no flags,
so nothing is added to the set their assertion compares against and their assertion is unchanged.
`multiple` comes out of `KNOWN_FAILURES`, which leaves `utf16xmlsvg` (#3489).

## The `file -b -k` comparison

Over all 88 corpus test files, comparing `join_matches` against
`file -b -k -m <the test's sidecars or magic.mgc>`:

| | count |
|---|---|
| identical | 6 |
| identical after two `-k` artifacts are dropped from libmagic's string | 41 |
| differ only in where the parts are split | 15 |
| differ in content | 26 |

The two artifacts are a trailing `\012- data` part, from `file_default` printing `data` after
`file_ascmagic` declined a binary file with the run already continued (`funcs.c:504-511`), and empty
parts, from a check that matched but printed nothing. PolyFile reports no match for either.

The 15 that differ only in part boundaries are the ones where libmagic emits a separator *inside* one
entry. `print_sep` at `softmagic.c:445-465` fires on an entry's first printing continuation when
nothing has printed for that entry yet, which happens whenever a `use` recursion or an empty level 0
description means the entry's own test printed nothing. So libmagic's parts are finer-grained than one
per level 0 entry, and PolyFile, which has one `Match` per level 0 test, has no boundary there:

```
file:     'Animated PNG image data, 100 x 100, 8-bit/color RGBA, non-interlaced\012- , 20 frames, play indefinitely'
polyfile: 'Animated PNG image data, 100 x 100, 8-bit/color RGBA, non-interlaced, 20 frames, play indefinitely'
```

Concatenating across those separators makes the two strings identical. The others in this group are
`apng-ffmpeg`, `bcachefs`, `bcachefs2`, `efi-signature-list-sha256`, `pnm1`, `pnm3` and eight
`pgp-binary-key-*` files.

The 26 that differ in content differ because the set of matches differs, not because of the format:

- 11 files where `-k` makes libmagic run on to `file_ascmagic` after a check that would otherwise have
  ended the run, so the text-encoding description arrives as another part: `json1` through `json8`,
  `jsonlines1`, `CVE-2014-1943`, `pnm2`, `regex-eol`, `searchbug`. PolyFile reports
  `JSON text data` where `file -k` reports `JSON text data\012- , ASCII text`, which is #3488's
  `appends_text_encoding` being right for one description per line.
- 6 where PolyFile reports a match libmagic does not: `cmd1` through `cmd4` and `matilde.arm` report
  both the `script text executable` and the `script executable (binary data)` variant, and
  `HWP2016.hwpx.zip` reports `Microsoft OOXML` (#3517).
- 5 where libmagic's zip entry contributes parts PolyFile does not report: `escapevel`,
  `issue311docx`, `issue359xlsx`, `keyman-2`, `HWP2016.hwpx.zip`.
- 4 pre-existing message differences: `HWP2016.hwp` (the `hancom hwp` case `corpus_result_matches`
  already works around), `gpkg-1-zst` (PolyFile prints empty tar fields libmagic omits), `uf2` (the
  `%#8.8x` zero, the other case `corpus_result_matches` works around), and `utf16xmlsvg` (#3489).

The format itself holds on all 88. Each joined description has exactly one separator fewer than the
number of matches, the encoding name appears exactly once and only in the last part, and no
unprintable character survives the escaping.

## Verification

Corpus differential against the 14 stems that master skipped at 36602cb:

```
NEWLY PASSING (13): ['JW07022A.mp3', 'cmd1', 'cmd2', 'cmd3', 'cmd4', 'gedcom', 'jpeg-text',
                     'jsonlines1', 'multiple', 'osm', 'pnm1', 'pnm2', 'pnm3']
STILL FAILING (1): ['utf16xmlsvg']
REGRESSIONS   (0):
```

The 12 stems other than `multiple` were fixed by earlier PRs in #3480.

```
$ pytest tests -q
1101 passed, 3 skipped, 3 warnings, 785 subtests passed in 181.32s
```

Master at e8e720d reports 1094 passed, 3 skipped, 785 subtests, 3 warnings, so this adds 7 tests and
loses none. The 3 warnings are the pre-existing `SyntaxWarning`s from the generated Kaitai parsers
(#3462).

```
$ flake8 polyfile polymerge tests --max-complexity=10 --max-line-length=127 \
      --exclude=polyfile/kaitai/parsers | wc -l
226
$ flake8 polyfile polymerge tests --exclude=polyfile/kaitai/parsers --select=E9,F63,F7,F82 --count
0
```

226 is master's count; the only difference in the output is two line numbers shifting.

## The CLI

No new flag. `--format file` prints one match per line, deduped, and that already reports every match,
which is what `-k` exists to turn on. A `--continue`-style flag would only change which of two
renderings of the same matches gets printed, and nobody has asked for the joined one; the corpus
harness is the only caller. Adding it would be configuration without a user.

## Tests

`MatchJoinTest` in `tests/test_magic.py`, alongside `TextEncodingDescriptionTest` and
`MatchOrderTest`. Every string it expects is `file -b -k` output for the same input, checked against
libmagic 5.48 built from the `file` submodule:

- two matches join with `\012- `, and with `\n- ` under `raw=True`
- the encoding description appears exactly once and only on the last part, and the first part keeps
  the ` text` the splice did not reach
- joining leaves the per-match descriptions #3488 produces alone
- a single match joins to just its own description
- the parts follow the order of the matches, over `multiple`'s sidecars against `multiple.result`
- an unprintable character is octal-escaped, and is not under `raw=True`

Each was checked by breaking the corresponding part of the join and confirming the test fails:
appending the trailer per part, dropping the escaping, changing the separator, leaving the trailing
separator on, sorting the parts, moving the description off the matches, and escaping printable
characters too. Every breakage was caught, and removing the harness's `join_matches` call makes the
`multiple` corpus subtest fail.

## Merge order

Independent of #3489, which is the other stem in `KNOWN_FAILURES`. Expect a `tests/test_magic.py`
merge with it: both PRs remove one entry from the same two-entry map and both append a test class.
Neither touches the other's code. Whichever lands second resolves those two hunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VS8hTTRQeG8ZCmCZ9KLHiV
