### PR TITLE
Run text tests against libmagic's decoded UCS buffer

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -791,15 +791,55 @@ class SourceInfo:
 
 
 class MatchContext:
-    def __init__(self, data: bytes, path: Optional[Path] = None, only_match_mime: bool = False):
+    """A buffer to run tests against, and where that buffer came from."""
+
+    def __init__(
+            self,
+            data: bytes,
+            path: Optional[Path] = None,
+            only_match_mime: bool = False,
+            decoded_from: Optional[str] = None
+    ):
+        """
+        Args:
+            data: the bytes the tests read.
+            path: the file `data` came from, if there is one.
+            only_match_mime: whether to discard matches that name no MIME type.
+            decoded_from: the encoding `data` was decoded from, if `data` is a rendering of the
+                file's bytes rather than the bytes themselves. Offsets into `data` are then
+                offsets into that rendering, not into the file.
+        """
         self.data: bytes = data
         self.path: Optional[Path] = path
         self.only_match_mime: bool = only_match_mime
+        self.decoded_from: Optional[str] = decoded_from
 
     def __getitem__(self, s: slice) -> "MatchContext":
         if not isinstance(s, slice):
             raise ValueError("Match contexts can only be sliced")
-        return MatchContext(data=self.data[s], path=self.path, only_match_mime=self.only_match_mime)
+        return MatchContext(data=self.data[s], path=self.path, only_match_mime=self.only_match_mime,
+                            decoded_from=self.decoded_from)
+
+    def text_test_context(self, encoding: Optional[str]) -> "MatchContext":
+        """The buffer libmagic runs its text tests against.
+
+        libmagic decodes its input into a UCS-4 buffer, drops the byte order mark, re-encodes that
+        buffer as UTF-8, and runs its text tests against the result rather than against the file's
+        bytes (``file_ascmagic_with_encoding`` in ``file/src/ascmagic.c``). That only changes the
+        bytes for a UCS encoding, so every other input keeps this context and the offsets its tests
+        report stay offsets into the file.
+
+        Args:
+            encoding: the encoding `detect_text_encoding` named for this context's data, or None if
+                it is not text.
+
+        Returns:
+            This context, or a context over the decoded text when the data are UCS-encoded.
+        """
+        if encoding is None or encoding not in _UCS_BOM_LENGTHS:
+            return self
+        return MatchContext(data=_decode_text(self.data, encoding).encode("utf-8"), path=self.path,
+                            only_match_mime=self.only_match_mime, decoded_from=encoding)
 
     @property
     def is_executable(self) -> bool:
@@ -3838,13 +3878,20 @@ class TextEncodingDescription:
     characters. `describe` applies that rewrite to one match's message.
     """
 
-    def __init__(self, code: str, text: str):
+    def __init__(self, encoding: str, text: str):
         """
         Args:
-            code: libmagic's name for the encoding, such as ``ASCII``.
+            encoding: the encoding `detect_text_encoding` named, such as ``ascii``.
             text: the decoded characters libmagic would scan.
+
+        Raises:
+            ValueError: if `LIBMAGIC_ENCODING_NAMES` has no description for `encoding`.
         """
-        self.code: str = code
+        if encoding not in LIBMAGIC_ENCODING_NAMES:
+            raise ValueError(f"there is no libmagic description for the text encoding "
+                             f"{encoding!r}; add one to LIBMAGIC_ENCODING_NAMES")
+        self.encoding: str = encoding
+        self.code: str = LIBMAGIC_ENCODING_NAMES[encoding]
         self.crlf: int = text.count("\r\n")
         self.lf: int = text.count("\n") - self.crlf
         # libmagic counts a CR when it reads the character after it, so a CR that ends the buffer
@@ -3875,10 +3922,7 @@ class TextEncodingDescription:
         encoding = detect_text_encoding(data)
         if encoding is None:
             return None
-        if encoding not in LIBMAGIC_ENCODING_NAMES:
-            raise ValueError(f"there is no libmagic description for the text encoding "
-                             f"{encoding!r}; add one to LIBMAGIC_ENCODING_NAMES")
-        return cls(LIBMAGIC_ENCODING_NAMES[encoding], _decode_text(data, encoding))
+        return cls(encoding, _decode_text(data, encoding))
 
     def _splice(self, message: str) -> Tuple[str, bool]:
         """Replaces a soft magic message's trailing ``text`` with the separator libmagic uses.
