### PR TITLE
Fix when a default test fires, and the bytes a regex matches against

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -2622,9 +2622,26 @@ class RegexType(DataType[MagicRegex]):
             return DataTypeMatch(raw_match, value, initial_offset=start, relative_base=start)
         return DataTypeMatch(raw_match, value, initial_offset=start)
 
+    def subject(self, data: bytes) -> bytes:
+        """The bytes libmagic hands to ``regexec``, given the file's bytes from this test's offset.
+
+        libmagic copies at most `length` bytes of the region and then terminates the copy by
+        overwriting its last byte with a NUL (``file/src/softmagic.c:2393-2405``). It passes the
+        result as a C string, so the pattern never sees the final byte of the region, and never
+        sees anything past a NUL that was already in it.
+
+        Args:
+            data: The file's bytes from the offset this test runs at.
+
+        Returns:
+            The bytes to match the pattern against.
+        """
+        region = data[:self.length]
+        return region[:-1].partition(b"\0")[0]
+
     def match(self, data: bytes, expected: MagicRegex) -> DataTypeMatch:
         if not self.limit_lines:
-            m = expected.search(data[:self.length])
+            m = expected.search(self.subject(data))
             if m is None:
                 return DataTypeMatch.INVALID
             return self.matched_extent(m, 0)

--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -152,32 +152,38 @@ def unescape(to_unescape: Union[str, bytes]) -> bytes:
 
 
 class TestResult(ABC):
+    """The result of running one test, and the chain of tests that led to it.
+
+    `child_matched` is libmagic's ``ms->c.li[cont_level].got_match``: whether a continuation of
+    this test has already matched. A ``default`` fires only when it is unset, and a ``clear``
+    unsets it (``file/src/softmagic.c:418-428``). libmagic holds one flag per continuation level
+    and zeroes it on every descent into a level (``file/src/softmagic.c:346`` and ``:487``, through
+    ``file_check_mem`` at ``file/src/funcs.c:640-660``); the entries of a level are exactly the
+    continuations of one parent entry, so PolyFile holds the flag on the parent's result.
+
+    Any match raises its parent's flag, whatever its description says: libmagic gates only printing
+    and ``found_match`` on a non-empty description (``file/src/softmagic.c:432-440``), never
+    ``got_match``. Two kinds of result are excluded. A ``use`` raises the flag only when the named
+    list it ran printed something, which is what its ``magiccheck`` reports
+    (``file/src/softmagic.c:2429-2430``), so `UseTest._match` raises it itself. A ``name`` raises
+    nothing, because libmagic saves and restores the whole level array around a named list's run
+    (``file/src/softmagic.c:2013`` and ``:2033``), so what that list matches cannot reach the level
+    the ``use`` sits on.
+    """
+
     def __init__(self, test: "MagicTest", offset: int, parent: Optional["TestResult"] = None):
         self.test: MagicTest = test
         self.offset: int = offset
         self.parent: Optional["TestResult"] = parent
+        self.child_matched: bool = False
         if parent is not None and bool(self):
             assert self.test.named_test is self.test or parent.test.level == self.test.level - 1
-            if not isinstance(self.test, UseTest):
+            if not isinstance(self.test, (NamedTest, UseTest)):
                 parent.child_matched = True
-        self._child_matched: bool = False
 
     @abstractmethod
     def explain(self, writer: ANSIWriter, file: Streamable):
         raise NotImplementedError()
-
-    @property
-    def child_matched(self) -> bool:
-        return self._child_matched
-
-    @child_matched.setter
-    def child_matched(self, did_match: bool):
-        if did_match and isinstance(self.test, NamedTest):
-            assert isinstance(self.parent.test, UseTest)
-            self.parent.child_matched = True
-            if self.parent.parent is not None:
-                self.parent.parent.child_matched = True
-        self._child_matched = did_match
 
     def __hash__(self):
         return hash((self.test, self.offset))
@@ -3400,6 +3406,10 @@ class UseTest(MagicTest):
         )
         if not matched:
             return
