### PR TITLE
Select the soft magic pass from a definition's text and binary flags

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -1609,6 +1609,7 @@ class DataType(ABC, Generic[T]):
                 dt = GUIDType(endianness=Endianness.LITTLE)
         else:
             dt = NumericDataType.parse(fmt)
+        _check_name_spells_every_flag(fmt, dt)
         if dt.name in TYPES_BY_NAME:
             # Sometimes a data type will change its name based on modifiers.
             # For example, string and pstring will always include their modifiers after their name
@@ -1618,11 +1619,41 @@ class DataType(ABC, Generic[T]):
         TYPES_BY_NAME[fmt] = dt
         return dt
 
+    def behavior(self) -> Dict[str, Any]:
+        """Everything about this type that decides how it matches.
+
+        Returns:
+            Every attribute except the name, which is a rendering of the rest.
+        """
+        return {key: value for key, value in vars(self).items() if key != "name"}
+
     def __str__(self):
         return self.name
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.name})"
+
+
+def _check_name_spells_every_flag(fmt: str, data_type: DataType) -> None:
+    """Checks that a flag-bearing type's name records everything the type does.
+
+    `DataType.parse` interns a type under its name, so two declarations that differ only by a flag
+    the name leaves out share one instance and silently share its flags (issue #3515). A flag a
+    type reads but does not spell shows up here as a name that parses back into a different type.
+
+    Args:
+        fmt: The declaration `data_type` was parsed from.
+        data_type: The type that was parsed.
+
+    Raises:
+        ValueError: If `data_type.name` does not parse back into a type that behaves the same way.
+    """
+    if fmt == data_type.name or not isinstance(data_type, (StringType, RegexType)):
+        return
+    rebuilt = DataType.parse(data_type.name)
+    if type(rebuilt) is not type(data_type) or rebuilt.behavior() != data_type.behavior():
+        raise ValueError(f"{fmt!r} parsed to a type named {data_type.name!r}, but that name parses back as "
+                         f"{rebuilt!r}: the name leaves out something the declaration set")
 
 
 class UUIDWildcard:
@@ -2084,7 +2115,47 @@ class StringMatch(StringTest):
         return repr(self.string)
 
 
+def reject_pascal_string_flags(declaration: str, format_str: str, options: str) -> None:
+    """Raises if `options` carries a length modifier that only ``pstring`` accepts.
+
+    ``B``, ``H``, ``h``, ``L`` and ``J`` size a Pascal string's length prefix, and libmagic's flag
+    loop jumps to its error label for any other type (``file/src/apprentice.c:1983-2020``). ``l``
+    is the exception, because on a ``regex`` it means ``REGEX_LINE_COUNT``.
+
+    Args:
+        declaration: The word the type was declared with.
+        format_str: The whole declaration, for the error message.
+        options: The flag letters that followed it.
+
+    Raises:
+        ValueError: If `options` carries a modifier only ``pstring`` accepts.
+    """
+    invalid = "".join(sorted({opt for opt in options if opt in "BHhLJ"}))
+    if invalid:
+        raise ValueError(f"Invalid {declaration} type declaration: {format_str!r} carries the {invalid!r} "
+                         f"modifier(s), which libmagic accepts only on pstring")
+
+
 class StringType(DataType[StringTest]):
+    DECLARATION: str = "string"
+    """The word a definition writes to declare this type."""
+
+    FLAGS: Tuple[Tuple[str, str], ...] = (
+        ("W", "compact_whitespace"),
+        ("w", "optional_blanks"),
+        ("C", "case_insensitive_upper"),
+        ("c", "case_insensitive_lower"),
+        ("T", "trim"),
+        ("f", "full_word_match"),
+        ("t", "force_text"),
+        ("b", "force_binary"),
+    )
+    """Every flag this type can carry, in the order `DataType.name` spells them.
+
+    See the letters in ``file/src/file.h:415-431`` and the loop that reads them in
+    ``file/src/apprentice.c:1940-2028``.
+    """
+
     def __init__(
             self,
             case_insensitive_lower: bool = False,
@@ -2094,20 +2165,9 @@ class StringType(DataType[StringTest]):
             full_word_match: bool = False,
             trim: bool = False,
             force_text: bool = False,
+            force_binary: bool = False,
             num_bytes: Optional[int] = None
     ):
-        if not any((num_bytes is not None, case_insensitive_lower, case_insensitive_upper, compact_whitespace,
-                    optional_blanks, trim, force_text)):
-            name = "string"
-        else:
-            if num_bytes is not None:
-                name = f"{num_bytes}/"
-            else:
-                name = ""
-            name = f"string/{name}{['', 'W'][compact_whitespace]}{['', 'w'][optional_blanks]}"\
-                   f"{['', 'C'][case_insensitive_upper]}{['', 'c'][case_insensitive_lower]}"\
-                   f"{['', 'T'][trim]}{['', 'f'][full_word_match]}{['', 't'][force_text]}"
-        super().__init__(name)
         self.case_insensitive_lower: bool = case_insensitive_lower
         self.case_insensitive_upper: bool = case_insensitive_upper
         self.compact_whitespace: bool = compact_whitespace
@@ -2115,7 +2175,23 @@ class StringType(DataType[StringTest]):
         self.full_word_match: bool = full_word_match
         self.trim: bool = trim
         self.force_text: bool = force_text
+        self.force_binary: bool = force_binary
         self.num_bytes: Optional[int] = num_bytes
+        super().__init__(self.declaration())
+
+    def declaration(self) -> str:
+        """Rebuilds the declaration this type was parsed from, which is also its name.
+
+        Returns:
+            A string `DataType.parse` accepts and that spells every flag this type carries.
+        """
+        parts = [self.DECLARATION]
+        if self.num_bytes is not None:
+            parts.append(str(self.num_bytes))
+        flags = "".join(letter for letter, attribute in self.FLAGS if getattr(self, attribute))
+        if flags:
+            parts.append(flags)
+        return "/".join(parts)
 
     def is_text(self, value: StringTest) -> bool:
         return self.force_text
@@ -2159,13 +2235,8 @@ class StringType(DataType[StringTest]):
             num_bytes: Optional[int] = None
         else:
             num_bytes = int(m.group("numbytes"))
-        if m.group("opts") is None:
-            options: Iterable[str] = ()
-        else:
-            options = m.group("opts")
-        unsupported_options = {opt for opt in options if opt not in "/WwcCtbTf"}
-        if unsupported_options:
-            log.warning(f"{format_str!r} has invalid option(s) that will be ignored: {', '.join(unsupported_options)}")
+        options = m.group("opts") or ""
+        reject_pascal_string_flags(cls.DECLARATION, format_str, options)
         return StringType(
             case_insensitive_lower="c" in options,
             case_insensitive_upper="C" in options,
@@ -2174,11 +2245,15 @@ class StringType(DataType[StringTest]):
             full_word_match="f" in options,
             trim="T" in options,
             force_text="t" in options,
+            force_binary="b" in options,
             num_bytes=num_bytes
         )
 
 
 class SearchType(StringType):
+    DECLARATION: str = "search"
+    FLAGS: Tuple[Tuple[str, str], ...] = StringType.FLAGS + (("s", "match_to_start"),)
+
     def __init__(
             self,
             repetitions: Optional[int] = None,
@@ -2189,46 +2264,23 @@ class SearchType(StringType):
             match_to_start: bool = False,
             full_word_match: bool = False,
             trim: bool = False,
+            force_text: bool = False,
             force_binary: bool = False
     ):
         if repetitions is not None and repetitions <= 0:
             raise ValueError("repetitions must be either None or a positive integer")
+        self.match_to_start: bool = match_to_start
         super().__init__(
             case_insensitive_lower=case_insensitive_lower,
             case_insensitive_upper=case_insensitive_upper,
             compact_whitespace=compact_whitespace,
             optional_blanks=optional_blanks,
             full_word_match=full_word_match,
-            trim=trim
+            trim=trim,
+            force_text=force_text,
+            force_binary=force_binary,
+            num_bytes=repetitions
         )
-        self.num_bytes = repetitions
-        if repetitions is None:
-            rep_str = ""
-        else:
-            rep_str = f"/{repetitions}"
-        assert self.name.startswith("string")
-        self.name = f"search{rep_str}{self.name[6:]}"
-        self.match_to_start: bool = match_to_start
-        self.force_binary: bool = force_binary
-        if match_to_start:
-            self._name_flag("s", rep_str)
-        if force_binary:
-            self._name_flag("b", rep_str)
-
-    def _name_flag(self, flag: str, rep_str: str) -> None:
-        """Records `flag` in this type's name, opening the flag group if it is the first one.
-
-        `DataType.parse` keys its cache of parsed types on the name, so a flag left out of the
-        name would make a declaration that carries it share an instance with one that does not.
-
-        Args:
-            flag: The declaration letter of the flag.
-            rep_str: The repetition count as it appears in the name, or an empty string.
-        """
-        if self.name == f"search{rep_str}":
-            self.name = f"search{rep_str}/{flag}"
-        else:
-            self.name = f"{self.name}{flag}"
 
     @property
     def repetitions(self) -> Optional[int]:
@@ -2537,13 +2589,29 @@ class MagicRegex:
 
 
 class RegexType(DataType[MagicRegex]):
+    FLAGS: Tuple[Tuple[str, str], ...] = (
+        ("c", "case_insensitive"),
+        ("s", "match_to_start"),
+        ("l", "limit_lines"),
+        ("T", "trim"),
+        ("t", "force_text"),
+        ("b", "force_binary"),
+    )
+    """Every flag this type can carry, in the order `DataType.name` spells them.
+
+    ``l`` is ``CHAR_PSTRING_4_LE``, which libmagic reads as ``REGEX_LINE_COUNT`` on a regular
+    expression (``file/src/file.h:409`` and ``file/src/apprentice.c:2003-2012``).
+    """
+
     def __init__(
             self,
             length: Optional[int] = None,
             case_insensitive: bool = False,
             match_to_start: bool = False,
             limit_lines: bool = False,
-            trim: bool = False
+            trim: bool = False,
+            force_text: bool = False,
+            force_binary: bool = False
     ):
         if length is None:
             if limit_lines:
