### PR TITLE
Fix data type interning collisions

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -1841,7 +1841,7 @@ class StringType(DataType[StringTest]):
             num_bytes: Optional[int] = None
     ):
         if not any((num_bytes is not None, case_insensitive_lower, case_insensitive_upper, compact_whitespace,
-                    optional_blanks, trim, force_text)):
+                    optional_blanks, full_word_match, trim, force_text)):
             name = "string"
         else:
             if num_bytes is not None:
@@ -2256,7 +2256,8 @@ class RegexType(DataType[MagicRegex]):
             case_insensitive: bool = False,
             match_to_start: bool = False,
             limit_lines: bool = False,
-            trim: bool = False
+            trim: bool = False,
+            force_text: bool = False
     ):
         if length is None:
             if limit_lines:
@@ -2268,12 +2269,15 @@ class RegexType(DataType[MagicRegex]):
         self.case_insensitive: bool = case_insensitive
         self.match_to_start: bool = match_to_start
         self.trim: bool = trim
+        self.force_text: bool = force_text
         super().__init__(f"regex/{self.length}{['', 'c'][case_insensitive]}{['', 's'][match_to_start]}"
-                         f"{['', 'l'][self.limit_lines]}{['', 'T'][self.trim]}")
+                         f"{['', 'l'][self.limit_lines]}{['', 'T'][self.trim]}{['', 't'][self.force_text]}")
 
     DOLLAR_PATTERN = re.compile(rb"(^|[^\\])\$", re.MULTILINE)
 
     def is_text(self, value: MagicRegex) -> bool:
+        if self.force_text:
+            return True
         try:
             _ = value.pattern.decode("ascii")
             return True
@@ -2375,7 +2379,8 @@ class RegexType(DataType[MagicRegex]):
             case_insensitive="c" in options,
             match_to_start="s" in options,
             limit_lines="l" in options,
-            trim="T" in options
+            trim="T" in options,
+            force_text="t" in options
         )
 
 

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -777,6 +777,26 @@ class RegexSemanticsTest(TestCase):
                          self.messages(self.relative_offset_definition("/s", "bb"), self.DATA))
 
 
+class DataTypeInterningTest(TestCase):
+    """Regression tests for type interning collisions reported in issue #3515."""
+
+    def test_string_full_word_flag_is_part_of_the_type_name(self):
+        plain = DataType.parse("string")
+        full_word = DataType.parse("string/f")
+
+        self.assertIsNot(plain, full_word)
+        self.assertTrue(plain.match(b"wordy", plain.parse_expected("word")))
+        self.assertFalse(full_word.match(b"wordy", full_word.parse_expected("word")))
+
+    def test_regex_force_text_flag_is_part_of_the_type_name(self):
+        plain = DataType.parse("regex")
+        force_text = DataType.parse("regex/t")
+
+        self.assertIsNot(plain, force_text)
+        self.assertFalse(plain.is_text(plain.parse_expected(r"\xff")))
+        self.assertTrue(force_text.is_text(force_text.parse_expected(r"\xff")))
+
+
 class StringDataTypeTest(TestCase):
     """Regression tests for the `string` data type defects reported in issue #3483."""
 


### PR DESCRIPTION
Fixes #3515

DataType.parse() interns parsed types by DataType.name, but StringType omitted full_word_match and RegexType omitted the force-text t flag from that name. As a result, string/string/f and regex/regex/t could silently share a cached instance.

This patch includes both omitted flags in the canonical names, preserves regex force-text classification, and adds focused regressions for distinct identity and behavior.

Validation:
- uv run pytest tests/test_magic.py -k DataTypeInterningTest -q
- uv run pytest tests/test_magic.py -q
- git diff --check

AI disclosure: This PR was prepared with AI assistance and is a minimal implementation of issue #3515.