+        if parent_match is not None:
+            # a `use` that succeeded counts as a match at its level, so a later `default` there
+            # does not fire (`file/src/softmagic.c:424-428`)
+            parent_match.child_matched = True
         yield use_match
         for named_result in named_results:
             if not context.only_match_mime or named_result.test.mime is not None:
@@ -3647,11 +3657,17 @@ class ClearTest(MagicTest):
         return "x"
 
     def test(self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]) -> MatchedTest:
-        if parent_match is None:
-            return MatchedTest(self, offset=absolute_offset, length=0, value=None)
-        else:
+        """Matches unconditionally, having unset the parent's `TestResult.child_matched`.
+
+        The flag is unset after building the result, because building it raises the flag the way
+        any other match would. libmagic reaches the same place from the other direction: the
+        ``FILE_CLEAR`` arm of ``file/src/softmagic.c:422-428`` zeroes ``got_match`` instead of
+        taking the arm that would raise it.
+        """
+        result = MatchedTest(self, offset=absolute_offset, length=0, parent=parent_match, value=None)
+        if parent_match is not None:
             parent_match.child_matched = False
-            return MatchedTest(self, offset=absolute_offset, length=0, parent=parent_match, value=None)
+        return result
 
     def test_flip_endianness(
             self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -2044,3 +2044,131 @@ class UCSTextBufferTest(TestCase):
             {str(match) for match in
              MagicMatcher.DEFAULT_INSTANCE.match(self.encode(document, "utf-16le"))}
         )