@@ -2555,17 +2623,40 @@ class RegexType(DataType[MagicRegex]):
         self.case_insensitive: bool = case_insensitive
         self.match_to_start: bool = match_to_start
         self.trim: bool = trim
-        super().__init__(f"regex/{self.length}{['', 'c'][case_insensitive]}{['', 's'][match_to_start]}"
-                         f"{['', 'l'][self.limit_lines]}{['', 'T'][self.trim]}")
+        self.force_text: bool = force_text
+        self.force_binary: bool = force_binary
+        super().__init__(self.declaration())
+
+    def declaration(self) -> str:
+        """Rebuilds the declaration this type was parsed from, which is also its name.
+
+        Returns:
+            A string `DataType.parse` accepts and that spells every flag this type carries.
+        """
+        flags = "".join(letter for letter, attribute in self.FLAGS if getattr(self, attribute))
+        return f"regex/{self.length}{flags}"
 
     DOLLAR_PATTERN = re.compile(rb"(^|[^\\])\$", re.MULTILINE)
 
     def is_text(self, value: MagicRegex) -> bool:
-        try:
-            _ = value.pattern.decode("ascii")
-            return True
-        except UnicodeDecodeError:
+        """Whether libmagic runs this regular expression in its text pass.
+
+        A declared ``b`` or ``t`` decides on its own, because ``set_test_type`` reads the string
+        flags and breaks out of the case before it reaches ``file_looks_utf8``
+        (``file/src/apprentice.c:1258-1283``). Otherwise the pattern itself decides, by the same
+        rule libmagic applies to a `search` value.
+
+        Args:
+            value: The parsed regular expression.
+
+        Returns:
+            True if libmagic classifies the test as a text test.
+        """
+        if self.force_binary:
             return False
+        elif self.force_text:
+            return True
+        return _looks_like_utf8(value.pattern)
 
     def strength_term(self, expected: MagicRegex) -> int:
         """One unit per literal character, capped the way a `search` is.
@@ -2636,11 +2727,8 @@ class RegexType(DataType[MagicRegex]):
         return DataTypeMatch.INVALID
 
     REGEX_TYPE_FORMAT: Pattern[str] = re.compile(
-        r"^regex(/(?P<length>\d+)?(?P<flags1>[cslTt]*)(/(?P<flags2>[cslTt]*))?(b\d*)?)?$"
+        r"^regex(/(?P<length>\d+)?(?P<flags1>[bcslTt]*)(/(?P<flags2>[bcslTt]*))?)?$"
     )
-    # NOTE: some specification files like `cad` use `regex/b`, which is undocumented, and it's unclear from the libmagic
-    #       source code whether it is simply ignored or if it has a purpose. We ignore it here.
-    # NOTE: the `t` flag (force text) is also supported but currently ignored as it's a hint for output formatting.
     # NOTE: flags can appear either after length directly (regex/31cs) or with a slash (regex/31/cs).
 
     @classmethod
@@ -2662,7 +2750,9 @@ class RegexType(DataType[MagicRegex]):
             case_insensitive="c" in options,
             match_to_start="s" in options,
             limit_lines="l" in options,
-            trim="T" in options
+            trim="T" in options,
+            force_text="t" in options,
+            force_binary="b" in options
         )
 
 

--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -4631,20 +4631,21 @@ class MagicMatcher:
             text_encoding: Optional[TextEncodingDescription],
             description: str,
             file_context: Optional[MatchContext] = None
-    ) -> Iterator[Match]:
+    ) -> Iterator[Tuple[MagicTest, Match]]:
         """Yields a match for each of `tests` that matches `context`.
 
         Args:
             tests: the level 0 tests to run.
             context: the buffer to run them against.
-            text_encoding: the description of `context`'s text encoding, or None if it is not text.
+            text_encoding: the description libmagic appends to a match from this pass, or None if
+                this pass appends none.
             description: the label for the progress log.
             file_context: the buffer holding the file's own bytes, when `context` is a rendering of
                 them. A check `MagicTest.precedes_soft_magic` names runs against this instead.
 
         Yields:
-            One match per test that matched, carrying `text_encoding` if libmagic would append it
-            to that test's message.
+            The test and its match, for each test that matched, carrying `text_encoding` if
+            libmagic would append it to that test's message.
         """
         for test in log.range(tests, desc=description, unit=" tests", delay=1.0):
             if file_context is not None and test.precedes_soft_magic:
@@ -4657,7 +4658,29 @@ class MagicMatcher:
             if m and (not test_context.only_match_mime or any(t is not None for t in m.mimetypes)):
                 if test.appends_text_encoding:
                     m.text_encoding = text_encoding
-                yield m
+                yield test, m
+
+    def binary_pass_tests(self, looks_text: bool) -> Iterable[MagicTest]:
+        """The level 0 tests `MagicMatcher.match` runs over the file's own bytes.
+
+        ``softmagic`` skips an entry whose declared string flags are exactly ``STRING_BINTEST``
+        when the buffer looks like text (``file/src/softmagic.c:249-253``). That is what keeps
+        libmagic from reporting the binary half of a definition that spells one shebang twice, as
+        ``magic_defs/varied.script`` does. An entry that declares both flags is not skipped,
+        because the test is for one bit and not the other.
+
+        Args:
+            looks_text: Whether `TextEncodingDescription.detect` recognized the buffer as text,
+                which is the ``looks_text`` ``file_buffer`` hands ``file_softmagic``
+                (``file/src/funcs.c:314-317`` and ``482``).
+
+        Returns:
+            The tests to run, in the order `MagicMatcher.match` runs them.
+        """
+        if not looks_text:
+            return self.non_text_tests
+        return [test for test in self.non_text_tests
+                if test.declared_test_type() != TestType.BINARY]
 
     def match(self, to_match: Union[bytes, BinaryIO, str, Path, MatchContext]) -> Iterator[Match]:
         if isinstance(to_match, bytes):
@@ -4666,7 +4689,13 @@ class MagicMatcher:
             to_match = MatchContext.load(to_match)
         text_encoding = TextEncodingDescription.detect(to_match.data)
         yielded = False
-        for m in self._run_tests(self.non_text_tests, to_match, text_encoding, "binary matching"):
+        matched_on_the_files_bytes: Set[MagicTest] = set()
+        # only the text pass carries the encoding description: `file_ascmagic` prints it, and
+        # `file_buffer` reaches `file_ascmagic` only once binary soft magic has printed nothing
+        # (`file/src/funcs.c:479-503`)
+        for test, m in self._run_tests(self.binary_pass_tests(text_encoding is not None),
+                                       to_match, None, "binary matching"):
+            matched_on_the_files_bytes.add(test)
             yield m
             yielded = True
         # is this a plain text file?
@@ -4678,8 +4707,9 @@ class MagicMatcher:
             # this is a text file, so try all of the textual tests, against the buffer libmagic
             # hands them rather than against the file's bytes
             text_context = to_match.text_test_context(text_encoding.encoding)
-            for m in self._run_tests(self.text_tests, text_context, text_encoding, "text matching",
-                                     file_context=to_match):
+            text_tests = [test for test in self.text_tests if test not in matched_on_the_files_bytes]
+            for _, m in self._run_tests(text_tests, text_context, text_encoding, "text matching",
+                                        file_context=to_match):
                 yield m
                 yielded = True
         if not yielded:

--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -2329,9 +2329,9 @@ class SearchType(StringType):
         r"((/(?P<repetitions1>(0[xX][\dA-Fa-f]+|\d+)))(/(?P<flags1>[BbCctTWwsf]*)?)?|"
         r"/((?P<flags2>[BbCctTWwsf]*)/?)?(?P<repetitions2>(0[xX][\dA-Fa-f]+|\d+)))$"
     )
-    # NOTE: some specification files like `ber` use `search/b64`, which is undocumented. We treat that equivalent to
-    #       the compliant `search/b/64`.
-    # TODO: Figure out if this is correct.
+    # NOTE: `ber` writes `search/b64`, which the documentation does not describe. libmagic reads the
+    #       digits of a string declaration as the repetition count and every letter as a flag
+    #       (`file/src/apprentice.c:1940-1956`), so that is `search/64` with `b` set.
 
     @classmethod
     def parse(cls, format_str: str) -> "SearchType":
@@ -2349,10 +2349,8 @@ class SearchType(StringType):
             flags = m.group("flags2")
         else:
             raise ValueError(f"Invalid search type declaration: {format_str!r}")
-        if flags is None:
-            options: Iterable[str] = ()
-        else:
-            options = flags
+        options = flags or ""
+        reject_pascal_string_flags(cls.DECLARATION, format_str, options)
         return SearchType(
             repetitions=repetitions,
             case_insensitive_lower="c" in options,
@@ -2362,6 +2360,7 @@ class SearchType(StringType):
             full_word_match="f" in options,
             trim="T" in options,
             match_to_start="s" in options,
+            force_text="t" in options,
             force_binary="b" in options
         )
 

--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -954,9 +954,39 @@ class Comment:
 
 
 class TestType(IntFlag):
+    """The soft magic passes a level 0 test runs in.
+
+    libmagic runs soft magic twice, once over the file's bytes in ``BINTEST`` mode
+    (``file/src/funcs.c:482``) and once over the decoded text buffer in ``TEXTTEST`` mode
+    (``file/src/ascmagic.c:161-162``), and an entry can belong to either pass or to both.
+    """
+
     UNKNOWN = 0
     BINARY = 1
     TEXT = 2
+    BOTH = BINARY | TEXT
+
+
+def declared_passes(force_text: bool, force_binary: bool) -> TestType:
+    """The passes a definition's ``b`` and ``t`` flags name.
+
+    ``set_test_type`` sets ``BINTEST`` for ``b`` and ``TEXTTEST`` for ``t`` and then stops, so a
+    declaration that carries both belongs to both passes and one that carries neither leaves the
+    choice to its type (``file/src/apprentice.c:1258-1266``).
+
+    Args:
+        force_text: Whether the declaration carried ``t``.
+        force_binary: Whether the declaration carried ``b``.
+
+    Returns:
+        The passes the flags name, or `TestType.UNKNOWN` if they name none.
+    """
+    passes = TestType.UNKNOWN
+    if force_binary:
+        passes |= TestType.BINARY
+    if force_text:
+        passes |= TestType.TEXT
+    return passes
 
 
 class MagicTest(ABC):
@@ -1025,27 +1055,33 @@ class MagicTest(ABC):
     def message(self, new_value: Message):
         self._message = new_value
 
+    def declared_test_type(self) -> TestType:
+        """The passes this test's own declaration named, if it named any.
+
+        Returns:
+            `TestType.UNKNOWN`, unless the declaration carried a ``b`` or a ``t`` flag.
+        """
+        return TestType.UNKNOWN
+
     @property
     def test_type(self) -> TestType:
+        """The soft magic passes `MagicMatcher.match` runs this test in.
+
+        libmagic decides from the level 0 line alone. ``set_text_binary`` hands ``set_test_type``
+        one entry per top-level test, and ``set_test_type`` reads that entry's own ``str_flags``
+        and ``type`` (``file/src/apprentice.c:1200-1284`` and ``1423-1453``); a subtest never
+        changes the answer. `subtest_type` reports exactly that decision. `IndirectTest` is the
+        one deliberate exception: it forces every ancestor to binary, because an indirect test can
+        dispatch any other test.
+
+        Returns:
+            The passes this test belongs to.
+        """
         if self._type == TestType.UNKNOWN:
             if hasattr(self, "__calculating_test_type") and getattr(self, "__calculating_test_type"):
                 return TestType.UNKNOWN
             setattr(self, "__calculating_test_type", True)
-            if self.can_be_indirect:
-                # indirect tests can execute any other (binary) test, so classify ourselves as binary
-                self._type = TestType.BINARY
-            else:
-                if any(bool(child.test_type & TestType.BINARY) for child in self.children):
-                    self._type = TestType.BINARY
-                else:
-                    self._type = self.subtest_type()
-                    if (self._type == TestType.UNKNOWN and self.children) or bool(self._type & TestType.TEXT):
-                        # A pattern is considered to be a text test when all its patterns are text patterns;
-                        # otherwise, it is considered to be a binary pattern.
-                        if all(bool(child.test_type & TestType.TEXT) for child in self.children):
-                            self._type = TestType.TEXT
-                        else:
-                            self._type = TestType.UNKNOWN
+            self._type = self.subtest_type()
             delattr(self, "__calculating_test_type")
         return self._type
 
@@ -1070,10 +1106,9 @@ class MagicTest(ABC):
         binary soft magic pass printed nothing, so it lands on whatever the ``TEXTTEST`` soft magic
         pass printed (``src/funcs.c`` and ``src/ascmagic.c``). ``set_test_type`` in
         ``src/apprentice.c`` decides which pass a definition runs in from the type and flags of its
-        level 0 test alone, and that is what `subtest_type` reports. `test_type`, which chooses the
-        pass PolyFile itself runs the test in, cannot answer this: it reports a group with any
-        binary subtest as binary, which is why libmagic describes the encoding of
-        ``file/tests/pnm1.testfile`` while PolyFile matches it in its binary pass.
+        level 0 test alone, and that is what `subtest_type` reports. `test_type` answers from the
+        same place, except where `IndirectTest` has forced an ancestor to binary, so reading
+        `subtest_type` keeps the question about libmagic rather than about PolyFile's own pass.
 
         Returns:
             True if libmagic would append the description to this test's message.
@@ -1361,9 +1396,9 @@ class MagicTest(ABC):
             writer.write(self.message, color=ANSIColor.BLUE, bold=True)
         if self.level == 0:
             if self.test_type & TestType.BINARY:
-                writer.write(f" \uF5BB BINARY TEST", color=ANSIColor.BLUE)
-            elif self.test_type & TestType.TEXT:
-                writer.write(f" \uF5B9 ASCII TEST", color=ANSIColor.BLUE)
+                writer.write(" \uF5BB BINARY TEST", color=ANSIColor.BLUE)
+            if self.test_type & TestType.TEXT:
+                writer.write(" \uF5B9 ASCII TEST", color=ANSIColor.BLUE)
         writer.write(pre_mime_text)
         if self.mime is not None:
             writer.write(f"\n  {indent}!:mime ", dim=True)
@@ -1568,9 +1603,31 @@ class DataType(ABC, Generic[T]):
         """
         return "="
 
