### PR TITLE
Match a regex/Nl over its whole region instead of line by line

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -362,6 +362,15 @@ which of `MagicMatcher.match`'s two passes a test belongs to.
 STRING_DEFAULT_RANGE: int = 100
 """The ``str_range`` libmagic gives a ``search`` that declared none (``file/src/file.h:433``)."""
 
+REGEX_MAX: int = 8192
+"""``FILE_REGEX_MAX``, the hard ceiling libmagic puts on a regular expression's search region.
+
+``file/src/apprentice.c:573`` seeds ``ms->regex_max`` with it and ``file/src/softmagic.c:1421-1422``
+clamps the region to it, so a test that asks for more than 8KiB silently gets 8KiB. ``regex/128l``
+asks for 10240 bytes and is one of the shipped definitions this bites.
+"""
+
+
 STRING_FLAG_BITS: Tuple[Tuple[str, int], ...] = (
     ("compact_whitespace", 0x0001),
     ("optional_blanks", 0x0002),
@@ -2636,11 +2645,46 @@ class MagicRegex:
     def search(self, data: bytes) -> Optional["re.Match[bytes]"]:
         return self.compiled.search(data)
 
-    def match(self, data: bytes) -> Optional["re.Match[bytes]"]:
-        return self.compiled.match(data)
-
     def __str__(self):
         return self.pattern.decode("utf-8", errors="replace")
+
+
+def line_region_length(region: bytes, line_count: int) -> int:
+    """How many bytes of `region` fall within its first `line_count` lines.
+
+    ``file/src/softmagic.c:1424-1440`` walks forward one line terminator at a time and stops once
+    it has stepped over `line_count` of them. Three details of that walk are load bearing: it looks
+    for a ``\\r`` only when no ``\\n`` remains anywhere ahead, it leaves the terminator out of the
+    region when the terminator is the region's own last byte, and it resumes each search one byte
+    past the line it just took, so a terminator sitting in that position is passed over. Running
+    out of terminators before `line_count` of them widens the region back to all of `region`.
+
+    libmagic also steps over a ``\\r\\n`` pair as one terminator, which this leaves out because the
+    step cannot be reached: the ``\\r`` search runs only once no ``\\n`` remains ahead, and a pair
+    needs one.
+
+    Args:
+        region: The bytes the byte budget already limited the test to.
+        line_count: The number of lines the ``l`` flag allows; zero imposes no limit.
+
+    Returns:
+        The number of bytes of `region` that the test may search.
+    """
+    end = len(region)
+    last = end
+    lines = line_count
+    position = 0
+    while lines and position < end:
+        found = region.find(b"\n", position, end)
+        if found < 0:
+            found = region.find(b"\r", position, end)
+        if found < 0:
+            break
+        position = found + 1 if found < end - 1 and region[found] == 0x0A else found
+        last = position
+        lines -= 1
+        position += 1
+    return end if lines else last
 
 
 class RegexType(DataType[MagicRegex]):
@@ -2766,13 +2810,38 @@ class RegexType(DataType[MagicRegex]):
             return DataTypeMatch(raw_match, value, initial_offset=start, relative_base=start)
         return DataTypeMatch(raw_match, value, initial_offset=start)
 
+    def region(self, data: bytes) -> bytes:
+        """The bytes of `data` this test is allowed to look at, before it is NUL-terminated.
+
+        ``mcopy`` budgets the region in bytes: `length` of them, or, under the ``l`` flag, `length`
+        lines of an assumed 80 bytes each. A budget of zero means the rest of the file. Either way
+        the budget is clamped to what the file has left and then to `REGEX_MAX`
+        (``file/src/softmagic.c:1411-1422``). The ``l`` flag then cuts the region back to whole
+        lines (``file/src/softmagic.c:1424-1440``).
+
+        Args:
+            data: The file's bytes from the offset this test runs at.
+
+        Returns:
+            The region libmagic copies for ``regexec``.
+        """
+        byte_budget = self.length * 80 if self.limit_lines else self.length
+        if byte_budget == 0 or byte_budget > len(data):
+            byte_budget = len(data)
+        region = data[:min(byte_budget, REGEX_MAX)]
+        if self.limit_lines:
+            return region[:line_region_length(region, self.length)]
+        return region
+
     def subject(self, data: bytes) -> bytes:
         """The bytes libmagic hands to ``regexec``, given the file's bytes from this test's offset.
 
-        libmagic copies at most `length` bytes of the region and then terminates the copy by
+        libmagic copies the region `RegexType.region` picks out, then terminates the copy by
         overwriting its last byte with a NUL (``file/src/softmagic.c:2393-2405``). It passes the
         result as a C string, so the pattern never sees the final byte of the region, and never
-        sees anything past a NUL that was already in it.
+        sees anything past a NUL that was already in it. The ``l`` flag narrows the region rather
+        than the copy, so under it the byte the NUL claims is the last byte of the last allowed
+        line.
 
         Args:
             data: The file's bytes from the offset this test runs at.
@@ -2780,27 +2849,13 @@ class RegexType(DataType[MagicRegex]):
         Returns:
             The bytes to match the pattern against.
         """
-        region = data[:self.length]
-        return region[:-1].partition(b"\0")[0]
+        return self.region(data)[:-1].partition(b"\0")[0]
 
     def match(self, data: bytes, expected: MagicRegex) -> DataTypeMatch:
-        if not self.limit_lines:
-            m = expected.search(self.subject(data))
-            if m is None:
-                return DataTypeMatch.INVALID
-            return self.matched_extent(m, 0)
-        offset = 0
-        # libmagic uses an implicit byte limit that assumes 80 characters per line
-        byte_limit = 80 * self.length
-        for _ in range(self.length):
-            line_offset = data.find(b"\n", offset, byte_limit)
-            if line_offset < 0:
-                return DataTypeMatch.INVALID
-            m = expected.match(data[offset:line_offset])
-            if m is not None:
-                return self.matched_extent(m, offset)
-            offset = line_offset + 1
-        return DataTypeMatch.INVALID
+        m = expected.search(self.subject(data))
+        if m is None:
+            return DataTypeMatch.INVALID
+        return self.matched_extent(m, 0)
 
     REGEX_TYPE_FORMAT: Pattern[str] = re.compile(
         r"^regex(/(?P<length>\d+)?(?P<flags1>[bcslTt]*)(/(?P<flags2>[bcslTt]*))?)?$"

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -2586,3 +2586,134 @@ class RegexSubjectTest(TestCase):
         matches = [str(match) for match in MagicMatcher.DEFAULT_INSTANCE.match(testfile.read_bytes())]
         self.assertNotIn("Microsoft OOXML", matches)
         self.assertEqual("Hancom HWP (Hangul Word Processor) file, HWPX", matches[0])
+
+
+class RegexLineLimitTest(TestCase):
+    """Regression tests for the `l` flag on a `regex` test, reported in issue #3525.
+
+    `l` bounds how much buffer the test may scan, expressed in lines. `mcopy` narrows the region
+    to whole lines and clamps it to `FILE_REGEX_MAX` (`file/src/softmagic.c:1411-1440`), and
+    `magiccheck` then runs one `regexec` over the whole region. The compile is
+    `REG_EXTENDED | REG_NEWLINE | REGEX_ICASE(m)` (`file/src/softmagic.c:2160`), where
+    `REG_NEWLINE` does not depend on the flag, so `^` and `$` match at line boundaries and `.`
+    stops at one whether or not `l` is set.
+
+    PolyFile split the region on newlines and called `Pattern.match` on each line instead, which
+    anchored every pattern to a line start, and which reached `regexec`'s subject through neither
+    `RegexType.subject` nor the byte clamp, so neither the NUL rule that issue #3517 fixed nor
+    `FILE_REGEX_MAX` applied under `l`.
+
+    Every verdict these tests assert is what `file -b -k` reports for the same definition and
+    input, checked against libmagic 5.48 built from the `file` submodule.
+    """
+
+    UNANCHORED: str = "0\tregex/4l\t=beta\tfound\n"
+    """Looks for `beta` anywhere within the first four lines."""
+
+    @staticmethod
+    def found(definitions: str, data: bytes) -> bool:
+        """Reports whether the `found` message of the definition's `regex` test appears.
+
+        Args:
+            definitions: The contents of a libmagic definition file, with tab separated columns.
+            data: The bytes to classify.
+
+        Returns:
+            True if some match carries the `found` message.
+        """
+        with TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "regex_line_limit"
+            path.write_text(definitions)
+            return any("found" in str(match) for match in MagicMatcher.parse(path).match(data))
+
+    def test_a_pattern_matches_part_way_into_a_line(self):
+        """`beta` three characters into line two used to be missed, because `l` anchored.
+
+        This is the reproducer from issue #3525. 31 of the 40 shipped `regex/...l` tests carry a
+        pattern that does not begin with `^`, so each of them could only match at a line start.
+        """
+        self.assertTrue(self.found(self.UNANCHORED, b"alpha\nxxbeta\ngamma\n"))
+
+    def test_the_line_count_still_bounds_the_scan(self):
+        """Widening the scan must not reach past the declared number of lines."""
+        self.assertTrue(self.found(self.UNANCHORED, b"a\nb\nc\nxxbeta\ne\n"))
+        self.assertFalse(self.found(self.UNANCHORED, b"a\nb\nc\nd\nxxbeta\n"))
+
+    def test_a_crlf_pair_counts_as_one_line_break(self):
+        """Counting the `\\r` of a `\\r\\n` pair as a line of its own would halve the budget.
+
+        `mcopy` finds the `\\n` and steps past it (`file/src/softmagic.c:1433-1436`), so the four
+        lines this input is allowed reach the one that holds `beta`.
+        """
+        self.assertTrue(self.found(self.UNANCHORED, b"a\r\nb\r\nc\r\nxxbeta\r\ne\r\n"))
+
+    def test_a_caret_still_anchors_at_a_line_start(self):
+        """`REG_NEWLINE` makes `^` match at a line start and nowhere else."""
+        anchored = "0\tregex/4l\t=^beta\tfound\n"
+        self.assertTrue(self.found(anchored, b"alpha\nbeta\ngamma\n"))
+        self.assertFalse(self.found(anchored, b"alpha\nxxbeta\ngamma\n"))
+
+    def test_a_dollar_still_matches_at_a_line_end(self):
+        """`REG_NEWLINE` makes `$` match before a newline, not only at the end of the region."""
+        at_line_end = "0\tregex/4l\t=beta$\tfound\n"
+        self.assertTrue(self.found(at_line_end, b"alphabeta\nxx\nyy\nzz\n"))
+        self.assertFalse(self.found(at_line_end, b"alpha\nbetaxx\nyy\nzz\n"))
+
+    def test_a_dot_does_not_cross_a_newline(self):
+        """One `regexec` over a multi-line region must still not let `.` span the lines."""
+        spanning = "0\tregex/4l\t=beta.gamma\tfound\n"
+        self.assertFalse(self.found(spanning, b"beta\ngamma\nzz\nyy\n"))
+        self.assertTrue(self.found(spanning, b"betaXgamma\nzz\nyy\nww\n"))
+
+    def test_the_region_still_stops_at_a_nul(self):
+        """Issue #3517's NUL rule never applied under `l`, because `l` skipped `subject`.
+
+        Both inputs hold a NUL, so both are binary and the `b` flag puts the test in the pass that
+        runs on them (`file/src/softmagic.c:249-253`). Only the NUL that precedes `beta` hides it.
+        """
+        binary = "0\tregex/4lb\t=beta\tfound\n"
+        self.assertTrue(self.found(binary, b"xxbeta\nzz\x00\nyy\nww\n"))
+        self.assertFalse(self.found(binary, b"xx\x00beta\nzz\nyy\nww\n"))
+
+    def test_the_region_still_loses_its_last_byte(self):
+        """A file with no line terminator at all is scanned whole, and so loses its last byte.
+
+        `magiccheck` overwrites the region's last byte with the NUL that terminates its copy, so
+        `beta` at the very end of the file is out of reach and `betaZ` is not. PolyFile used to
+        report no match either way, because its per-line loop gave up on finding no newline.
+        """
+        self.assertFalse(self.found(self.UNANCHORED, b"xxbeta"))
+        self.assertTrue(self.found(self.UNANCHORED, b"xxbetaZ"))
+
+    def test_the_walk_passes_over_a_terminator_it_lands_on(self):
+        """The line walk resumes one byte past the line it just took, skipping a blank line.
+
+        `mcopy` steps past the terminator and then the `for` increment steps again
+        (`file/src/softmagic.c:1433-1437`), so a terminator sitting in that second position is not
+        counted. Four blank-separated lines therefore cost three of the four the budget allows,
+        and `beta` is still in reach; a budget of two runs out before it.
+        """
+        self.assertTrue(self.found(self.UNANCHORED, b"a\n\n\n\nxxbeta\n"))
+        self.assertFalse(self.found("0\tregex/2l\t=beta\tfound\n", b"a\n\n\n\nxxbeta\n"))
+
+    def test_running_out_of_lines_widens_the_region(self):
+        """An unterminated last line is searched, rather than dropped.
+
+        Running out of terminators before the line count is reached puts the region back to the
+        whole byte budget (`file/src/softmagic.c:1438-1439`). With a budget of three lines this
+        input runs out and its unterminated tail is searched; with a budget of two the budget is
+        spent on the two terminated lines and the tail is left out.
+        """
+        self.assertTrue(self.found("0\tregex/3l\t=beta\tfound\n", b"a\nb\nxxbetaZ"))
+        self.assertFalse(self.found("0\tregex/2l\t=beta\tfound\n", b"a\nb\nxxbetaZ"))
+
+    def test_a_line_budget_over_8_kib_is_clamped(self):
+        """`regex/128l` asks for 10240 bytes and gets 8192, which PolyFile did not model.
+
+        `bytecnt` is `linecnt * 80` clamped to `ms->regex_max`, which `apprentice.c:573` seeds
+        with `FILE_REGEX_MAX` (`file/src/softmagic.c:1417-1422`). 19 shipped definitions declare
+        `regex/128l`, so a long first line used to let them match bytes libmagic cannot reach.
+        """
+        clamped = "0\tregex/128l\t=beta\tfound\n"
+        self.assertTrue(self.found(clamped, b"a" * 8000 + b"beta" + b"a" * 2000))
+        self.assertFalse(self.found(clamped, b"a" * 9000 + b"beta" + b"a" * 2000))


### PR DESCRIPTION
Closes #3525

## What the `l` flag means

`l` bounds how much buffer a `regex` test may scan, expressed in lines. libmagic implements it in
`mcopy` and then runs **one** `regexec` over the resulting region:

- `file/src/softmagic.c:1411-1416` — with `REGEX_LINE_COUNT` set, `linecnt = m->str_range` and
  `bytecnt = linecnt * 80`; otherwise `linecnt = 0` and `bytecnt = m->str_range`.
- `file/src/softmagic.c:1417-1422` — `bytecnt` of zero means the rest of the file, and `bytecnt` is
  then clamped to the bytes remaining and to `ms->regex_max`, which `file/src/apprentice.c:573`
  seeds with `FILE_REGEX_MAX` (8192, `file/src/file.h:524`).
- `file/src/softmagic.c:1424-1440` — a forward walk over line terminators cuts the region back to
  `linecnt` whole lines. Running out of terminators first widens it back to the whole byte budget.
- `file/src/softmagic.c:2381-2412` — `magiccheck` copies that region, NUL-terminates the copy, and
  calls `regexec` once.

So `l` bounds the buffer; it does not turn matching into a per-line operation. PolyFile's
`RegexType.match` split the buffer on newlines and called `Pattern.match` on each line, which
anchors at position 0, so a pattern occurring part way into a line never matched.

### `REG_NEWLINE` is unconditional, and the non-`l` path already agreed

The compile at `file/src/softmagic.c:2160` is `REG_EXTENDED | REG_NEWLINE | REGEX_ICASE(m)`.
`REG_NEWLINE` does not depend on the `l` flag: `^` and `$` match at line boundaries and `.` does not
cross a newline for *every* `regex` test.

I checked rather than assumed, and the non-`l` path already agreed. `parse_expected` compiles with
`re.MULTILINE`, which gives `^` and `$` at line boundaries, and Python's `.` already excludes `\n`
without `re.DOTALL`. Between them that is `REG_NEWLINE`. So the non-`l` path needed no change, and
the `l` path reduces to the same single `search` over a narrower region.

## How the line-count region and #3524's NUL rule compose

They compose by ordering, and they were not composed at all before. #3524 put the NUL rule in
`RegexType.subject`, but the `l` branch never called `subject` — it sliced `data` itself — so under
`l` neither the trailing-byte loss nor the NUL truncation applied.

libmagic decides the region first (`mcopy`) and NUL-terminates second (`magiccheck`), and
`magiccheck` overwrites the *region's* last byte. Under `l` the region ends at the last allowed
line, so the byte the NUL claims is the last byte of that line, not the last byte of the file.
`RegexType.region` now picks the region and `subject` applies `[:-1].partition(b"\0")[0]` to it, in
that order, for both paths.

## Two further divergences this picks up

- **The `regex_max` clamp was missing entirely.** `regex/128l` asks for `128 * 80 = 10240` bytes and
  gets 8192. 19 shipped definitions declare `regex/128l`. No shipped non-`l` `regex` declares a
  range above 8192, so the clamp is observable only on the `l` sites.
- **Running out of line terminators used to fail the test.** The old loop returned `INVALID` the
  moment `data.find(b"\n", ...)` came up empty. libmagic widens the region back to the whole byte
  budget instead (`file/src/softmagic.c:1438-1439`), so a file whose last line is unterminated is
  still searched.

I also found that libmagic's `\r\n` step at `file/src/softmagic.c:1431-1432` is **unreachable**: the
`\r` search runs only once `memchr` finds no `\n` anywhere ahead, and a `\r\n` pair needs one. The
Python does not reproduce it, and the docstring says why.

## Affected shipped sites

I count **40** `regex/...l` sites out of **369** `regex` sites, not the 48 out of ~396 the issue
estimates. Of the 40, **31** have a pattern that does not begin with `^` after unescaping and so can
change behavior. `fortran:6` is in that 31 only because PolyFile parses its leading `!` as part of
the pattern rather than as the negated relation (#3498); its pattern `!^[^Cc \t].*$` can match under
neither the old nor the new code, so it is unaffected in practice.

<details><summary>The 31 unanchored sites</summary>

| site | type | pattern |
| --- | --- | --- |
| `fortran:6` | `regex/100l` | `!^[^Cc \t].*$` |
| `marc21:17` | `regex/1l` | `(^[0-9]{5})[acdnp][^bhlnqsu-z]` |
| `marc21:19` | `regex/1l` | `(^[0-9]{5})[acdnosx][z]` |
| `marc21:21` | `regex/1l` | `(^[0-9]{5})[cdn][uvxy]` |
| `marc21:23` | `regex/1l` | `(^[0-9]{5})[acdn][w]` |
| `marc21:25` | `regex/1l` | `(^[0-9]{5})[cdn][q]` |
| `marc21:29` | `regex/1l` | `(^.{21})([^0]{2})` |
| `ringdove:6-9,12-21,25-29` (17 sites) | `regex/128l` | `ha:rnd-menu-v[0-9]+[ \t\r\n]*[{]` and 16 siblings |
| `ringdove:32` | `regex/1l` | `tEDAx[ \t\r\n]v` |
| `scientific:128` | `regex/1l` | `[0-9]{2}-[A-Z]{3}-[0-9]{2} {3}` |
| `scientific:129` | `regex/1sl` | `[A-Z0-9]{4}.{14}$` |
| `scientific:130` | `regex/1l` | `[A-Z0-9]{4}` |
| `scientific:132` | `regex/1l` | `[0-9]{2}-[A-Z]{3}-[0-9]{2}` |

The nine that start with `^` and so behave the same either way: `android:77`, `fonts:283`,
`fortran:7`, `make:6`, `make:15`, `make:19`, `scientific:127`, `troff:23`, `troff:26`.
</details>

## Evidence

### Corpus differential

Unchanged from `master`, which is the point:

```
NEWLY PASSING (14): ['JW07022A.mp3', 'cmd1', 'cmd2', 'cmd3', 'cmd4', 'gedcom', 'jpeg-text',
                     'jsonlines1', 'multiple', 'osm', 'pnm1', 'pnm2', 'pnm3', 'utf16xmlsvg']
STILL FAILING (0): []
REGRESSIONS   (0):
```

`KNOWN_FAILURES` stays empty.

### Randomized differential against libmagic 5.48

A generator of newline-, CR-, CRLF- and NUL-heavy inputs, run against the built `file` binary with
ad-hoc `regex/Nl` definitions over 12 patterns and 6 line counts, in both the text pass and the
binary pass:

| | trials | mismatches |
| --- | ---: | ---: |
| `master` | 795 | **151** |
| this branch | 1194 | **0** |

`master`'s 151 split both ways: it missed matches libmagic finds (the anchoring bug) and it also
*reported* matches libmagic does not, because the `l` branch applied neither the NUL rule nor the
8192 clamp.

### Broad oracle comparison

**111 mixed files** — all 88 `file/tests/*.testfile`, plus C sources, Markdown, Python, magic
definition files, a `.mgc`, a zip and a gzip. PolyFile's full match list is **identical before and
after on all 111**. Nothing in that set exercises a `regex/...l` site, which is the expected result
and the reason for the next table.

**40 files built to exercise the shipped `l` sites** (ringdove lihata headers, tEDAx, PDB, MARC21,
troff, make, fortran; each at a line start, mid-line, on the last allowed line, one line past it,
across the 8192 boundary, and with CR / CRLF / no terminator / an embedded NUL). PolyFile's match
list changed on **12 of 40**, and every one of the 12 moved *towards* `file -b -k`:

| file | change | libmagic agrees? |
| --- | --- | --- |
| `ringdove_board_midline` | `+ pcb-rnd board file (lihata)` | yes |
| `ringdove_menu_midline` | `+ librnd menu system (lihata)` | yes |
| `ringdove_conf_midline` | `+ pcb-rnd configuration (lihata)` | yes |
| `ringdove_sheet_midline` | `+ sch-rnd/cschem schematic sheet (lihata)` | yes |
| `ringdove_devmap_midline` | `+ sch-rnd devmap (device mapping; lihata)` | yes |
| `ringdove_board_crlf` | `+ pcb-rnd board file (lihata)` | yes |
| `ringdove_board_cr` | `+ pcb-rnd board file (lihata)` | yes |
| `ringdove_tedax_midline` | `+ tEDAx (Trivial EDA eXchange) with schematic symbol` | yes |
| `marc21_bib` | `+ MARC21 Bibliographic` | yes |
| `marc21_auth` | `+ MARC21 Authority` | yes |
| `pdb_conforming` | `+ , 02-JAN-70` on the PDB message | yes |
| `ringdove_board_byte9000` | `- pcb-rnd board file (lihata)` | yes — the 8192 clamp; libmagic does not report it either |

**Zero blockers**: no file gained a match libmagic does not report, and no file lost one it does.
The `- ASCII text` lines that accompany several of the wins are PolyFile's plain-text fallback being
superseded by a real match, which is how the fallback is meant to behave.

The three `fortran_*` files still miss `FORTRAN program` before and after. That is #3498, untouched.

### Synthetic cases against the oracle

Each asserted verdict below was taken from `TZ=UTC file -b -k -m <defs> <input>` before it was
written into a test:

| case | definition | input | verdict |
| --- | --- | --- | --- |
| mid-line match (the issue) | `regex/4l` `=beta` | `alpha\nxxbeta\ngamma\n` | match |
| last allowed line | `regex/4l` `=beta` | `a\nb\nc\nxxbeta\ne\n` | match |
| one line past the limit | `regex/4l` `=beta` | `a\nb\nc\nd\nxxbeta\n` | no match |
| `^` at a line start | `regex/4l` `=^beta` | `alpha\nbeta\ngamma\n` | match |
| `^` not mid-line | `regex/4l` `=^beta` | `alpha\nxxbeta\ngamma\n` | no match |
| `$` at a line end | `regex/4l` `=beta$` | `alphabeta\nxx\nyy\nzz\n` | match |
| `$` not mid-line | `regex/4l` `=beta$` | `alpha\nbetaxx\nyy\nzz\n` | no match |
| `.` does not cross `\n` | `regex/4l` `=beta.gamma` | `beta\ngamma\nzz\nyy\n` | no match |
| `.` within a line | `regex/4l` `=beta.gamma` | `betaXgamma\nzz\nyy\nww\n` | match |
| NUL after the match | `regex/4lb` `=beta` | `xxbeta\nzz\0\nyy\nww\n` | match |
| NUL before the match | `regex/4lb` `=beta` | `xx\0beta\nzz\nyy\nww\n` | no match |
| region loses its last byte | `regex/4l` `=beta` | `xxbeta` / `xxbetaZ` | no match / match |
| unterminated tail is searched | `regex/3l` / `regex/2l` `=beta` | `a\nb\nxxbetaZ` | match / no match |
| blank lines and the skipped byte | `regex/4l` / `regex/2l` `=beta` | `a\n\n\n\nxxbeta\n` | match / no match |
| CRLF counts as one break | `regex/4l` `=beta` | `a\r\nb\r\nc\r\nxxbeta\r\ne\r\n` | match |
| 8192 clamp | `regex/128l` `=beta` | `beta` at 8000 / at 9000 | match / no match |

### Tests

Nine tests in a new `RegexLineLimitTest`. Each was mutation-checked: I broke the corresponding part
of `polyfile/magic.py`, confirmed the test failed, restored, and confirmed it passed. All nine
mutations are caught:

| mutation | caught by |
| --- | --- |
| `search` back to an anchored `match` | mid-line, `$`, clamp, NUL, last-byte |
| drop `re.MULTILINE` | `^`, `$` |
| add `re.DOTALL` | `.` does not cross a newline |
| drop the line limit | line count bounds the scan |
| drop the `REGEX_MAX` clamp | 8 KiB budget is clamped |
| drop the NUL termination | NUL, last-byte |
| do not step past the newline that ends a line | CRLF, blank lines |
| do not widen when terminators run out | unterminated tail |
| `subject` no longer covers the non-`l` path | the existing `RegexSubjectTest` (#3524) |

### Counts and timing

| | `master` | this branch |
| --- | --- | --- |
| `pytest tests` | 1140 passed, 3 skipped, 862 subtests, 3 warnings | **1151 passed**, 3 skipped, 862 subtests, 3 warnings |
| wall clock | 103.53 s | **103.19 s** (100.20 s on a second run) |
| `flake8 --max-complexity=10 --max-line-length=127` | 224 | **224**, with an identical per-file breakdown |
| `flake8 --select=E9,F63,F7,F82` | 0 | **0** |

The three warnings are the pre-existing `SyntaxWarning`s from generated Kaitai parsers (#3462).

The full flake8 count is 224 here, not the 226 the issue triage mentioned; `master` in the same tree
also reports 224, so nothing was removed. The new code is complexity 6 or lower, under 50 lines per
function and under 100 columns.

### Performance

One `search` over a bounded region replaces a Python-level loop, so this should be no slower, and it
is not. Fifteen adversarial 8 KiB inputs aimed at the `l` definitions — near-miss ringdove headers,
a run of `n` for `android:77`, runs of blank lines, CRLF, CR, one long line, many short lines —
timed through the full `MagicMatcher`:

| input | `master` | this branch |
| --- | ---: | ---: |
| ringdove near-miss × 8 KiB | 0.313 s | 0.313 s |
| ringdove hit at 8 KiB | 0.258 s | 0.259 s |
| `android:77` run of `n` | 0.271 s | 0.271 s |
| blank lines × 8192 | 0.752 s | 0.749 s |
| CRLF blank lines | 0.455 s | 0.450 s |
| one long line | 0.281 s | 0.272 s |
| gentoo #3473 reproducer | 3.110 s | 3.100 s |

Every case is within noise. No definition got materially slower.

On backtracking: #3473's `gentoo:38` is a non-`l` `regex`, and its region is byte-for-byte what it
was, so this neither helps nor hurts it. The `regex_max` clamp can only *reduce* the bytes a pattern
scans, and it reduces them for the 19 `regex/128l` sites.

## Unrelated finding

While benchmarking I hit a separate, pre-existing pathology: **8192 CR bytes take about 183 seconds**
to classify, identically on `master` and on this branch. The cost is one `re.Pattern.search` in
PolyFile's own `HTTP1.1Matcher` (`polyfile/http/matcher.py:16`), whose pattern
`[^\n]*?\s+HTTP/1.1\s*$` backtracks catastrophically on a long run of whitespace. It is a sibling of
#3473 but in PolyFile's own definition rather than a shipped one. Out of scope here; worth its own
issue.

## Scope notes

- I did not read, fetch, or base anything on PR #3519 (issue #3498, the negated `regex` relation).
  It touches `RegexType`, so a merge will be needed if it lands. The conflict should be small: #3519
  works on the relation, and this rewrites the region and drops the `l` branch. `fortran:6` is the
  one shipped site where the two interact, and fixing the negation there would turn its pattern into
  `^[^Cc \t].*$`, which is anchored and so unaffected by this change.
- #3473 and #3503/#3504 are untouched, and neither is made harder: the region for a non-`l` `regex`
  is unchanged.
- `RegexType.DOLLAR_PATTERN` is still dead. I left it alone rather than widen the diff.
- One divergence remains, with no shipped site: a bare `regex/l` with no number. libmagic reads
  `str_range == 0` as "no line limit, whole file up to 8192"; PolyFile's constructor substitutes
  `8 * 1024 // 80 = 102` lines. All 40 shipped `l` sites declare an explicit count, so this is
  unreachable from the definitions. Worth a follow-up but not worth changing `declaration()` here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VS8hTTRQeG8ZCmCZ9KLHiV