+
+
+class DefaultTestSemanticsTest(TestCase):
+    """Regression tests for when a `default` test fires, reported in issue #3517.
+
+    libmagic keeps one `got_match` flag per continuation level and zeroes it whenever it descends
+    into a level (`file/src/funcs.c:640-660`, called from `file/src/softmagic.c:346` and `:487`).
+    A `default` fires only while that flag is unset, a `clear` unsets it, and every other test that
+    passes `magiccheck` sets it (`file/src/softmagic.c:418-428`).
+
+    Every string these tests expect is what `file -b -k` reports for the same definitions and
+    input, checked against libmagic 5.48 built from the `file` submodule.
+    """
+
+    @staticmethod
+    def messages(definitions: str, data: bytes) -> Set[str]:
+        """Matches `data` against ad-hoc definitions and collects the resulting messages.
+
+        Args:
+            definitions: The contents of a libmagic definition file, with tab separated columns.
+            data: The bytes to classify.
+
+        Returns:
+            The message of every match the definitions produce.
+        """
+        with TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "default_semantics"
+            path.write_text(definitions)
+            matcher = MagicMatcher.parse(path)
+            return {str(match) for match in matcher.match(data)}
+
+    def fired(self, definitions: str, data: bytes = b"HEADB") -> bool:
+        """Reports whether the `fallback` message of a `default` test appears in the output.
+
+        Args:
+            definitions: The contents of a libmagic definition file.
+            data: The bytes to classify, defaulting to one whose fifth byte is `B`.
+
+        Returns:
+            True if some match carries the `fallback` message.
+        """
+        return any("fallback" in message for message in self.messages(definitions, data))
+
+    HEAD: str = "0\tstring\tHEAD\thead\n"
+    """A level 0 test that matches the first four bytes of this class's test data."""
+
+    NAMED_LIST: str = "0\tname\tnlist\n>0\tstring\tB\tnamed list matched\n\n"
+    """A named list that prints a message when the byte it is invoked at is `B`."""
+
+    def test_a_default_fires_when_no_earlier_test_at_its_level_matched(self):
+        """A `default` is the fallback for its level, so a failed sibling must not stop it."""
+        self.assertTrue(self.fired(
+            self.HEAD + ">4\tstring\tZ\tsibling\n>4\tdefault\tx\tfallback\n"
+        ))
+
+    def test_a_default_does_not_fire_when_an_earlier_test_at_its_level_matched(self):
+        """A matched sibling sets `got_match` for the level, which suppresses the `default`."""
+        self.assertFalse(self.fired(
+            self.HEAD + ">4\tstring\tB\tsibling\n>4\tdefault\tx\tfallback\n"
+        ))
+
+    def test_an_undescribed_sibling_suppresses_a_default(self):
+        """An earlier sibling counts even with no description, which #3517 predicted otherwise.
+
+        libmagic gates `found_match` and printing on a non-empty description
+        (`file/src/softmagic.c:432-440`) but sets `got_match` for any test that passes
+        `magiccheck` (`file/src/softmagic.c:424-428`), so the two are not the same condition.
+        `file -b -k` reports only `head` for these definitions.
+        """
+        self.assertFalse(self.fired(
+            self.HEAD + ">4\tstring\tB\n>4\tdefault\tx\tfallback\n"
+        ))
+
+    def test_a_use_that_matched_suppresses_a_default(self):
+        """A `use` whose named list printed something sets `got_match` for its level."""
+        self.assertFalse(self.fired(
+            self.NAMED_LIST + self.HEAD + ">4\tuse\tnlist\n>4\tdefault\tx\tfallback\n"
+        ))
+
+    def test_a_use_that_printed_nothing_does_not_suppress_a_default(self):
+        """A `use` used to suppress a following `default` whenever its named list matched at all.
+
+        `FILE_USE`'s `magiccheck` is the number of entries in the named list that printed
+        (`file/src/softmagic.c:2429-2430`), so a list whose only entry is undescribed leaves the
+        `use` failing and the level's `got_match` unset. `file -b -k` reports `head fallback` for
+        these definitions.
+        """
+        self.assertTrue(self.fired(
+            "0\tname\tnlist\n>0\tstring\tB\n\n" + self.HEAD
+            + ">4\tuse\tnlist\n>4\tdefault\tx\tfallback\n"
+        ))
+
+    def test_a_named_list_does_not_suppress_a_default_under_its_use(self):
+        """What a named list matches used to leak into the level of the `use`'s own children.
+
+        libmagic saves the whole level array before running a named list and restores it afterwards
+        (`file/src/softmagic.c:2013` and `:2033`), so the list cannot touch the `got_match` of any
+        level outside itself. `file -b -k` reports `head named list matched fallback` here.
+        """
+        self.assertTrue(self.fired(
+            self.NAMED_LIST + self.HEAD + ">4\tuse\tnlist\n>>4\tstring\tZ\tsibling\n"
+            ">>4\tdefault\tx\tfallback\n"
+        ))
+
+    def test_clear_lets_a_later_default_fire_again(self):
+        """A `clear` used to set the condition it is supposed to reset.
+
+        `ClearTest.test` unset the parent's flag and then built a `MatchedTest` against that same
+        parent, which raised the flag straight back. libmagic's `FILE_CLEAR` arm zeroes
+        `got_match` instead of taking the arm that raises it (`file/src/softmagic.c:422-424`).
+        `file -b -k` reports `head sibling` and `fallback` for these definitions.
+        """
+        self.assertTrue(self.fired(
+            self.HEAD + ">4\tstring\tB\tsibling\n>4\tclear\tx\n>4\tdefault\tx\tfallback\n"
+        ))
+
+    def test_a_plain_png_is_reported_as_a_png(self):
+        """The broken `clear` cost every non-animated PNG its match.
+
+        `polyfile/magic_defs/images:524` clears the level so that the `>8 default x` at `:533` can
+        supply the standard PNG branch once the animated branch above it has failed. With the flag
+        stuck set, that `default` never fired and `MagicMatcher.match` fell through to
+        `OctetStreamTest`, reporting `data` for an ordinary PNG file.
+        """
+        ihdr = b"\x00\x00\x00\x0DIHDR" + (8).to_bytes(4, "big") * 2 + bytes((8, 6, 0, 0, 0))
+        png = b"\x89PNG\r\n\x1a\n" + ihdr
+        self.assertIn("PNG image data, 8 x 8, 8-bit/color RGBA, non-interlaced",
+                      {str(match) for match in MagicMatcher.DEFAULT_INSTANCE.match(png)})

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -2172,3 +2172,86 @@ class DefaultTestSemanticsTest(TestCase):
         png = b"\x89PNG\r\n\x1a\n" + ihdr
         self.assertIn("PNG image data, 8 x 8, 8-bit/color RGBA, non-interlaced",
                       {str(match) for match in MagicMatcher.DEFAULT_INSTANCE.match(png)})