-    @abstractmethod
-    def is_text(self, value: T) -> bool:
-        raise NotImplementedError()
+    def declared_test_types(self) -> TestType:
+        """The passes this type's declaration named outright, if it named any.
+
+        Returns:
+            `TestType.UNKNOWN`, unless the declaration carried a ``b`` or a ``t``.
+        """
+        return TestType.UNKNOWN
+
+    def test_types(self, expected: T) -> TestType:
+        """The soft magic passes libmagic runs a level 0 test of this type in.
+
+        ``set_test_type`` assigns ``BINTEST`` to every type that reads a fixed width of bytes, and
+        to a string type that names no pass of its own, which the comment there calls a
+        compatibility choice (``file/src/apprentice.c:1200-1284``).
+
+        Args:
+            expected: The value the test compares against.
+
+        Returns:
+            The passes the test belongs to.
+        """
+        declared = self.declared_test_types()
+        if declared != TestType.UNKNOWN:
+            return declared
+        return TestType.BINARY
 
     @abstractmethod
     def parse_expected(self, specification: str) -> T:
@@ -1673,9 +1730,6 @@ class GUIDType(DataType[Union[UUID, UUIDWildcard]]):
             raise ValueError(f"GUIDs only support big and little endianness, not {endianness!r}")
         self.endianness: Endianness = endianness
 
-    def is_text(self, value: Union[UUID, UUIDWildcard]) -> bool:
-        return False
-
     def strength_term(self, expected: Union[UUID, UUIDWildcard]) -> int:
         """A GUID is sized like the sixteen-byte integer it is (``file/src/apprentice.c:912-915``)."""
         return 16 * STRENGTH_MULT
@@ -1717,9 +1771,6 @@ class UTF16Type(DataType[bytes]):
         super().__init__(name)
         self.endianness: Endianness = endianness
         self.num_bytes: Optional[int] = num_bytes
-
-    def is_text(self, value: bytes) -> bool:
-        return True
 
     def strength_term(self, expected: bytes) -> int:
         """Half of what the same value would score as a `string` (``file/src/apprentice.c:1003``).
@@ -2193,8 +2244,8 @@ class StringType(DataType[StringTest]):
             parts.append(flags)
         return "/".join(parts)
 
-    def is_text(self, value: StringTest) -> bool:
-        return self.force_text
+    def declared_test_types(self) -> TestType:
+        return declared_passes(self.force_text, self.force_binary)
 
     def strength_term(self, expected: StringTest) -> int:
         """One unit per byte of the value, the dominant term for most definitions.
@@ -2292,22 +2343,25 @@ class SearchType(StringType):
         """
         return self.num_bytes
 
-    def is_text(self, value: StringTest) -> bool:
-        """Whether libmagic runs a search for `value` in its text pass.
+    def test_types(self, expected: StringTest) -> TestType:
+        """The passes libmagic runs a search for `expected` in.
 
-        An explicit ``b`` flag decides on its own: ``set_test_type`` sets ``BINTEST`` from the
-        declared string flags and breaks out of the case before it ever reaches
-        ``file_looks_utf8`` (``file/src/apprentice.c:1258-1283``).
+        A declared ``b`` or ``t`` decides on its own: ``set_test_type`` reads the string flags and
+        breaks out of the case before it ever reaches ``file_looks_utf8``
+        (``file/src/apprentice.c:1258-1283``). Otherwise the value itself decides.
 
         Args:
-            value: The parsed value the search looks for.
+            expected: The parsed value the search looks for.
 
         Returns:
-            True if libmagic classifies the search as a text test.
+            The passes the search belongs to.
         """
-        if self.force_binary:
-            return False
-        return value.is_always_text()
+        declared = self.declared_test_types()
+        if declared != TestType.UNKNOWN:
+            return declared
+        elif expected.is_always_text():
+            return TestType.TEXT
+        return TestType.BINARY
 
     def strength_term(self, expected: StringTest) -> int:
         """Far less than a `string` of the same length, because a search roams the buffer.
@@ -2411,10 +2465,6 @@ class PascalStringType(DataType[StringTest]):
         self.endianness: Endianness = endianness
         self.count_includes_length: int = count_includes_length
         self.string_type: StringType = StringType.parse(f"string/{string_flags}")
-
-    def is_text(self, value: StringTest) -> bool:
-        # TODO: See if Pascal strings should sometimes be forced to be text
-        return False
 
     def strength_term(self, expected: StringTest) -> int:
         """Scored like a `string`, counting the length prefix as part of the value.
@@ -2637,8 +2687,11 @@ class RegexType(DataType[MagicRegex]):
 
     DOLLAR_PATTERN = re.compile(rb"(^|[^\\])\$", re.MULTILINE)
 
-    def is_text(self, value: MagicRegex) -> bool:
-        """Whether libmagic runs this regular expression in its text pass.
+    def declared_test_types(self) -> TestType:
+        return declared_passes(self.force_text, self.force_binary)
+
+    def test_types(self, expected: MagicRegex) -> TestType:
+        """The passes libmagic runs this regular expression in.
 
         A declared ``b`` or ``t`` decides on its own, because ``set_test_type`` reads the string
         flags and breaks out of the case before it reaches ``file_looks_utf8``
@@ -2646,16 +2699,17 @@ class RegexType(DataType[MagicRegex]):
         rule libmagic applies to a `search` value.
 
         Args:
-            value: The parsed regular expression.
+            expected: The parsed regular expression.
 
         Returns:
-            True if libmagic classifies the test as a text test.
+            The passes the test belongs to.
         """
-        if self.force_binary:
-            return False
-        elif self.force_text:
-            return True
-        return _looks_like_utf8(value.pattern)
+        declared = self.declared_test_types()
+        if declared != TestType.UNKNOWN:
+            return declared
+        elif _looks_like_utf8(expected.pattern):
+            return TestType.TEXT
+        return TestType.BINARY
 
     def strength_term(self, expected: MagicRegex) -> int:
         """One unit per literal character, capped the way a `search` is.
@@ -2961,9 +3015,6 @@ class NumericDataType(DataType[NumericValue]):
         if self.endianness == Endianness.PDP and self.base_type.num_bytes != 4:
             raise ValueError(f"PDP endianness can only be used with four byte base types, not {self.base_type}")
 