@@ -4087,9 +4131,26 @@ class Match:
         return LazyIterableSet(_extensions())
 
     def explain(self, file: Streamable, ansi_color: Optional[bool] = None) -> str:
+        """Explains every test that contributed to this match.
+
+        A match against a decoded buffer reports offsets into that buffer, so this explains it
+        against the buffer the tests read and says which encoding it was decoded from. There is no
+        map from those offsets back to the file's bytes; see `MatchContext.decoded_from`.
+
+        Args:
+            file: the file this match came from.
+            ansi_color: whether to colorize the explanation, defaulting to whether stdout is a tty.
+
+        Returns:
+            The explanation.
+        """
         if ansi_color is None:
             ansi_color = sys.stdout.isatty()
         writer = ANSIWriter(use_ansi=ansi_color)
+        if self.context.decoded_from is not None:
+            writer.write(f"  Every offset below is an offset into the text decoded from this file "
+                         f"as {self.context.decoded_from}, not into the file itself\n", dim=True)
+            file = self.context.data
         for result in self:
             result.explain(writer, file=file)
         return str(writer)
@@ -4384,11 +4445,14 @@ class MagicMatcher:
             yielded = True
         # is this a plain text file?
         text_matcher = Match(matcher=self, context=to_match, results=PlainTextTest().match(to_match))
-        is_text = text_matcher and (not to_match.only_match_mime or any(t is not None for t in text_matcher.mimetypes))
+        is_text = text_encoding is not None and text_matcher and (
+            not to_match.only_match_mime or any(t is not None for t in text_matcher.mimetypes))
         if is_text:
             text_matcher.text_encoding = text_encoding
-            # this is a text file, so try all of the textual tests:
-            for m in self._run_tests(self.text_tests, to_match, text_encoding, "text matching"):
+            # this is a text file, so try all of the textual tests, against the buffer libmagic
+            # hands them rather than against the file's bytes
+            text_context = to_match.text_test_context(text_encoding.encoding)
+            for m in self._run_tests(self.text_tests, text_context, text_encoding, "text matching"):
                 yield m
                 yielded = True
         if not yielded:

--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -1050,6 +1050,19 @@ class MagicTest(ABC):
         return self._type
 
     @property
+    def precedes_soft_magic(self) -> bool:
+        """Whether libmagic runs this check ahead of soft magic, against the file's own bytes.
+
+        ``file_buffer`` runs its tar, JSON, CSV and SIMH checks before it reaches soft magic
+        (``src/funcs.c``), so such a check never reads the buffer ``file_ascmagic`` decodes for the
+        text pass, and the description ``file_ascmagic`` appends never lands on its message.
+
+        Returns:
+            True if libmagic runs this check before soft magic.
+        """
+        return False
+
+    @property
     def appends_text_encoding(self) -> bool:
         """Whether libmagic appends its text-encoding description to this test's message.
 
@@ -1065,7 +1078,7 @@ class MagicTest(ABC):
         Returns:
             True if libmagic would append the description to this test's message.
         """
-        return bool(self.subtest_type() & TestType.TEXT)
+        return not self.precedes_soft_magic and bool(self.subtest_type() & TestType.TEXT)
 
     @test_type.setter
     def test_type(self, value: TestType):
@@ -3514,17 +3527,17 @@ class JSONTest(MagicTest):
         return TestType.TEXT
 
     @property
-    def appends_text_encoding(self) -> bool:
-        """libmagic never appends its text-encoding description to a JSON verdict.
+    def precedes_soft_magic(self) -> bool:
+        """``file_is_json`` runs ahead of soft magic in ``file_buffer``.
 
-        ``file_is_json`` runs ahead of soft magic in ``file_buffer`` and its match ends the run, so
-        ``file_ascmagic`` never sees it: `file` reports ``JSON text data``, not
-        ``JSON text data, ASCII text``.
+        So it reads the file's own bytes rather than the buffer ``file_ascmagic`` decodes, and its
+        match ends the run before ``file_ascmagic`` can describe it: `file` reports
+        ``JSON text data``, not ``JSON text data, ASCII text``.
 
         Returns:
-            False.
+            True.
         """
-        return False
+        return True
 
     def test_flip_endianness(
             self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]
@@ -3577,16 +3590,16 @@ class CSVTest(MagicTest):
         return TestType.TEXT
 
     @property
-    def appends_text_encoding(self) -> bool:
-        """libmagic never appends its text-encoding description to a CSV verdict.
+    def precedes_soft_magic(self) -> bool:
+        """``file_is_csv`` runs ahead of soft magic in ``file_buffer``.
 
-        ``file_is_csv`` runs ahead of soft magic in ``file_buffer``, names the encoding itself, and
-        its match ends the run, so ``file_ascmagic`` never sees it.
+        So it reads the file's own bytes rather than the buffer ``file_ascmagic`` decodes, and it
+        names the encoding itself and ends the run before ``file_ascmagic`` can describe it.
 
         Returns:
-            False.
+            True.
         """
-        return False
+        return True
 
     def test_flip_endianness(
             self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]
@@ -4410,7 +4423,8 @@ class MagicMatcher:
             tests: Iterable[MagicTest],
             context: MatchContext,
             text_encoding: Optional[TextEncodingDescription],
-            description: str
+            description: str,
+            file_context: Optional[MatchContext] = None
     ) -> Iterator[Match]:
         """Yields a match for each of `tests` that matches `context`.
 
@@ -4419,16 +4433,22 @@ class MagicMatcher:
             context: the buffer to run them against.
             text_encoding: the description of `context`'s text encoding, or None if it is not text.
             description: the label for the progress log.
+            file_context: the buffer holding the file's own bytes, when `context` is a rendering of
+                them. A check `MagicTest.precedes_soft_magic` names runs against this instead.
 
         Yields:
             One match per test that matched, carrying `text_encoding` if libmagic would append it
             to that test's message.
         """
         for test in log.range(tests, desc=description, unit=" tests", delay=1.0):
-            m = Match(matcher=self, context=context, results=test.match(context))
+            if file_context is not None and test.precedes_soft_magic:
+                test_context = file_context
+            else:
+                test_context = context
+            m = Match(matcher=self, context=test_context, results=test.match(test_context))
             # the description is how a match is rendered, so it must not make an empty message
             # look like a match
-            if m and (not context.only_match_mime or any(t is not None for t in m.mimetypes)):
+            if m and (not test_context.only_match_mime or any(t is not None for t in m.mimetypes)):
                 if test.appends_text_encoding:
                     m.text_encoding = text_encoding
                 yield m
@@ -4452,7 +4472,8 @@ class MagicMatcher:
             # this is a text file, so try all of the textual tests, against the buffer libmagic
             # hands them rather than against the file's bytes
             text_context = to_match.text_test_context(text_encoding.encoding)
-            for m in self._run_tests(self.text_tests, text_context, text_encoding, "text matching"):
+            for m in self._run_tests(self.text_tests, text_context, text_encoding, "text matching",
+                                     file_context=to_match):
                 yield m
                 yielded = True
         if not yielded:

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -38,9 +38,6 @@ KNOWN_FAILURES: Dict[str, int] = {
     # already right, which `MatchOrderTest` checks directly. Splitting the expected string on
     # `\012- ` here instead would drop #3491 from that list.
     "multiple": 3491,
-    # Text tests run against the raw bytes, so the SVG test never matches a UTF-16 file and
-    # PolyFile reports only the text-encoding description.
-    "utf16xmlsvg": 3489,
 }
 """Corpus stems that cannot pass yet, each mapped to the issue that has to be fixed first."""
 

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1722,3 +1722,196 @@ class MatchOrderTest(TestCase):
                          for seed, output in reported.items())
         self.assertEqual(1, len(set(reported.values())),
                          f"the match order differs between hash seeds:\n{detail}")