+
+
+class RegexSubjectTest(TestCase):
+    """Regression tests for the bytes a `regex` test matches against, reported in issue #3517.
+
+    libmagic copies the region a `regex` runs over and NUL-terminates the copy by overwriting its
+    last byte (`file/src/softmagic.c:2393-2405`), then passes it to `regexec` as a C string. The
+    pattern therefore never sees the region's last byte, and never sees anything past a NUL that
+    was already in the region. PolyFile handed the pattern the whole region, so a `regex` matched
+    bytes libmagic cannot reach.
+
+    Every string these tests expect is what `file -b -k` reports for the same definitions and
+    input, checked against libmagic 5.48 built from the `file` submodule.
+    """
+
+    DEFINITION: str = "0\tstring\tHEAD\thead\n>4\tregex\tTARGET\tfound\n"
+    """A level 0 test on `HEAD`, whose continuation looks for `TARGET` in the rest of the file."""
+
+    @staticmethod
+    def messages(definitions: str, data: bytes) -> Set[str]:
+        """Matches `data` against ad-hoc definitions and collects the resulting messages.
+
+        Args:
+            definitions: The contents of a libmagic definition file, with tab separated columns.
+            data: The bytes to classify.
+
+        Returns:
+            The message of every match the definitions produce.
+        """
+        with TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "regex_subject"
+            path.write_text(definitions)
+            matcher = MagicMatcher.parse(path)
+            return {str(match) for match in matcher.match(data)}
+
+    def found(self, definitions: str, data: bytes) -> bool:
+        """Reports whether the `found` message of the `regex` test appears in the output.
+
+        Args:
+            definitions: The contents of a libmagic definition file.
+            data: The bytes to classify.
+
+        Returns:
+            True if some match carries the `found` message.
+        """
+        return any("found" in message for message in self.messages(definitions, data))
+
+    def test_a_regex_does_not_see_past_a_nul_in_its_region(self):
+        """A pattern used to match bytes that libmagic's C string cannot reach."""
+        self.assertTrue(self.found(self.DEFINITION, b"HEADTARGETxx\n"))
+        self.assertFalse(self.found(self.DEFINITION, b"HEADxx\x00TARGETxx\n"))
+
+    def test_a_regex_does_not_see_the_last_byte_of_its_region(self):
+        """The NUL that terminates libmagic's copy overwrites the region's final byte."""
+        self.assertFalse(self.found(self.DEFINITION, b"HEADTARGET"))
+        self.assertTrue(self.found(self.DEFINITION, b"HEADTARGETx"))
+
+    def test_an_explicit_range_is_trimmed_after_it_is_applied(self):
+        """`regex/N` reads N bytes and then loses the last of them, so N must exceed the pattern.
+
+        `bytecnt` is the declared range clamped to what is left of the buffer
+        (`file/src/softmagic.c:1417-1422`), and the trim happens afterwards, in `magiccheck`.
+        """
+        self.assertFalse(self.found("0\tstring\tHEAD\thead\n>4\tregex/6\tTARGET\tfound\n",
+                                    b"HEADTARGETxxxx"))
+        self.assertTrue(self.found("0\tstring\tHEAD\thead\n>4\tregex/7\tTARGET\tfound\n",
+                                   b"HEADTARGETxxxx"))
+
+    def test_hwpx_is_not_reported_as_microsoft_ooxml(self):
+        """A Hancom HWPX file used to report as `Microsoft OOXML`, and to report it first.
+
+        `polyfile/magic_defs/msooxml:38` looks for an OOXML part name at offset 0x1E, which in this
+        file holds `mimetypeapplication/hwp+zip` followed by the next local file header. libmagic
+        stops at the NUL inside that header and finds no part name, so it never reaches the
+        `default x  Microsoft OOXML` ladder at `:63-69`. PolyFile read on to the end of the file,
+        found `.png` in a later member name, and took the whole ladder down to `:66`, whose level 0
+        entry scores 81 and so sorted the wrong type to the front of the output.
+        """
+        testfile = FILE_TEST_DIR / "HWP2016.hwpx.zip.testfile"
+        self.assertTrue(testfile.exists(), "Make sure to run `git submodule init && git submodule update`")
+        matches = [str(match) for match in MagicMatcher.DEFAULT_INSTANCE.match(testfile.read_bytes())]
+        self.assertNotIn("Microsoft OOXML", matches)
+        self.assertEqual("Hancom HWP (Hangul Word Processor) file, HWPX", matches[0])