-    def is_text(self, value: NumericValue) -> bool:
-        return False
-
     def strength_term(self, expected: NumericValue) -> int:
         """One unit per byte the type reads (``file/src/apprentice.c:975-996``)."""
         return self.base_type.num_bytes * STRENGTH_MULT
@@ -3187,10 +3238,10 @@ class ConstantMatchTest(MagicTest, Generic[T]):
         return self.data_type.relation(self.constant)
 
     def subtest_type(self) -> TestType:
-        if self.data_type.is_text(self.constant):
-            return TestType.TEXT
-        else:
-            return TestType.BINARY
+        return self.data_type.test_types(self.constant)
+
+    def declared_test_type(self) -> TestType:
+        return self.data_type.declared_test_types()
 
     def calculate_absolute_offset(self, data: bytes, parent_match: Optional[TestResult] = None) -> int:
         return self.offset.to_absolute(data, parent_match, self.data_type.allows_invalid_offsets(self.constant))
@@ -3338,6 +3389,8 @@ class IndirectTest(MagicTest):
         self.relative: bool = relative
         self.can_match_mime = True
         self.can_be_indirect = True
+        # an indirect test can dispatch any other test, so PolyFile keeps the whole group in the
+        # binary pass rather than letting a level 0 flag hand it the decoded text buffer
         self._type = TestType.BINARY
         p = parent
         while p is not None:
@@ -4514,9 +4567,10 @@ class MagicMatcher:
         self._tests_by_ext = defaultdict(set)
         self._tests_by_mime = defaultdict(set)
         for test in self._tests:
-            if test.test_type == TestType.TEXT:
+            test_type = test.test_type
+            if test_type & TestType.TEXT:
                 self._text_tests[test] = None
-            else:
+            if test_type & TestType.BINARY or test_type == TestType.UNKNOWN:
                 self._non_text_tests[test] = None
             if test.can_be_indirect:
                 self._tests_that_can_be_indirect.add(test)

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -2274,3 +2274,100 @@ class PassSelectionTest(TestCase):
             if test.source_info is not None
         }
         self.assertEqual({"sgml:6", "sgml:17", "sgml:74"}, in_both)