+
+
+class UCSTextBufferTest(TestCase):
+    """Regression tests for the buffer the text tests read, reported in issue #3489.
+
+    libmagic decodes its input into a UCS-4 buffer, drops the byte order mark, re-encodes that
+    buffer as UTF-8, and runs its text tests against the result rather than against the file's
+    bytes (`file_ascmagic_with_encoding` in `file/src/ascmagic.c`, `looks_ucs16` and `looks_ucs32`
+    in `file/src/encoding.c`). PolyFile ran its text tests against the raw bytes, so no text
+    definition could match a UTF-16 or UTF-32 file.
+
+    Every string these tests expect is what `file -b -k` prints for the same input, checked against
+    libmagic 5.48 built from the `file` submodule. libmagic joins its `-k` output into one string
+    and appends a single text-encoding description to the end of the join, which is issue #3491, so
+    these tests read the description off each match instead.
+    """
+
+    SVG: str = ('<?xml version="1.0"?>\n'
+                '<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"/>\n')
+    """A document `polyfile/magic_defs/sgml` reports as SVG, XML 1.0 and XML."""
+
+    ENCODINGS: Tuple[Tuple[str, str, bytes], ...] = (
+        ("utf-16le", "UTF-16, little-endian", b"\xff\xfe"),
+        ("utf-16be", "UTF-16, big-endian", b"\xfe\xff"),
+        ("utf-32le", "UTF-32, little-endian", b"\xff\xfe\x00\x00"),
+        ("utf-32be", "UTF-32, big-endian", b"\x00\x00\xfe\xff"),
+    )
+    """Each UCS encoding libmagic names, with the name it gives it and its byte order mark."""
+
+    @staticmethod
+    def encode(text: str, encoding: str) -> bytes:
+        """Encodes `text` the way a file in `encoding` holds it, byte order mark included.
+
+        Args:
+            text: The characters to encode.
+            encoding: One of the encoding names in `ENCODINGS`.
+
+        Returns:
+            The encoded bytes.
+        """
+        bom = next(mark for name, _, mark in UCSTextBufferTest.ENCODINGS if name == encoding)
+        return bom + text.encode(encoding)
+
+    @staticmethod
+    def text_buffer(data: bytes) -> Optional[bytes]:
+        """Returns the buffer `MagicMatcher.match` would hand the text tests for `data`.
+
+        Args:
+            data: The bytes to classify.
+
+        Returns:
+            The buffer, or None if `data` is not text.
+        """
+        encoding = polyfile.magic.detect_text_encoding(data)
+        if encoding is None:
+            return None
+        return MatchContext(data).text_test_context(encoding).data
+
+    def test_a_utf16_document_matches_the_text_tests(self):
+        """Tests that the SVG and XML definitions match a UTF-16 document of either endianness.
+
+        `polyfile/magic_defs/sgml:6` anchors `\\<?xml\\ version=` at offset 0, which no UTF-16 file
+        can satisfy in its own bytes: `file/tests/utf16xmlsvg.testfile` begins
+        `ff fe 3c 00 3f 00 78 00`.
+        """
+        for encoding, name, _ in self.ENCODINGS[:2]:
+            with self.subTest(encoding=encoding):
+                data = self.encode(self.SVG, encoding)
+                self.assertEqual(
+                    {f"SVG Scalable Vector Graphics image, Unicode text, {name} text",
+                     f"XML 1.0 document, Unicode text, {name} text",
+                     f"XML document, Unicode text, {name} text"},
+                    {str(match) for match in MagicMatcher.DEFAULT_INSTANCE.match(data)}
+                )
+
+    def test_a_utf32_document_matches_the_text_tests(self):
+        """Tests that a UTF-32 document matches the same text tests, plus its byte order mark.
+
+        `looks_ucs32` runs ahead of `looks_ucs16` in `file_encoding`, and `polyfile/magic_defs/
+        unicode:13` matches the UTF-32 mark in the binary pass, which is why `file -b` stops at
+        `Unicode text, UTF-32, little-endian` and only `file -b -k` shows the text matches.
+        """
+        for encoding, name, _ in self.ENCODINGS[2:]:
+            with self.subTest(encoding=encoding):
+                data = self.encode(self.SVG, encoding)
+                self.assertEqual(
+                    {f"Unicode text, {name}",
+                     f"SVG Scalable Vector Graphics image, Unicode text, {name} text",
+                     f"XML 1.0 document, Unicode text, {name} text",
+                     f"XML document, Unicode text, {name} text"},
+                    {str(match) for match in MagicMatcher.DEFAULT_INSTANCE.match(data)}
+                )
+
+    def test_the_byte_order_mark_is_not_in_the_text_buffer(self):
+        """Tests that the decoded buffer starts at the first character, not at the mark.
+
+        `looks_ucs16` starts its loop at `i = 2` and `looks_ucs32` at `i = 4`
+        (`file/src/encoding.c`), so the mark never reaches the buffer the text tests read. Keeping
+        it as U+FEFF pushes every offset forward by the length of its UTF-8 form and costs the SVG
+        match, whose first test is anchored at offset 0.
+        """
+        for encoding, _, _ in self.ENCODINGS:
+            with self.subTest(encoding=encoding):
+                buffer = self.text_buffer(self.encode(self.SVG, encoding))
+                self.assertEqual(self.SVG.encode("utf-8"), buffer)
+
+    def test_an_eight_bit_input_is_not_decoded(self):
+        """Tests that only a UCS input gets a second buffer, so every other offset stays honest.
+
+        A buffer that differs from the file's bytes costs the offsets its tests report, and
+        decoding costs time on every input, so an encoding whose characters libmagic copies
+        straight into its UCS-4 buffer keeps the context it already had.
+        """
+        inputs = ((b"plain ascii text\n", "ascii"),
+                  ("café naïve\n".encode("utf-8"), "utf-8"),
+                  ("café naïve\n".encode("latin-1"), "iso-8859-1"),
+                  (b"caf\x85 na\x8bve\n", "unknown-8bit"))
+        for data, expected_encoding in inputs:
+            with self.subTest(encoding=expected_encoding):
+                self.assertEqual(expected_encoding, polyfile.magic.detect_text_encoding(data))
+                context = MatchContext(data)
+                self.assertIs(context, context.text_test_context(expected_encoding))
+                self.assertIsNone(context.decoded_from)
+
+    def test_the_decoded_buffer_stops_at_the_encoding_byte_limit(self):
+        """Tests that decoding reads at most `FILE_ENCODING_MAX` bytes of the file.
+
+        `file_encoding` clamps its input to `ms->encoding_max`, which `apprentice.c` sets to
+        `FILE_ENCODING_MAX`, 64 kibibytes (`file/src/file.h:525`). Without the clamp a UTF-16 file
+        of any size gets decoded in full on every call to `MagicMatcher.match`.
+        """
+        limit = polyfile.magic.TEXT_ENCODING_MAX_BYTES
+        data = self.encode("a" * (limit // 2), "utf-16le")
+        self.assertGreater(len(data), limit)
+        self.assertEqual(b"a" * (limit // 2 - 1), self.text_buffer(data))
+
+    def test_a_decoded_match_reports_offsets_into_the_buffer_it_read(self):
+        """Tests that a match against a decoded buffer says so rather than claiming file offsets.
+
+        There is no map from an offset in the decoded buffer back to the byte in the file that
+        produced it, so a match on a UCS file carries the encoding it was decoded from and
+        `Match.explain` explains it against the buffer its tests read. This is the limitation the
+        transcoding introduces, pinned so it cannot start reporting decoded offsets as file
+        offsets.
+        """
+        data = self.encode(self.SVG, "utf-16le")
+        matches = {str(match): match for match in MagicMatcher.DEFAULT_INSTANCE.match(data)}
+        match = matches["XML document, Unicode text, UTF-16, little-endian text"]
+        self.assertEqual("utf-16le", match.context.decoded_from)
+        result = match[0]
+        self.assertEqual(b"<?xml", match.context.data[result.offset:result.offset + result.length])
+        self.assertEqual(b"\xff\xfe<\x00?", data[result.offset:result.offset + result.length])
+        explanation = match.explain(file=data, ansi_color=False)
+        self.assertIn("decoded from this file as utf-16le, not into the file itself", explanation)
+
+    def test_a_match_on_the_files_own_bytes_claims_no_decoding(self):
+        """Tests that an ASCII match keeps reporting file offsets, with no note in `explain`.
+
+        The note and the switch to the decoded buffer belong to `MatchContext.decoded_from`, so a
+        match that read the file's bytes has to be explained exactly as it was before.
+        """
+        data = self.SVG.encode("utf-8")
+        matches = {str(match): match for match in MagicMatcher.DEFAULT_INSTANCE.match(data)}
+        match = matches["XML document, ASCII text"]
+        self.assertIsNone(match.context.decoded_from)
+        result = match[0]
+        self.assertEqual(b"<?xml", data[result.offset:result.offset + result.length])
+        self.assertNotIn("decoded from this file", match.explain(file=data, ansi_color=False))
+
+    def test_the_json_and_csv_checks_read_the_files_own_bytes(self):
+        """Tests that the checks `file_buffer` runs before soft magic never see decoded text.
+
+        `file_buffer` runs `file_is_json` and `file_is_csv` against the buffer it was handed
+        (`file/src/funcs.c:412-429`), so `file -b -k` reports only `Unicode text, UTF-16,
+        little-endian text` for a UTF-16 JSON document. PolyFile models both as text soft magic
+        tests, so decoding the text buffer would have handed them the decoded text and reported a
+        CSV match libmagic does not report.
+
+        The `JSON text data` this expects for the UTF-16 document is a separate divergence that
+        predates the decoding: `JSONTest` reads the bytes through `json.loads`, which sniffs a
+        UTF-16 byte order mark, and `file_is_json` does not. It stands in for the encoding
+        description because `MagicMatcher.match` reports the plain text match only when no other
+        test matched.
+        """
+        document = '{"a": 1, "b": 2}\n'
+        self.assertIn("CSV text (excel dialect)", {
+            str(match) for match in MagicMatcher.DEFAULT_INSTANCE.match(document.encode("utf-8"))
+        })
+        self.assertEqual(
+            {"JSON text data"},
+            {str(match) for match in
+             MagicMatcher.DEFAULT_INSTANCE.match(self.encode(document, "utf-16le"))}
+        )


### PR DESCRIPTION
Closes #3489

## What was wrong

libmagic does not run its text tests against the file's bytes. `file_ascmagic` calls
`file_encoding`, which decodes the input into a `file_unichar_t *ubuf`
(`file/src/ascmagic.c:71-101`, `file/src/encoding.c:75-175`). `looks_ucs16` starts its loop at
`i = 2` and `looks_ucs32` at `i = 4` (`file/src/encoding.c:491`, `:527`), so the byte order mark
never reaches `ubuf`. `file_ascmagic_with_encoding` then renders `ubuf` through `encode_utf8` into
a fresh `utf8_buf`, wraps it in a buffer, and calls
`file_softmagic(ms, &bb, NULL, NULL, TEXTTEST, text)` against **that**
(`file/src/ascmagic.c:140-163`).

PolyFile ran every text test against the same unmodified context, so no text definition could
match a UTF-16 or UTF-32 file. `polyfile/magic_defs/sgml:6` anchors `\<?xml\ version=` at offset 0,
and `file/tests/utf16xmlsvg.testfile` begins `ff fe 3c 00 3f 00 78 00`.

## What changed

`MatchContext.text_test_context` builds libmagic's buffer: it decodes the input, drops the byte
order mark, and re-encodes as UTF-8. It reuses `_decode_text`, which already clamps its input to
`TEXT_ENCODING_MAX_BYTES` the way `file_encoding` clamps to `ms->encoding_max`
(`FILE_ENCODING_MAX`, 64 KiB, `file/src/file.h:525`), so the decode is bounded no matter how large
the file is.

The bytes only change for a UCS encoding. `ascii`, `utf-8`, `iso-8859-1` and `unknown-8bit` get the
context they already had — `text_test_context` returns `self`, identity and all — so nothing but a
UCS file changes behavior and nothing but a UCS file pays for a decode. `TextEncodingDescription`
now carries the encoding name it already computed, so deciding this costs no extra scan of the
input.

The byte order mark has to go: keeping it as `ef bb bf` pushes every offset forward by three and
costs the SVG match, whose first test is anchored at offset 0.

### Offset provenance

**The decoded buffer's offsets are not file offsets, and this PR does not map them back.** There is
no map, and I did not build one. What it does instead is refuse to pass them off as file offsets:

- `MatchContext.decoded_from` records the encoding a context was decoded from, and is `None` on a
  context over the file's own bytes.
- `Match.explain` explains a decoded match against the buffer its tests actually read, and prefaces
  it with `Every offset below is an offset into the text decoded from this file as utf-16le, not
  into the file itself`. Before this change, `--format explain` on `utf16xmlsvg.testfile` printed
  one `ASCII TEST` match over the whole file; now it prints the three real matches, each labeled.
- `--format sbud` and the HTML viewer were already unaffected: the offsets they report for a magic
  match come from `Matcher.handle_mimetype`, which passes `offset=0` and the raw file length, not
  from a `TestResult.offset`. I checked before and after on `utf16xmlsvg.testfile`. Before:
  one element, `text/plain` at offset 0, size 5564. After: `image/svg+xml`, `text/xml`, `text/html`,
  each at offset 0, size 5564 — the real file length either way. `--format html` still renders.
- `test_a_decoded_match_reports_offsets_into_the_buffer_it_read` pins this, including that the
  file's bytes at a reported offset are *not* what the test matched, so it cannot silently start
  claiming otherwise.

One remaining gap: the interactive debugger prints the buffer the running test was handed, which is
the decoded text for a UCS file in the text pass. Its offsets are consistent with what it prints,
but it does not label the buffer as decoded — the debugger hook receives `data: bytes` and never
sees the context.

### One thing I had to fix alongside it

`file_buffer` runs libmagic's tar, JSON, CSV and SIMH checks against the buffer it was handed,
before it reaches soft magic (`file/src/funcs.c:401-434`). PolyFile models the JSON and CSV checks
as text soft magic tests, so handing the text pass a decoded buffer handed them decoded text too,
and PolyFile started reporting `CSV text (excel dialect)` for a UTF-16 JSON document. `file -b -k`
reports only `Unicode text, UTF-16, little-endian text` there.

`MagicTest.precedes_soft_magic` names those checks and `_run_tests` gives them the file's own bytes
even in the text pass. It also subsumes the two `appends_text_encoding` overrides, whose docstrings
already gave the same reason: a check that runs before soft magic ends the run before
`file_ascmagic` can describe it.

## `utf16xmlsvg`, before and after

`file/tests/utf16xmlsvg.result`, and `file -b`:

```
SVG Scalable Vector Graphics image, Unicode text, UTF-16, little-endian text
```

Before:

```
Unicode text, UTF-16, little-endian text
```

After (PolyFile reports every match, as `file -k` does):

```
SVG Scalable Vector Graphics image, Unicode text, UTF-16, little-endian text
XML 1.0 document, Unicode text, UTF-16, little-endian text
XML document, Unicode text, UTF-16, little-endian text
HTML document, Unicode text, UTF-16, little-endian text
exported SGML document, Unicode text, UTF-16, little-endian text
```

## Oracle comparison

97 files against `file -b` from the `file` submodule (libmagic 5.48): XML, SVG, HTML, shell,
Python, C, diff, JSON, POD, makefile, LaTeX, RTF, plain text, a 500-character line and a CRLF file,
each in ASCII, UTF-16LE, UTF-16BE, UTF-32LE and UTF-32BE; plus UTF-8, UTF-8-with-BOM, Latin-1 and
Non-ISO extended-ASCII versions; plus PNG, GIF, ELF, gzip, zip, PDF, all-bytes and all-zeros
binaries and a UTF-16 file with no byte order mark.

**68 of 97 before, 84 after.** Every one of the 16 changes is a UTF-16 file gaining its type, and
nothing else changed anywhere in the output — not one match string appeared or disappeared for any
ASCII, UTF-8, Latin-1, extended-ASCII, UTF-32 or binary input:

```
c.utf16{le,be}     MISS -> MATCH    C source, Unicode text, UTF-16, ... text
html.utf16{le,be}  MISS -> MATCH    HTML document, ...
make.utf16{le,be}  MISS -> MATCH    makefile script, ...
pod.utf16{le,be}   MISS -> MATCH    Perl POD document, ...
py.utf16{le,be}    MISS -> MATCH    Python script, ... text executable
svg.utf16{le,be}   MISS -> MATCH    SVG Scalable Vector Graphics image, ...
tex.utf16{le,be}   MISS -> MATCH    LaTeX 2e document, ...
xml.utf16{le,be}   MISS -> MATCH    XML 1.0 document, ...
```

UTF-32 files came out MATCH both before and after, for a reason worth stating: `polyfile/
magic_defs/unicode:13-14` matches the UTF-32 byte order mark in the **binary** pass, and once
binary soft magic prints something `file_buffer` never reaches `file_ascmagic`, so `file -b` stops
at `Unicode text, UTF-32, little-endian`. `file -b -k` shows what the text pass finds, and PolyFile
now agrees with it:

```
$ file -b -k svg.utf32le
Unicode text, UTF-32, little-endian\012- SVG Scalable Vector Graphics image\012- XML 1.0 document text\012- XML document, Unicode text, UTF-32, little-endian text
```

The 13 remaining misses are all pre-existing and none of them moved:

- `sh.*`, `diff.*` (UTF-16): `set_test_type` in `file/src/apprentice.c:190-280` marks a flagless
  `string` entry `BINTEST` and a flagless `search`/`regex` entry `TEXTTEST` if its pattern looks
  like UTF-8, and PolyFile classifies some of those differently. That is #3490.
- `svg.ascii`, `svg.utf8`: `string/bt` carries both flags, so libmagic runs the entry in both
  passes; it matches in the binary pass, `file_ascmagic` never runs, and no encoding is appended.
  PolyFile puts each level 0 entry in exactly one pass. Also #3490.
- `utf8bom.xml`, `utf8bom.svg`: `looks_utf8_with_BOM` decodes from `buf + 3`
  (`file/src/encoding.c:437`), so libmagic strips a UTF-8 byte order mark from its text buffer too
  and names the encoding `Unicode text, UTF-8 (with BOM)`. PolyFile's `detect_text_encoding`
  does not distinguish that encoding at all, so there is nothing here for `text_test_context` to
  act on yet. Deliberately left alone: it is a `detect_text_encoding` gap, not a buffer gap, and
  the same is true of libmagic widening `iso-8859-1` and `unknown-8bit` bytes into two-byte UTF-8
  in its text buffer.
- `png.bin`, `zip.bin`, `json.utf16{le,be}`: `trim_nuls` (`file/src/ascmagic.c:60`), a laxer zip
  test, and `json.loads` sniffing a UTF-16 byte order mark where `file_is_json` does not.

## Verification

Corpus differential (`BASELINE_FAILURES` is the original 14 stems, so the 12 already-fixed ones
report as newly passing):

```
NEWLY PASSING (13): ['JW07022A.mp3', 'cmd1', 'cmd2', 'cmd3', 'cmd4', 'gedcom', 'jpeg-text',
                     'jsonlines1', 'osm', 'pnm1', 'pnm2', 'pnm3', 'utf16xmlsvg']
STILL FAILING (1): ['multiple']
REGRESSIONS   (0):
```

`utf16xmlsvg` is removed from `KNOWN_FAILURES`; `multiple` is left alone.

```
$ pytest tests -q
1102 passed, 3 skipped, 3 warnings, 797 subtests passed
```

Baseline on `e8e720d` is 1094 passed, 3 skipped, 785 subtests, 3 warnings. Nothing was lost; the
8 new tests and 12 new subtests are `UCSTextBufferTest`. The 3 warnings are the pre-existing
`SyntaxWarning`s from generated Kaitai parsers (#3462).

```
$ flake8 polyfile polymerge tests --max-complexity=10 --max-line-length=127 \
      --exclude=polyfile/kaitai/parsers --count
226
$ flake8 polyfile polymerge tests --exclude=polyfile/kaitai/parsers \
      --select=E9,F63,F7,F82 --count
0
```

226 both before and after, so no new findings; the blocking selection stays at 0.

### Timing

`pytest tests`, alternating between this branch and `e8e720d` on the same machine:

| run | this branch | `e8e720d` |
| --- | --- | --- |
| 1 | 112.68s | 119.19s |
| 2 | 106.63s | 105.71s |

Indistinguishable — run-to-run noise on this machine is wider than any difference, and this branch
runs 8 more tests. `MagicMatcher.match` on one input, best of 5:

| input | `e8e720d` | this branch |
| --- | --- | --- |
| ASCII, 64 KiB | 17.4 ms | 17.5 ms |
| ASCII, 1 MiB | 29.4 ms | 26.8 ms |
| UTF-8, 1 MiB | 30.6 ms | 30.0 ms |
| Latin-1, 1 MiB | 28.6 ms | 28.1 ms |
| UTF-16LE SVG, 172 B | 14.0 ms | 13.8 ms |
| UTF-16LE, 1 MiB | 65.2 ms | 66.6 ms |
| PNG, 1 MiB | 23.8 ms | 23.0 ms |

Only the UTF-16 input pays anything, and the 64 KiB clamp is why 1 MiB costs the same 1.4 ms a
64 KiB file would.

## Tests

`UCSTextBufferTest` in `tests/test_magic.py`. Every expected string is what `file -b -k` prints for
the same input, checked against libmagic 5.48 built from the submodule. It covers a UTF-16 and a
UTF-32 document of either endianness matching the SVG and XML definitions, the byte order mark
staying out of the buffer for all four UCS encodings, an ASCII / UTF-8 / Latin-1 / extended-ASCII
input keeping the very context object it had, the 64 KiB clamp, the offsets a decoded match reports
and the note `Match.explain` writes about them, an undecoded match reporting file offsets with no
note, and the JSON and CSV checks reading the file's own bytes.

Each test was checked against a deliberate break: reverting the text-test context, keeping the byte
order mark, removing the 64 KiB clamp, decoding eight bit encodings too, dropping the
`decoded_from` provenance, claiming a decoding that did not happen, and disabling the
`precedes_soft_magic` routing. Each break failed the tests it should and no others, and each test
passed again once the break was undone.

## Merge order

Independent of #3491. Both PRs remove a stem from the same two-entry `KNOWN_FAILURES` map and both
append a test class to `tests/test_magic.py`, so expect a conflict there in whichever merges
second; the resolution is to keep both entries removed and both classes. Nothing here touches
`MagicTest.test_type`, the `t`/`b` flag handling (#3490) or the level 0 ordering (#3509).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VS8hTTRQeG8ZCmCZ9KLHiV