### PR DESCRIPTION
Closes #3517

## The diagnosis in the issue is wrong about the cause

`Microsoft OOXML` on `file/tests/HWP2016.hwpx.zip` is not a `default` misfire. libmagic's
`default` and PolyFile's already agree at `msooxml:37`: the `use msooxml` above it fails, so both
fire the fallback. The two diverge one line later, at the `regex` on `msooxml:38`.

libmagic copies the region a `regex` runs over and terminates the copy by overwriting its last
byte with a NUL (`file/src/softmagic.c:2393-2405`), then hands it to `regexec` as a C string. So
the pattern never sees the region's last byte, and never sees anything past a NUL that was
already in the region. `msooxml:38` looks for an OOXML part name at offset `0x1E`, where this
file holds `mimetypeapplication/hwp+zip` and then the next local file header; libmagic's subject
ends at the NUL inside that header, 32 bytes in, and matches nothing. PolyFile handed the pattern
the whole 8 KiB region, reached `Preview/PrvImage.png` 5836 bytes later, matched the `.*\.png`
alternative, and so entered the `default x  Microsoft OOXML` ladder at `msooxml:63-69` and took
it down to `:66`.

Both hypotheses the issue offers about `default` are also wrong:

1. **Description gating does not apply.** `*m->desc` gates `*found_match` and printing
   (`file/src/softmagic.c:432-440`), never `got_match`, which is set unconditionally at `:428`.
   An undescribed sibling that matched *does* suppress a following `default`, in libmagic and in
   PolyFile alike. `test_an_undescribed_sibling_suppresses_a_default` pins this down, and it is
   the one test that fails if you implement the issue's hypothesis.
2. **A `use` that succeeded does suppress a following `default`**, since `FILE_USE` is neither
   `FILE_CLEAR` nor `FILE_DEFAULT` at `file/src/softmagic.c:422-428`.

## The rule this implements

`ms->c.li[cont_level].got_match` — libmagic's "some earlier test at this continuation level
matched":

- `file_check_mem` zeroes it for a level (`file/src/funcs.c:640-660`), called on every descent
  into a level (`file/src/softmagic.c:346`, `:487`), so it is scoped to one parent entry's run of
  its continuations.
- On a continuation whose `magiccheck` succeeded (`file/src/softmagic.c:418-428`): `clear` zeroes
  it; a `default` is skipped entirely when it is already set; anything else sets it, whatever its
  description says.
- A `use` counts only when it succeeded, and `FILE_USE`'s `magiccheck` is the number of entries
  in the named list that printed (`file/src/softmagic.c:2429-2430`, fed by `:2022-2031`).
- A named list cannot touch any level outside itself: `mget` saves and restores the whole level
  array around the run (`file/src/softmagic.c:2013`, `:2033`).
- Level 0 has no tracking at all, so a level 0 `default` always fires. PolyFile still raises
  `NotImplementedError` for one; no shipped definition has one, so that is unchanged.

## What `child_matched` was doing wrong

Repaired, not replaced. `TestResult.child_matched` is the right shape: libmagic keys the flag on
the continuation level, and a level's entries are exactly the continuations of one parent entry,
which is what PolyFile's tree already gives it. Three things were wrong:

1. `ClearTest.test` unset the parent's flag and *then* built its `MatchedTest` against that same
   parent, whose `__init__` raised it straight back. A `clear` therefore set the condition it
   exists to reset. Now the result is built first and the flag unset after.
2. A `use` raised the flag whenever any entry of its named list matched, through a
   `child_matched` setter that forwarded two levels up. `UseTest._match` already computes the real
   condition for #3484, so it now raises the flag itself, and the setter is gone.