+
+
+class PassGateTest(TestCase):
+    """Regression tests for the missing pass gate reported in issue #3490.
+
+    `softmagic` skips an entry when the buffer looks like text and the entry declares only
+    `STRING_BINTEST`, and when it does not and the entry declares only `STRING_TEXTTEST`
+    (`file/src/softmagic.c:249-253`). PolyFile ran every non-text test against every input, so a
+    definition that spells one shebang twice reported both spellings.
+    """
+
+    @staticmethod
+    def messages(definition: str, data: bytes) -> Set[str]:
+        """Runs a single magic definition against `data`.
+
+        Args:
+            definition: The text of a magic definition file, with tab-separated columns.
+            data: The bytes to classify.
+
+        Returns:
+            The message of every match.
+        """
+        with TemporaryDirectory() as tmp_dir:
+            magic_file = Path(tmp_dir) / "test.magic"
+            magic_file.write_text(definition)
+            return {str(match) for match in MagicMatcher.parse(magic_file).match(data)}
+
+    def test_a_binary_flagged_entry_skips_a_text_buffer(self):
+        """Tests that `b` keeps an entry from running against a buffer that looks like text."""
+        definition = "0\tstring/b\tMARK\tbinary only\n"
+        self.assertNotIn("binary only", self.messages(definition, b"MARK and then some text\n"))
+        self.assertIn("binary only", self.messages(definition, b"MARK\x00\x01\x02\xff"))
+
+    def test_a_text_flagged_entry_skips_a_binary_buffer(self):
+        """Tests that `t` keeps an entry from running against a buffer that is not text.
+
+        The entry never reaches the text pass, because `file_buffer` runs `file_ascmagic` only for
+        a buffer `file_encoding` recognized (`file/src/funcs.c:495-503`).
+        """
+        definition = "0\tstring/t\tMARK\ttext only\n"
+        self.assertNotIn("text only", self.messages(definition, b"MARK\x00\x01\x02\xff"))
+        self.assertIn("text only, ASCII text",
+                      self.messages(definition, b"MARK and then some text\n"))
+
+    def test_an_unflagged_entry_runs_against_both_kinds_of_buffer(self):
+        """Tests that an entry naming no pass is never skipped for the pass it landed in.
+
+        The gate reads the declared flags, not the pass the entry was sorted into, because
+        `softmagic` tests `m->str_flags` rather than `m->flag`.
+        """
+        definition = "0\tstring\tMARK\tno flags\n"
+        self.assertIn("no flags", self.messages(definition, b"MARK\x00\x01\x02\xff"))
+        self.assertIn("no flags", self.messages(definition, b"MARK and then some text\n"))
+
+    def test_a_both_flagged_entry_runs_against_both_kinds_of_buffer(self):
+        """Tests that `b` and `t` together survive the gate in either direction.
+
+        `softmagic`'s skip fires only when exactly one of the two bits is set, so an entry that
+        sets both is never skipped. It must still report one match per buffer and not two, because
+        libmagic stops after its binary pass prints something.
+        """
+        definition = "0\tstring/bt\tMARK\tboth flags\n"
+        for data in (b"MARK\x00\x01\x02\xff", b"MARK and then some text\n"):
+            with self.subTest(data=data):
+                self.assertEqual({"both flags"}, self.messages(definition, data))
+
+    def test_a_script_reports_only_libmagics_variant(self):
+        """Tests that `file/tests/cmd1.testfile` no longer reports a binary variant.
+
+        `magic_defs/varied.script` spells one shebang twice, `string/wt` at line 8 and
+        `string/wb` at line 12. PolyFile reported `a /usr/bin/cmd1 script executable (binary
+        data)` alongside the correct message; `file -b` reports only the one asserted here.
+        """
+        self.assertTrue(FILE_TEST_DIR.exists(),
+                        "Run `git submodule init && git submodule update` in the repository root.")
+        for stem in ("cmd1", "cmd2"):
+            with self.subTest(stem=stem):
+                data = (FILE_TEST_DIR / f"{stem}.testfile").read_bytes()
+                messages = {str(m) for m in MagicMatcher.DEFAULT_INSTANCE.match(data)}
+                self.assertEqual({f"a /usr/bin/{stem} script, ASCII text executable"}, messages)
+
+    def test_an_ascii_svg_is_not_described(self):
+        """Tests that an SVG matched on the file's own bytes gains no encoding description.
+
+        `magic_defs/sgml:6` declares both flags, so it runs in both passes. libmagic's binary pass
+        matches it on the file's bytes and `checkdone` stops before `file_ascmagic`
+        (`file/src/funcs.c:479-503`), so `file -b` reports a bare `SVG Scalable Vector Graphics
+        image`. The same definition matched on the decoded buffer does gain the description, which
+        is what `file/tests/utf16xmlsvg.testfile` expects.
+        """
+        svg = b'<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>\n'
+        messages = {str(m) for m in MagicMatcher.DEFAULT_INSTANCE.match(svg)}
+        self.assertIn("SVG Scalable Vector Graphics image", messages)
+        self.assertNotIn("SVG Scalable Vector Graphics image, ASCII text", messages)
+        utf16 = b"\xff\xfe" + svg.decode("utf-8").encode("utf-16le")
+        self.assertIn("SVG Scalable Vector Graphics image, Unicode text, UTF-16, little-endian text",
+                      {str(m) for m in MagicMatcher.DEFAULT_INSTANCE.match(utf16)})

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -2170,3 +2170,107 @@ class SearchFlagTableTest(TestCase):
         """
         self.assertIs(DataType.parse("search/b64"), DataType.parse("search/64/b"))
         self.assertEqual(64, DataType.parse("search/b64").repetitions)
+
+
+class PassSelectionTest(TestCase):
+    """Regression tests for the pass selection defect reported in issue #3490.
+
+    libmagic decides which of its two soft magic passes a definition belongs to in
+    `set_test_type`, from the type and the `b`/`t` string flags of the entry's level 0 line alone
+    (`file/src/apprentice.c:1200-1284`). `set_text_binary` hands it one entry per top-level test
+    (`file/src/apprentice.c:1423-1453`), so a subtest never changes the answer. PolyFile derived
+    the classification from a test's children instead, which put both halves of a text/binary
+    definition pair in the binary pass.
+    """
+
+    @staticmethod
+    def passes(definition: str) -> polyfile.magic.TestType:
+        """The passes PolyFile runs the one level 0 test of `definition` in.
+
+        Args:
+            definition: The text of a magic definition file, with tab-separated columns.
+
+        Returns:
+            The passes the test landed in.
+        """
+        with TemporaryDirectory() as tmp_dir:
+            magic_file = Path(tmp_dir) / "test.magic"
+            magic_file.write_text(definition)
+            matcher = MagicMatcher.parse(magic_file)
+            text, binary = list(matcher.text_tests), list(matcher.non_text_tests)
+        assert len(set(text) | set(binary)) == 1, "expected exactly one level 0 test"
+        found = polyfile.magic.TestType.UNKNOWN
+        if text:
+            found |= polyfile.magic.TestType.TEXT
+        if binary:
+            found |= polyfile.magic.TestType.BINARY
+        return found
+
+    def test_a_text_flag_outranks_a_binary_subtest(self):
+        """Tests that `t` on the level 0 line wins over a binary subtest under it.
+
+        `magic_defs/varied.script:8` is `string/wt` with a `string/T` subtest, and its `string/wb`
+        twin sits four lines below. PolyFile put both in the binary pass, so
+        `file/tests/cmd1.testfile` reported the binary variant as well as the text one.
+        """
+        definition = "0\tstring/wt\t#!\\ \ta\n>&-1\tstring/T\tx\t%s script text executable\n"
+        self.assertEqual(polyfile.magic.TestType.TEXT, self.passes(definition))
+
+    def test_a_binary_flag_outranks_a_text_subtest(self):
+        """Tests that `b` on the level 0 line wins over an all-text group.
+
+        `magic_defs/varied.script:12` is the binary half of the same pair.
+        """
+        definition = "0\tstring/wb\t#!\\ \ta\n>&-1\tstring/T\tx\t%s script executable\n"
+        self.assertEqual(polyfile.magic.TestType.BINARY, self.passes(definition))
+
+    def test_a_subtest_never_adds_a_pass(self):
+        """Tests that a numeric subtest does not drag a text entry into the binary pass.
+
+        `file -l -m` over a definition of `0 string/t XY` with a `>2 belong 0` subtest lists it
+        under `Text patterns` only, because `set_text_binary` calls `set_test_type` once per
+        top-level entry and never for a continuation line.
+        """
+        definition = "0\tstring/t\tXY\tflagged text\n>2\tbelong\t0\t\\b, zero\n"
+        self.assertEqual(polyfile.magic.TestType.TEXT, self.passes(definition))
+        definition = "0\tsearch/1\tPQ\tunflagged search\n>2\tbelong\t0\t\\b, zero\n"
+        self.assertEqual(polyfile.magic.TestType.TEXT, self.passes(definition))
+
+    def test_an_unflagged_entry_belongs_to_exactly_one_pass(self):
+        """Tests the fallbacks `set_test_type` reaches when no flag names a pass.
+
+        A `string` takes the binary pass whatever its value, which the comment there calls a
+        compatibility choice; a `search` or a `regex` takes the pass its own value looks like,
+        by `file_looks_utf8`.
+        """
+        for definition, expected in (
+                ("0\tstring\tTU\tplain string\n", polyfile.magic.TestType.BINARY),
+                ("0\tregex/1024\tab+c\tunflagged regex\n", polyfile.magic.TestType.TEXT),
+                ("0\tsearch/1\ta\\x00b\tnull byte\n", polyfile.magic.TestType.BINARY),
+                ("0\tlestring16\tVersion=\tsixteen bit\n", polyfile.magic.TestType.BINARY),
+        ):
+            with self.subTest(definition=definition):
+                self.assertEqual(expected, self.passes(definition))
+
+    def test_both_flags_belong_to_both_passes(self):
+        """Tests that an entry carrying `b` and `t` runs in both passes.
+
+        `softmagic` skips an entry only when exactly one of the two bits is set and it is the
+        wrong one (`file/src/softmagic.c:249-253`), and `set_test_type` sets both bits from both
+        flags, so `magic_defs/sgml:6`, `sgml:17` and `sgml:74` are listed under `Binary patterns`
+        and under `Text patterns` by `file -l`. `TestType` could not express that.
+        """
+        self.assertEqual(polyfile.magic.TestType.BOTH,
+                         self.passes("0\tstring/bt\tRS\tboth flags\n"))
+        self.assertEqual(polyfile.magic.TestType.BOTH,
+                         self.passes("0\tsearch/4096/cWbt\t\\<!doctype\\ svg\tSVG XML document\n"))
+
+    def test_the_shipped_both_flag_entries_are_in_both_passes(self):
+        """Tests that the three shipped `b`-and-`t` entries reach both passes."""
+        matcher = MagicMatcher.parse(*MAGIC_DEFS)
+        in_both = {
+            f"{test.source_info.path.name}:{test.source_info.line}"
+            for test in set(matcher.text_tests) & set(matcher.non_text_tests)
+            if test.source_info is not None
+        }
+        self.assertEqual({"sgml:6", "sgml:17", "sgml:74"}, in_both)

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -204,79 +204,79 @@ class MagicTest(TestCase):
 
     def test_text_tests(self):
         matcher = MagicMatcher.parse(*MAGIC_DEFS)
-        self.assertEqual(len(matcher.text_tests & matcher.non_text_tests), 0)
         for test in matcher.text_tests:
-            self.assertEqual(test.test_type, polyfile.magic.TestType.TEXT)
+            self.assertTrue(test.test_type & polyfile.magic.TestType.TEXT)
         for test in matcher.non_text_tests:
-            self.assertNotEqual(test.test_type, polyfile.magic.TestType.TEXT)
+            self.assertTrue(test.test_type & polyfile.magic.TestType.BINARY
+                            or test.test_type == polyfile.magic.TestType.UNKNOWN)
+        # the three entries in both passes declare both the `b` and the `t` flag; see
+        # PassSelectionTest.test_the_shipped_both_flag_entries_are_in_both_passes
+        self.assertEqual(3, len(set(matcher.text_tests) & set(matcher.non_text_tests)))
         num_text_tests = len(matcher.text_tests)
         # expected_text_tests = repr({
         #         f"{test.source_info.path.name}:{test.source_info.line}"
         #         for test in matcher.text_tests if test.source_info is not None
         # })
         expected_text_tests = {
-            'a2ml:38', 'a2ml:44', 'andrew:30', 'android:221', 'apple:6', 'archive:583',
-            'assembler:11', 'assembler:13', 'assembler:15', 'assembler:17', 'assembler:5',
-            'assembler:7', 'assembler:9', 'audio:645', 'audio:648', 'bioinformatics:156',
-            'c-lang:10', 'c-lang:103', 'c-lang:107', 'c-lang:111', 'c-lang:22', 'c-lang:25',
-            'c-lang:29', 'c-lang:32', 'c-lang:35', 'c-lang:38', 'c-lang:41', 'c-lang:44',
-            'c-lang:47', 'c-lang:50', 'c-lang:59', 'c-lang:64', 'c-lang:68', 'c-lang:72',
-            'c-lang:77', 'c-lang:8', 'c-lang:81', 'c-lang:85', 'c-lang:89', 'c-lang:95', 'cad:317',
-            'cad:365', 'cddb:12', 'clojure:23', 'clojure:26', 'clojure:29', 'commands:101',
-            'commands:104', 'commands:106', 'commands:111', 'commands:113', 'commands:115',
-            'commands:118', 'commands:121', 'commands:123', 'commands:125', 'commands:128',
-            'commands:131', 'commands:133', 'commands:138', 'commands:14', 'commands:140',
-            'commands:146', 'commands:148', 'commands:150', 'commands:152', 'commands:164',
-            'commands:167', 'commands:169', 'commands:171', 'commands:174', 'commands:18',
-            'commands:191', 'commands:213', 'commands:23', 'commands:231', 'commands:232',
-            'commands:233', 'commands:25', 'commands:27', 'commands:29', 'commands:34',
-            'commands:36', 'commands:38', 'commands:40', 'commands:43', 'commands:45',
-            'commands:47', 'commands:49', 'commands:51', 'commands:53', 'commands:55',
-            'commands:57', 'commands:59', 'commands:61', 'commands:64', 'commands:66',
-            'commands:68', 'commands:7', 'commands:70', 'commands:72', 'commands:74', 'commands:76',
-            'commands:80', 'commands:83', 'commands:87', 'commands:91', 'commands:95',
-            'commands:99', 'csv:6', 'ctags:6', 'database:900', 'diff:13', 'diff:25', 'diff:35',
-            'diff:41', 'diff:48', 'fonts:132', 'fonts:6', 'forth:10', 'forth:16', 'fortran:6',
-            'games:248', 'games:411', 'games:412', 'gentoo:44', 'gimp:14', 'gimp:7', 'gnu:170',
-            'images:2364', 'images:2657', 'inform:9', 'java:19', 'java:49', 'java:51',
-            'javascript:10', 'javascript:12', 'javascript:14', 'javascript:16', 'javascript:22',
-            'javascript:26', 'javascript:30', 'javascript:34', 'javascript:38', 'javascript:42',
-            'javascript:46', 'javascript:50', 'javascript:54', 'javascript:6', 'javascript:60',
-            'javascript:8', 'json:12', 'json:6', 'k9:28', 'kde:10', 'kde:6', 'kde:8', 'lex:10',
-            'lex:12', 'linux:366', 'linux:369', 'linux:370', 'linux:54', 'linux:938', 'lisp:16',
-            'lisp:18', 'lisp:20', 'lisp:22', 'lisp:24', 'lisp:26', 'lisp:77', 'lua:11', 'lua:13',
-            'lua:15', 'lua:17', 'lua:9', 'm4:5', 'm4:8', 'magic:8', 'mail.news:11', 'mail.news:13',
-            'mail.news:15', 'mail.news:17', 'mail.news:19', 'mail.news:21', 'mail.news:23',
-            'mail.news:25', 'mail.news:27', 'mail.news:29', 'mail.news:31', 'mail.news:33',
-            'mail.news:35', 'mail.news:49', 'mail.news:7', 'mail.news:9', 'make:15', 'make:19',
-            'make:6', 'mathematica:21', 'misctools:104', 'misctools:6', 'misctools:99', 'msdos:26',
-            'msdos:28', 'msx:79', 'nim-lang:7', 'pascal:5', 'perl:10', 'perl:12', 'perl:14',
-            'perl:16', 'perl:18', 'perl:20', 'perl:22', 'perl:24', 'perl:36', 'perl:40', 'perl:47',
-            'perl:48', 'perl:49', 'perl:50', 'perl:51', 'perl:52', 'perl:53', 'perl:54', 'perl:8',
-            'psl:9', 'python:250', 'python:253', 'python:256', 'python:262', 'python:271',
-            'python:277', 'python:295', 'python:303', 'python:309', 'python:9', 'qt:13',
-            'revision:7', 'ringdove:12', 'ringdove:13', 'ringdove:14', 'ringdove:15', 'ringdove:16',
-            'ringdove:17', 'ringdove:18', 'ringdove:19', 'ringdove:20', 'ringdove:21',
-            'ringdove:22', 'ringdove:25', 'ringdove:26', 'ringdove:27', 'ringdove:28',
-            'ringdove:29', 'ringdove:32', 'ringdove:6', 'ringdove:7', 'ringdove:8', 'ringdove:9',
-            'rst:5', 'ruby:12', 'ruby:15', 'ruby:18', 'ruby:25', 'ruby:31', 'ruby:37', 'ruby:44',
-            'ruby:50', 'ruby:9', 'securitycerts:4', 'securitycerts:5', 'sgml:102', 'sgml:105',
-            'sgml:108', 'sgml:111', 'sgml:115', 'sgml:121', 'sgml:128', 'sgml:131', 'sgml:134',
-            'sgml:140', 'sgml:146', 'sgml:152', 'sgml:153', 'sgml:154', 'sgml:160', 'sgml:161',
-            'sgml:162', 'sgml:17', 'sgml:57', 'sgml:6', 'sgml:62', 'sgml:64', 'sgml:66', 'sgml:78',
-            'sgml:81', 'sgml:84', 'sgml:87', 'sgml:90', 'sgml:93', 'sgml:96', 'sgml:99', 'sisu:11',
-            'sisu:14', 'sisu:17', 'sisu:5', 'sisu:8', 'sketch:6', 'softquad:26', 'subtitle:19',
-            'subtitle:25', 'tcl:11', 'tcl:13', 'tcl:15', 'tcl:17', 'tcl:19', 'tcl:21', 'tcl:25',
-            'tcl:28', 'tcl:7', 'tcl:9', 'terminfo:49', 'tex:107', 'tex:108', 'tex:109', 'tex:110',
-            'tex:111', 'tex:112', 'tex:113', 'tex:114', 'tex:115', 'tex:116', 'tex:117', 'tex:119',
-            'tex:121', 'tex:123', 'tex:125', 'tex:127', 'tex:133', 'tex:135', 'tex:137', 'tex:139',
-            'tex:141', 'tex:143', 'tex:145', 'tex:147', 'tex:149', 'tex:151', 'tex:153', 'tex:155',
-            'tex:157', 'tex:159', 'tex:22', 'tex:23', 'tex:24', 'tex:25', 'tex:26', 'tex:27',
-            'tex:28', 'tex:29', 'tex:30', 'tex:31', 'tex:32', 'tex:33', 'tex:34', 'tex:61',
-            'tex:64', 'tex:67', 'tex:70', 'tex:73', 'tex:76', 'tex:79', 'tex:82', 'tex:85',
-            'tex:88', 'tex:92', 'tex:95', 'tex:96', 'tex:97', 'tex:98', 'tex:99', 'troff:12',
-            'troff:15', 'troff:18', 'troff:23', 'troff:26', 'troff:31', 'troff:9', 'uuencode:18',
-            'uuencode:22', 'uuencode:26', 'windows:1064', 'windows:457',
+            'a2ml:38', 'a2ml:44', 'algol68:12', 'algol68:14', 'algol68:16', 'algol68:18', 'algol68:9',
+            'andrew:30', 'android:221', 'apple:6', 'archive:583', 'assembler:11', 'assembler:13',
+            'assembler:15', 'assembler:17', 'assembler:5', 'assembler:7', 'assembler:9', 'audio:645',
+            'audio:648', 'bioinformatics:113', 'bioinformatics:156', 'c-lang:10', 'c-lang:103', 'c-lang:107',
+            'c-lang:111', 'c-lang:15', 'c-lang:22', 'c-lang:25', 'c-lang:29', 'c-lang:32', 'c-lang:35',
+            'c-lang:38', 'c-lang:41', 'c-lang:44', 'c-lang:47', 'c-lang:50', 'c-lang:59', 'c-lang:64',
+            'c-lang:68', 'c-lang:72', 'c-lang:77', 'c-lang:8', 'c-lang:81', 'c-lang:85', 'c-lang:89',
+            'c-lang:95', 'cddb:12', 'clojure:23', 'clojure:26', 'clojure:29', 'commands:101', 'commands:104',
+            'commands:106', 'commands:111', 'commands:113', 'commands:115', 'commands:118', 'commands:121',
+            'commands:123', 'commands:125', 'commands:128', 'commands:131', 'commands:133', 'commands:138',
+            'commands:14', 'commands:140', 'commands:146', 'commands:148', 'commands:150', 'commands:152',
+            'commands:164', 'commands:167', 'commands:169', 'commands:171', 'commands:174', 'commands:18',
+            'commands:191', 'commands:213', 'commands:23', 'commands:231', 'commands:232', 'commands:233',
+            'commands:25', 'commands:27', 'commands:29', 'commands:34', 'commands:36', 'commands:38',
+            'commands:40', 'commands:43', 'commands:45', 'commands:47', 'commands:49', 'commands:51',
+            'commands:53', 'commands:55', 'commands:57', 'commands:59', 'commands:61', 'commands:64',
+            'commands:66', 'commands:68', 'commands:7', 'commands:70', 'commands:72', 'commands:74',
+            'commands:76', 'commands:80', 'commands:83', 'commands:87', 'commands:91', 'commands:95',
+            'commands:99', 'csv:6', 'ctags:6', 'database:900', 'diff:114', 'diff:13', 'diff:25', 'diff:35',
+            'diff:41', 'diff:48', 'fonts:132', 'fonts:6', 'forth:10', 'forth:16', 'fortran:6', 'frame:71',
+            'games:180', 'games:248', 'games:411', 'games:412', 'gentoo:44', 'gentoo:49', 'gimp:14', 'gimp:7',
+            'gnu:170', 'images:196', 'images:210', 'images:219', 'images:2364', 'images:2657', 'images:666',
+            'inform:9', 'java:19', 'java:49', 'java:51', 'javascript:10', 'javascript:12', 'javascript:14',
+            'javascript:16', 'javascript:22', 'javascript:26', 'javascript:30', 'javascript:34',
+            'javascript:38', 'javascript:42', 'javascript:46', 'javascript:50', 'javascript:54', 'javascript:6',
+            'javascript:60', 'javascript:8', 'json:12', 'json:6', 'k9:28', 'kde:10', 'kde:6', 'kde:8', 'kml:9',
+            'lex:10', 'lex:12', 'lex:7', 'linux:366', 'linux:369', 'linux:370', 'linux:54', 'linux:938',
+            'lisp:16', 'lisp:18', 'lisp:20', 'lisp:22', 'lisp:24', 'lisp:26', 'lisp:77', 'lua:11', 'lua:13',
+            'lua:15', 'lua:17', 'lua:9', 'm4:5', 'm4:8', 'macintosh:14', 'magic:8', 'mail.news:11',
+            'mail.news:13', 'mail.news:15', 'mail.news:17', 'mail.news:19', 'mail.news:21', 'mail.news:23',
+            'mail.news:25', 'mail.news:27', 'mail.news:29', 'mail.news:31', 'mail.news:33', 'mail.news:35',
+            'mail.news:49', 'mail.news:7', 'mail.news:9', 'make:15', 'make:19', 'make:6', 'mathematica:21',
+            'mime:6', 'mime:8', 'misctools:104', 'misctools:6', 'misctools:99', 'msdos:26', 'msdos:28',
+            'msdos:9', 'msx:79', 'mup:13', 'nim-lang:7', 'os2:204', 'os2:9', 'pascal:5', 'pdf:45', 'perl:10',
+            'perl:12', 'perl:14', 'perl:16', 'perl:18', 'perl:20', 'perl:22', 'perl:24', 'perl:36', 'perl:40',
+            'perl:47', 'perl:48', 'perl:49', 'perl:50', 'perl:51', 'perl:52', 'perl:53', 'perl:54', 'perl:8',
+            'psl:9', 'python:250', 'python:253', 'python:256', 'python:262', 'python:271', 'python:277',
+            'python:295', 'python:303', 'python:309', 'python:9', 'qt:13', 'revision:7', 'ringdove:12',
+            'ringdove:13', 'ringdove:14', 'ringdove:15', 'ringdove:16', 'ringdove:17', 'ringdove:18',
+            'ringdove:19', 'ringdove:20', 'ringdove:21', 'ringdove:22', 'ringdove:25', 'ringdove:26',
+            'ringdove:27', 'ringdove:28', 'ringdove:29', 'ringdove:32', 'ringdove:6', 'ringdove:7',
+            'ringdove:8', 'ringdove:9', 'rst:5', 'ruby:12', 'ruby:15', 'ruby:18', 'ruby:25', 'ruby:31',
+            'ruby:37', 'ruby:44', 'ruby:50', 'ruby:9', 'scientific:71', 'securitycerts:4', 'securitycerts:5',
+            'sgi:137', 'sgml:102', 'sgml:105', 'sgml:108', 'sgml:111', 'sgml:115', 'sgml:121', 'sgml:128',
+            'sgml:131', 'sgml:134', 'sgml:140', 'sgml:146', 'sgml:152', 'sgml:153', 'sgml:154', 'sgml:160',
+            'sgml:161', 'sgml:162', 'sgml:17', 'sgml:21', 'sgml:57', 'sgml:6', 'sgml:62', 'sgml:64', 'sgml:66',
+            'sgml:74', 'sgml:78', 'sgml:81', 'sgml:84', 'sgml:87', 'sgml:90', 'sgml:93', 'sgml:96', 'sgml:99',
+            'sisu:11', 'sisu:14', 'sisu:17', 'sisu:5', 'sisu:8', 'sketch:6', 'softquad:26', 'sosi:30',
+            'subtitle:19', 'subtitle:25', 'subtitle:32', 'tcl:11', 'tcl:13', 'tcl:15', 'tcl:17', 'tcl:19',
+            'tcl:21', 'tcl:25', 'tcl:28', 'tcl:7', 'tcl:9', 'terminfo:49', 'tex:107', 'tex:108', 'tex:109',
+            'tex:110', 'tex:111', 'tex:112', 'tex:113', 'tex:114', 'tex:115', 'tex:116', 'tex:117', 'tex:119',
+            'tex:121', 'tex:123', 'tex:125', 'tex:127', 'tex:133', 'tex:135', 'tex:137', 'tex:139', 'tex:141',
+            'tex:143', 'tex:145', 'tex:147', 'tex:149', 'tex:151', 'tex:153', 'tex:155', 'tex:157', 'tex:159',
+            'tex:22', 'tex:23', 'tex:24', 'tex:25', 'tex:26', 'tex:27', 'tex:28', 'tex:29', 'tex:30', 'tex:31',
+            'tex:32', 'tex:33', 'tex:34', 'tex:61', 'tex:64', 'tex:67', 'tex:70', 'tex:73', 'tex:76', 'tex:79',
+            'tex:82', 'tex:85', 'tex:88', 'tex:92', 'tex:95', 'tex:96', 'tex:97', 'tex:98', 'tex:99',
+            'troff:12', 'troff:15', 'troff:18', 'troff:23', 'troff:26', 'troff:31', 'troff:9', 'uuencode:11',
+            'uuencode:18', 'uuencode:22', 'uuencode:26', 'varied.script:18', 'varied.script:27',
+            'varied.script:8', 'windows:1313', 'windows:650', 'xwindows:39',
         }
         if num_text_tests > len(expected_text_tests):
             actual_text_tests = {
@@ -295,6 +295,10 @@ class MagicTest(TestCase):
                     history |= set(new_tests)
                     queue.extend(reversed(new_tests))
         self.assertEqual(num_text_tests, len(expected_text_tests))
+        self.assertEqual(expected_text_tests, {
+            f"{test.source_info.path.name}:{test.source_info.line}"
+            for test in matcher.text_tests if test.source_info is not None
+        })
 
     def test_only_matching(self):
         matcher = MagicMatcher.parse(*MAGIC_DEFS)

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -2044,3 +2044,72 @@ class UCSTextBufferTest(TestCase):
             {str(match) for match in
              MagicMatcher.DEFAULT_INSTANCE.match(self.encode(document, "utf-16le"))}
         )
+
+
+class DataTypeNameTest(TestCase):
+    """Regression tests for the interning collision reported in issue #3515.
+
+    `DataType.parse` interns every type it builds in `polyfile.magic.TYPES_BY_NAME`, keyed on the
+    name the type builds for itself. A flag the name leaves out makes two declarations that differ
+    only by that flag share one instance, and whichever declaration parses first decides the flags
+    for both. `RegexType` left out `t` and `b`, and `StringType`'s no-flag shortcut left out `f`.
+    """
+
+    def test_every_flag_reaches_the_name(self):
+        """Tests that each flag letter of each type appears in the parsed type's name.
+
+        A missing letter is what makes two declarations collide, so this asserts the property the
+        collision violated rather than the pairs that happened to collide.
+        """
+        for declaration, flags in (("string", "WwCcTftb"), ("search/8", "WwCcTfbs"),
+                                   ("regex/8", "cslTtb")):
+            for flag in flags:
+                spec = f"{declaration}/{flag}"
+                with self.subTest(declaration=spec):
+                    self.assertIn(flag, DataType.parse(spec).name)
+
+    def test_declarations_that_differ_by_one_flag_are_distinct(self):
+        """Tests that adding a flag to a declaration yields a different interned type."""
+        for declaration, flags in (("string", "WwCcTftb"), ("search/8", "WwCcTfbs"),
+                                   ("regex/8", "cslTtb")):
+            plain = DataType.parse(declaration)
+            for flag in flags:
+                spec = f"{declaration}/{flag}"
+                with self.subTest(declaration=spec):
+                    self.assertIsNot(plain, DataType.parse(spec))
+
+    def test_a_name_that_drops_a_flag_is_rejected(self):
+        """Tests that a type whose name loses a flag raises instead of interning silently.
+
+        The failure this prevents is silent: no exception and no warning, just a type behaving as
+        though its flag were absent. `DataType.parse` now reparses the name it built and compares
+        the result, which is the check that would have caught both halves of issue #3515.
+        """
+        class ForgetfulStringType(StringType):
+            def declaration(self) -> str:
+                return "string"
+
+        DataType.parse("string")
+        try:
+            polyfile.magic.StringType = ForgetfulStringType
+            polyfile.magic.TYPES_BY_NAME.pop("string/f", None)
+            with self.assertRaises(ValueError):
+                DataType.parse("string/f")
+        finally:
+            polyfile.magic.StringType = StringType
+            polyfile.magic.TYPES_BY_NAME.pop("string/f", None)
+
+    def test_whole_word_match_survives_parsing(self):
+        """Tests that `string/f` is its own type and matches whole words only.
+
+        `StringType.__init__` left `full_word_match` out of the tuple that decides whether a
+        declaration carries any flag, so a declaration whose only flag was `f` took the bare name
+        `string` and shared the unflagged type's instance.
+        """
+        whole_word = DataType.parse("string/f")
+        self.assertIsNot(whole_word, DataType.parse("string"))
+        self.assertTrue(whole_word.full_word_match)
+        self.assertFalse(DataType.parse("string").full_word_match)
+        expected = whole_word.parse_expected("if")
+        self.assertTrue(whole_word.match(b"if x then", expected))
+        self.assertFalse(whole_word.match(b"iffy", expected))

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -2061,7 +2061,7 @@ class DataTypeNameTest(TestCase):
         A missing letter is what makes two declarations collide, so this asserts the property the
         collision violated rather than the pairs that happened to collide.
         """