3. A named list's own result raised the flag of the level the `use` sits on, because a `NamedTest`
   result is parented to the `use`'s result as a plumbing device. `NamedTest` is now excluded
   alongside `UseTest` in `TestResult.__init__`.

The property and its setter are replaced by a plain attribute, and the rule is documented on
`TestResult` with the `softmagic.c` citations.

## Before and after on `HWP2016.hwpx.zip`

```console
$ TZ=UTC ./file/src/file -b -k -r -m file/magic/magic.mgc file/tests/HWP2016.hwpx.zip.testfile
Hancom HWP (Hangul Word Processor) file, HWPX
-  Zip archive data, made by v2.3
...
```

Before:

```
Microsoft OOXML | Hancom HWP (Hangul Word Processor) file, HWPX | Zip archive, with extra data prepended | ZIP end of central directory record
```

After:

```
Hancom HWP (Hangul Word Processor) file, HWPX | Zip archive, with extra data prepended | ZIP end of central directory record
```

The wrong type is gone and the right one is first, matching libmagic's strongest match.

## The `clear` fix also fixes plain PNG detection

`polyfile/magic_defs/images:524` clears the level so that the `>8 default x` at `:533` can supply
the standard PNG branch once the animated branch above it has failed. With the flag stuck set
that `default` never fired, `MagicMatcher.match` fell through to `OctetStreamTest`, and an
ordinary non-animated PNG came out as `data`. All four PNGs in `logo/` were affected. This is the
larger of the two behaviour changes by file count.

## #3501's `hancom hwp` case: not this bug, and not fixable from the definitions

Not the same misfire, and unchanged here. `file -d` shows the standalone
`Hancom HWP (Hangul Word Processor) file, version 5.0` that libmagic reports as its strongest
match for `file/tests/HWP2016.hwp` coming from `[try cdf 1]`, before soft magic runs at all: it
is hard-coded in libmagic's C compound-document reader (`file/src/readcdf.c:630-636`, the
`HWP5_SIGNATURE` check). The only Hancom 5.0 entry in the definitions is
`ole2compounddocs:269`, which carries the `: ` prefix, and that is the OLE-prefixed variant
PolyFile already produces. Producing the bare string would take a compound-document stream reader,
so `test_file_corpus`'s `hancom hwp` branch stays as it is, and #3501 wants re-scoping rather than
closing.

## Verification

Corpus differential, unchanged from the baseline:

```
NEWLY PASSING (14): ['JW07022A.mp3', 'cmd1', 'cmd2', 'cmd3', 'cmd4', 'gedcom', 'jpeg-text', 'jsonlines1', 'multiple', 'osm', 'pnm1', 'pnm2', 'pnm3', 'utf16xmlsvg']
STILL FAILING (0): []
REGRESSIONS   (0):
```

`KNOWN_FAILURES` is still empty.

Broad oracle comparison over 500 files — every `*.testfile` in `file/tests`, this repo's PNGs,
definitions, templates, generated parsers, workflows and `testdata`, plus samples from `/bin`,
`/etc`, `/usr/lib/python3.9`, `/usr/share/zoneinfo`, `/usr/share/man/man1` and
`/System/Library/CoreServices` — diffing PolyFile's full match list against
`file -b -k -r` before and after:

| change | files | detail |
| --- | --- | --- |
| `default` family | 4 | `logo/*.png`: gained the exact `PNG image data, …` string libmagic reports, and dropped the `data` fallback that PolyFile only emits when nothing matched |
| `regex` subject | 1 | `HWP2016.hwpx.zip.testfile`: dropped `Microsoft OOXML`, which libmagic does not report under `-k` either |
| **total** | **5 of 500** | 1 match removed, absent from libmagic's output; 4 added, all present in libmagic's output; **0 blockers** |

Instrumenting the same 500 files: **5 verdict flips in 27,779 non-line-limited `regex`
evaluations.** Four are `windows:650`'s `\^(:|;)`, on files where the oracle reports no `cnt`
match either way, so they change no output. The fifth is `msooxml:38`. The blast radius is small
because nearly every shipped `regex` runs at an offset whose region holds no early NUL.

Synthetic differential against the oracle, in `/tmp` magic files built for the purpose: 21 cases
covering `default` with a matched, failed, and undescribed sibling; two `default`s in a row; an
undescribed `default`; deeper-level excursions; per-parent reset; `clear` before and after a
match; `use` with a described, undescribed, deep-described, deep-undescribed, and failing named
list; `use` then `clear`; a `default` among a `use`'s own children; and a `default` inside a named
list. All 21 agree with `file -b -k` after this change; 8 disagreed before.

```
pytest tests            1121 passed, 3 skipped, 3 warnings, 797 subtests passed in 101.95s
flake8 --select=E9,F63,F7,F82 --count   0
flake8 (full)           226, unchanged from master; no new findings in either file touched
```

The 3 warnings are the pre-existing `SyntaxWarning`s from generated Kaitai parsers, #3462.

Timing: `pytest tests` 1:48.54 wall against the ~1m48s baseline, and `corpus_diff.py`
2.29-2.34 s against 2.33-2.39 s with master's `polyfile/magic.py` — no measurable change.

12 tests added, in two classes. Each was verified by breaking the corresponding part of the fix,
confirming the test fails, restoring, and confirming it passes:

| broke | failed |
| --- | --- |
| named list raises the outer flag again | `test_a_named_list_does_not_suppress_a_default_under_its_use` |
| a successful `use` no longer raises the flag | `test_a_use_that_matched_suppresses_a_default` |
| any `use` raises the flag, printing or not | `test_a_use_that_printed_nothing_does_not_suppress_a_default` |
| `clear` raises the flag it should reset | `test_clear_lets_a_later_default_fire_again`, `test_a_plain_png_is_reported_as_a_png` |
| `default` always fires | `test_a_default_does_not_fire_when_an_earlier_test_at_its_level_matched`, `test_an_undescribed_sibling_suppresses_a_default`, and 2 more |
| `default` never fires | `test_a_default_fires_when_no_earlier_test_at_its_level_matched`, and 4 more |
| the flag is gated on a non-empty description (the issue's hypothesis) | `test_an_undescribed_sibling_suppresses_a_default` |
| no regex trim at all (master's behaviour) | all 4 of `RegexSubjectTest` |
| cut at the NUL but keep the last byte | `test_a_regex_does_not_see_the_last_byte_of_its_region`, `test_an_explicit_range_is_trimmed_after_it_is_applied` |
| drop the last byte but read past the NUL | `test_a_regex_does_not_see_past_a_nul_in_its_region`, `test_hwpx_is_not_reported_as_microsoft_ooxml` |

The four pre-existing `UseTestSemanticsTest` tests from #3484 pass throughout.

## Left alone, and worth separate issues

- **`regex/l`.** libmagic runs one `regexec` with `REG_NEWLINE` over a multi-line region and
  applies the same NUL trim; `RegexType.match`'s line-limited path matches each line separately
  and *anchored*, which is a different model. About 50 of the 396 shipped `regex` tests use the
  flag. Not touched here.
- **A `regex` value whose first character is a relation operator.** libmagic reads `^`, `!`, `<`,
  `>`, `&` and `=` off the value before it compiles the pattern, so `regex ^foo` compiles `foo`
  under the `^` relation, which inverts the verdict. PolyFile handles the `=` case
  (`RegexType.parse_expected`) and treats the rest as pattern text. Harmless in practice: all four
  such lines in the definitions escape the operator (`archive:1629`, `fortran:6`, `windows:650`),
  which is exactly how libmagic wants a literal anchor written.
- **A `name` line that carries its own description.** libmagic prints it from `mget`'s
  `FILE_NAME` arm and counts it toward `found_match`, so the `use` succeeds on the name line
  alone; PolyFile agrees on that after this change, but joins the message with a space where
  libmagic emits none. That is the message-join divergence, out of scope here.

## Merge order

Merge #3523 first. It touches `MagicTest.test_type`, the flag naming, `SearchType.parse` and
`MagicMatcher.match`'s pass gate, none of which this branch goes near, so `polyfile/magic.py`
merges cleanly. Expect a conflict in `tests/test_magic.py`, where both branches append a test
class at the end of the file; take both classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VS8hTTRQeG8ZCmCZ9KLHiV