-        for declaration, flags in (("string", "WwCcTftb"), ("search/8", "WwCcTfbs"),
+        for declaration, flags in (("string", "WwCcTftb"), ("search/8", "WwCcTftbs"),
                                    ("regex/8", "cslTtb")):
             for flag in flags:
                 spec = f"{declaration}/{flag}"
@@ -2070,7 +2070,7 @@ class DataTypeNameTest(TestCase):
 
     def test_declarations_that_differ_by_one_flag_are_distinct(self):
         """Tests that adding a flag to a declaration yields a different interned type."""
-        for declaration, flags in (("string", "WwCcTftb"), ("search/8", "WwCcTfbs"),
+        for declaration, flags in (("string", "WwCcTftb"), ("search/8", "WwCcTftbs"),
                                    ("regex/8", "cslTtb")):
             plain = DataType.parse(declaration)
             for flag in flags:
@@ -2113,3 +2113,60 @@ class DataTypeNameTest(TestCase):
         expected = whole_word.parse_expected("if")
         self.assertTrue(whole_word.match(b"if x then", expected))
         self.assertFalse(whole_word.match(b"iffy", expected))
+
+
+class SearchFlagTableTest(TestCase):
+    """Regression tests for the `search` flag table reported in issue #3478.
+
+    libmagic reads the string flags of a `search` in one loop shared with `string`, `pstring` and
+    `regex` (`file/src/apprentice.c:1940-2028`), and the letters are defined in
+    `file/src/file.h:415-431`. `SearchType.parse` read `B` as compact whitespace, read `b` as
+    optional blanks, and dropped `t` altogether.
+    """
+
+    FLAGS: Tuple[Tuple[str, str], ...] = (
+        ("W", "compact_whitespace"),
+        ("w", "optional_blanks"),
+        ("c", "case_insensitive_lower"),
+        ("C", "case_insensitive_upper"),
+        ("T", "trim"),
+        ("f", "full_word_match"),
+        ("s", "match_to_start"),
+        ("t", "force_text"),
+        ("b", "force_binary"),
+    )
+    """Each flag a `search` accepts, paired with the behavior libmagic gives it."""
+
+    def test_each_flag_sets_only_its_own_behavior(self):
+        """Tests that every letter maps to the one behavior libmagic gives it.
+
+        `b` set `optional_blanks`, which made a `search` tolerate whitespace libmagic requires to
+        match exactly, so PolyFile reported matches libmagic does not.
+        """
+        for letter, attribute in self.FLAGS:
+            with self.subTest(flag=letter):
+                flagged = SearchType.parse(f"search/8/{letter}")
+                for _, other in self.FLAGS:
+                    self.assertEqual(other == attribute, getattr(flagged, other), other)
+
+    def test_the_pascal_string_length_flag_is_rejected(self):
+        """Tests that `B` raises rather than passing for compact whitespace.
+
+        `B` is `CHAR_PSTRING_1_BE`, and libmagic's flag loop jumps to its error label for any type
+        but `pstring` (`file/src/apprentice.c:1983-1986`). Reading it as `W` would have let a
+        `search/B` silently compact the whitespace of its value.
+        """
+        for declaration in ("search/8/B", "string/B"):
+            with self.subTest(declaration=declaration):
+                with self.assertRaises(ValueError):
+                    DataType.parse(declaration)
+        self.assertEqual(1, DataType.parse("pstring/B").byte_length)
+
+    def test_flags_may_precede_an_undocumented_repetition_count(self):
+        """Tests that `ber`'s `search/b64` is `search/64` with the binary flag set.
+
+        libmagic reads the digits of a string declaration as the repetition count and each letter
+        as a flag, in one loop, so the two orders mean the same thing.
+        """
+        self.assertIs(DataType.parse("search/b64"), DataType.parse("search/64/b"))
+        self.assertEqual(64, DataType.parse("search/b64").repetitions)


### PR DESCRIPTION
Closes #3490
Closes #3515
Closes #3478

The interning collision fixed here was also reported and patched independently by @LouisDeconinck in #3521. That patch could not be merged because the contributor licence agreement is unsigned, so this implementation was written from the issue rather than from it. Thank you for the report.

## Summary

libmagic runs soft magic twice: once over the file's bytes in `BINTEST` mode (`file/src/funcs.c:482`) and once over the decoded text buffer in `TEXTTEST` mode (`file/src/ascmagic.c:161-162`). A definition's `b` and `t` string flags choose which pass it belongs to. PolyFile derived that choice from a test's children, dropped `b` on a `string` and both flags on a `regex`, and ran every binary test against every input.

Five commits: the interning fix that everything else needs, the `search` flag table, the pass assignment, the pass gate, and the regenerated expectation.

## What libmagic actually does, and one correction

`set_test_type` (`file/src/apprentice.c:1200-1284`) reads the entry's own `str_flags` and `type`:

```c
if (mstart->str_flags & STRING_BINTEST) mstart->flag |= BINTEST;
if (mstart->str_flags & STRING_TEXTTEST) mstart->flag |= TEXTTEST;
if (mstart->flag & (TEXTTEST|BINTEST)) break;
if (m->type != FILE_REGEX && m->type != FILE_SEARCH) { mstart->flag |= BINTEST; break; }
if (file_looks_utf8(m->value.us, m->vallen, NULL, NULL) <= 0) mstart->flag |= BINTEST;
else mstart->flag |= TEXTTEST;
```

Two things follow that the issues state differently.

**A subtest never changes the answer, at all.** #3490 says continuation lines never change it because of the `break`, but the `break` is not what does it: `set_text_binary` (`file/src/apprentice.c:1423-1453`) loops `while (++i < nme && me[i].mp->cont_level != 0)`, and `me` holds one `magic_entry` per top-level test with its continuations inside `mp`, so `me[i].mp->cont_level` is always 0 and the loop body runs exactly once with `mstart == m`. The child-propagation rule was not a weaker version of libmagic's rule; it had no counterpart in libmagic. So this replaces it rather than letting an explicit flag win over it.

**An entry with neither flag belongs to exactly one pass, not both.** #3490 says an unflagged entry runs in both passes. It does not: without a flag, a `string` takes `BINTEST` from the compatibility branch and a `search` or `regex` takes whichever pass its own value looks like. Only an entry carrying *both* flags gets both bits. Probed directly:

```
$ cat passprobe.magic
0	string/t	XY	flagged text
>2	belong	0	\b, zero
0	search/1	PQ	unflagged search
>2	belong	0	\b, zero
0	string/bt	RS	both flags
0	string	TU	plain string
0	regex/1024	ab+c	unflagged regex

$ file -l -m passprobe.magic
Binary patterns:
Strength =  50@7: both flags []
Strength =  50@9: plain string []
Text patterns:
Strength =  50@7: both flags []
Strength =  50@1: flagged text []
Strength =  40@4: unflagged search []
Strength =  39@11: unflagged regex []
```

The tri-state type is therefore what the both-flags case needs, and only that case. Over the whole shipped definition set there are three such entries.

## The design

**Interning (#3515).** Every flag-bearing type builds its name from one ordered table of `(letter, attribute)` pairs, so a flag the type reads is a flag the name spells. `DataType.parse` then reparses the name it built and compares the two types attribute by attribute, which turns a future omission into a load-time `ValueError`:

```
ValueError: magic_defs/commands line 7: 'string/fwt' parsed to a type named 'string/wt',
but that name parses back as StringType(string/wt): the name leaves out something the
declaration set
```

That check catches both halves of #3515 as reported, and it caught them again when I deliberately removed the table entries to confirm the tests fail.

**Flag table (#3478).** `t` is now read as `CHAR_TEXTTEST`; `B` is `CHAR_PSTRING_1_BE` and raises for anything but a `pstring`, as `apprentice.c`'s flag loop does with `goto bad`. Note that `b`/`B` were already corrected by the #3511 fix, so the remaining live gap was `t` alone: 35 shipped declaration sites carry it on a `search`, 25 of them in `magic_defs/sgml`, and each was parsing to a type indistinguishable from the same declaration without the flag. No shipped definition uses `B` on a `search` or a `string`, so that half stays latent, now as an error instead of a silent misreading. The stale `search/b64` note is replaced: the digits are the repetition count and each letter is a flag, in one loop, so `search/b64` is `search/64` with `b` set.

**Tri-state (#3490 parts 1 to 3).** `TestType` gains `BOTH = BINARY | TEXT`, `_reassign_test_types` adds an entry to each bucket its bits name, and `MagicTest.test_type` is now the level 0 test's own `subtest_type()`. `DataType.is_text` gives way to `test_types`, which returns pass bits rather than a boolean; the four types that only restated the binary default no longer override anything, and `lestring16` stops claiming to be text, which is what the compatibility branch says for every string type that names no pass of its own. `appends_text_encoding` still reads `subtest_type()`, and its docstring is updated: `test_type` now answers from the same place, so the reason it could not is gone, and the one remaining difference is `IndirectTest` forcing its ancestors to binary.

**The gate (#3490 part 4).** `softmagic` skips an entry when the buffer looks like text and the entry declares only `STRING_BINTEST`, or the mirror case (`file/src/softmagic.c:249-253`). `MagicMatcher.binary_pass_tests` mirrors that, keyed on the *declared* flags and not on the bucket, because `softmagic` tests `m->str_flags` and not `m->flag`. `looks_text` is `TextEncodingDescription.detect(...) is not None`, which is the `file_encoding` return value `file_buffer` passes down (`file/src/funcs.c:314-317`, `482`).

**The both-flags case.** An entry with both bits runs in both passes, so it can match twice. libmagic stops after its binary pass prints something (`checkdone` in `file/src/funcs.c:479-503`), so PolyFile reports such an entry once, from whichever pass matched first, and only the text pass carries the encoding description `file_ascmagic` prints. That single rule gets both SVG cases right.

## Tests that moved between passes

38 in, 4 out. Every mover matches the section `file -l -m file/magic/Magdir/<name>` lists it in; a script that compares PolyFile's two buckets against those sections over every level 0 entry of the shipped set reports **44 disagreements on `master` and 0 here**.

| group | entries | why |
| --- | --- | --- |
| unflagged `search`/`regex` whose own value looks like UTF-8, with a binary subtest under it | algol68:9, algol68:12, algol68:14, algol68:16, algol68:18, bioinformatics:113, c-lang:15, diff:114, frame:71, games:180, gentoo:49, images:196, images:210, images:219, lex:7, macintosh:14, mup:13, os2:9, pdf:45, scientific:71, sosi:30, uuencode:11, windows:650, windows:1313, xwindows:39 | → Text. The subtest used to override; libmagic never consults it. |
| declared `t` that lost to a binary subtest | kml:9, mime:6, mime:8, msdos:9, os2:204, sgi:137, sgml:21, subtitle:32, varied.script:8 | → Text. The explicit flag now decides. |
| `t` dropped at parse time | images:666 (`search/1/ts`), varied.script:18, varied.script:27 (`regex/t`) | → Text. #3478 and #3515. |
| both flags | sgml:74 (`search/4096/cWbt`) | → both, joining sgml:6 and sgml:17 (`string/bt`), which were already text-only in the expectation and are now in both. |
| pattern holds a null byte | cad:317 | → Binary. `RegexType.is_text` decoded the pattern as ASCII, which accepts `\0`; `_looks_like_utf8` is what `file_looks_utf8` does. |
| declared `b` on a `regex` | cad:365 | → Binary. `regex/b` was ignored. |
| `lestring16` | windows:457, windows:1064 | → Binary. `UTF16Type.is_text` returned True; `set_test_type` has no such case. |

The expectation now asserts the set and not only its size, so a swap of one entry for another can no longer pass.

## Before and after

`cmd1` (and `cmd2`) — `magic_defs/varied.script` spells one shebang twice, `string/wt` at line 8 and `string/wb` at line 12:

```
$ file -b file/tests/cmd1.testfile
a /usr/bin/cmd1 script, ASCII text executable

# before
a /usr/bin/cmd1 script executable (binary data)
a /usr/bin/cmd1 script text executable

# after
a /usr/bin/cmd1 script, ASCII text executable
```

SVG — `magic_defs/sgml:6` declares both flags:

```
$ file -b simple.svg
SVG Scalable Vector Graphics image

# before
SVG Scalable Vector Graphics image, ASCII text

# after
SVG Scalable Vector Graphics image
```

and the same definition on the UTF-16 buffer keeps the description `file/tests/utf16xmlsvg.testfile` expects, because there the binary pass finds nothing and the text pass is what matches:

```
SVG Scalable Vector Graphics image, Unicode text, UTF-16, little-endian text
```

`gimp:67` — `0 search/21/b \040ncells:`, a text-looking value with an explicit `b`:

```
# before and after
GIMP animated brush data
```

It stays in the binary pass, so a `.gih` buffer, which is not text, still reaches it. `PassGateTest` and the existing `test_a_gimp_animated_brush_is_still_detected` both cover it.

## Verification

**Corpus differential.** `NEWLY PASSING (14)`, `STILL FAILING (0)`, `REGRESSIONS (0)`. `KNOWN_FAILURES` is still empty.

**pytest.** 1128 passed, 3 skipped, 862 subtests, 3 warnings, against 1109 / 3 / 797 / 3 on `master`. The three warnings are the pre-existing `SyntaxWarning`s from generated Kaitai parsers tracked in #3462. The 19 new tests are `DataTypeNameTest`, `SearchFlagTableTest`, `PassSelectionTest` and `PassGateTest`. Each was checked by breaking the corresponding code and confirming the test fails: the two naming table entries, the three `search` flag mappings, child propagation, the `BOTH` bucket split, the unflagged-`string` fallback, the `looks_text` gate, the both-pass dedupe, and the binary pass carrying the encoding description.

**flake8.** `--select=E9,F63,F7,F82` is 0. The full `--max-complexity=10 --max-line-length=127` run is 224, against 226 on `master`; the two that went away are `F541` f-strings without placeholders in a line this change touched. No new finding of any kind.

**Reference comparison.** Over 184 mixed files — every `file/tests/*.testfile` with no sidecar magic, plus this repository's Python, Markdown, TOML, YAML, magic definitions, templates, workflows, docs, and 15 files of `file/src` — the string `file -b` reports is present in PolyFile's match set for 178 of them both before and after: nothing was lost. Six files changed, all by dropping a match `file -b -k` does not list, and none moved away from the reference:

| file | dropped |
| --- | --- |
| cmd1, cmd2 | `a /usr/bin/cmdN script executable (binary data)` |
| cmd3, cmd4 | `a /usr/bin/cmdN script text executable` |
| matilde.arm | `a AMR script text executable` |
| tests/magic.mgc | `SOSI map data, version `, `Variant Call Format (VCF) version ` |

Total matches over the sample fall from 255 to 248. The six remaining disagreements are the same before and after and are unrelated: `HWP2016.hwp` and one message whose tab is escaped differently.

**Timing.** Matching every `file/tests/*.testfile` three times, best of three: **3.299s on `master`, 1.247s here**, a 2.6x speedup. It comes from binary inputs: the unflagged whole-buffer searches that moved into the text pass — bare `search` in `bioinformatics` and `sosi`, `search/8192`, `search/11054`, `search/2048`, `regex/4006` — used to scan every binary file. The text-only subset of the same corpus is unchanged at 0.264s. `pytest tests` is 100.6s against 102.2s, which is within noise; the suite is not dominated by matching.

## Merge order and conflicts

Merge after #3522 (already in `master`); this branch is cut from db56ed5.

External PR #3519 (issue #3498, negated regular expressions) touches `RegexType.parse` and `RegexType.__init__`, both of which this change rewrites: `REGEX_TYPE_FORMAT` gains `b` in its flag classes and loses the trailing `(b\d*)?` group, and the constructor gains `force_text` and `force_binary` and builds its name from a flag table. A conflict there is likely whichever lands first. Nothing else in this change goes near regular expression relations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VS8hTTRQeG8ZCmCZ9KLHiV
