### PR TITLE
Parse the regex relational operator, from @LouisDeconinck's #3519

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -2225,12 +2225,13 @@ class MagicRegex:
     scan, so the count is one lower per class unless it is taken first.
     """
 
-    def __init__(self, specification: bytes, flags: int = 0):
+    def __init__(self, specification: bytes, flags: int = 0, negated: bool = False):
         """Compiles `specification`, counting its literals before the POSIX rewrite.
 
         Args:
             specification: The unescaped pattern, as libmagic would hold it.
             flags: The regular expression flags to compile with.
+            negated: Whether the definition uses libmagic's ``!`` relation.
 
         Raises:
             re.error: If `specification` is not a valid regular expression.
@@ -2238,6 +2239,7 @@ class MagicRegex:
         self.literal_count: int = nonmagic(specification)
         self.pattern: bytes = posix_to_python_re(specification)
         self.compiled: Pattern[bytes] = re.compile(self.pattern, flags)
+        self.negated: bool = negated
 
     def search(self, data: bytes) -> Optional["re.Match[bytes]"]:
         return self.compiled.search(data)
@@ -2288,7 +2290,15 @@ class RegexType(DataType[MagicRegex]):
         literals = expected.literal_count
         return literals * max(STRENGTH_MULT // literals, 1)
 
+    def relation(self, expected: MagicRegex) -> str:
+        return "!" if expected.negated else "="
+
     def parse_expected(self, specification: str) -> MagicRegex:
+        negated = specification.startswith("!")
+        if negated:
+            # libmagic consumes a leading `!` as the relation operator rather than compiling it
+            # as part of the regular expression (`file/src/apprentice.c:2389-2391`).
+            specification = specification[1:]
         if specification.startswith("="):
             # libmagic parses a leading `=` as the equality operator, not as part of the pattern
             # (`file/src/apprentice.c:2383-2384`)
@@ -2297,7 +2307,7 @@ class RegexType(DataType[MagicRegex]):
         if self.case_insensitive:
             flags |= re.IGNORECASE
         try:
-            return MagicRegex(unescape(specification), flags)
+            return MagicRegex(unescape(specification), flags, negated=negated)
         except re.error as e:
             raise ValueError(str(e))
 
@@ -2333,6 +2343,8 @@ class RegexType(DataType[MagicRegex]):
         if not self.limit_lines:
             m = expected.search(data[:self.length])
             if m is None:
+                return DataTypeMatch(b"", "") if expected.negated else DataTypeMatch.INVALID
+            if expected.negated:
                 return DataTypeMatch.INVALID
             return self.matched_extent(m, 0)
         offset = 0
@@ -2341,12 +2353,14 @@ class RegexType(DataType[MagicRegex]):
         for _ in range(self.length):
             line_offset = data.find(b"\n", offset, byte_limit)
             if line_offset < 0:
-                return DataTypeMatch.INVALID
+                return DataTypeMatch(b"", "") if expected.negated else DataTypeMatch.INVALID
             m = expected.match(data[offset:line_offset])
             if m is not None:
+                if expected.negated:
+                    return DataTypeMatch.INVALID
                 return self.matched_extent(m, offset)
             offset = line_offset + 1
-        return DataTypeMatch.INVALID
+        return DataTypeMatch(b"", "") if expected.negated else DataTypeMatch.INVALID
 
     REGEX_TYPE_FORMAT: Pattern[str] = re.compile(
         r"^regex(/(?P<length>\d+)?(?P<flags1>[cslTt]*)(/(?P<flags2>[cslTt]*))?(b\d*)?)?$"

--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -2777,10 +2777,11 @@ class RegexType(DataType[MagicRegex]):
     def parse_expected(self, specification: str) -> MagicRegex:
         negated = specification.startswith("!")
         if negated:
-            # libmagic consumes a leading `!` as the relation operator rather than compiling it
-            # as part of the regular expression (`file/src/apprentice.c:2389-2391`).
+            # libmagic reads exactly one relational operator off the front of the value and
+            # compiles everything after it, so the `=` of a `!=` belongs to the pattern rather
+            # than being a second operator to strip (`file/src/apprentice.c:2383-2393`)
             specification = specification[1:]
-        if specification.startswith("="):
+        elif specification.startswith("="):
             # libmagic parses a leading `=` as the equality operator, not as part of the pattern
             # (`file/src/apprentice.c:2383-2384`)
             specification = specification[1:]

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -751,12 +751,34 @@ class RegexSemanticsTest(TestCase):
 
         self.assertEqual(b"^[^Cc \t].*$", expected.pattern)
         self.assertEqual("!", regex.relation(expected))
-        self.assertEqual(expected.pattern, regex.parse_expected(r"!=\^[^Cc\ \t].*$").pattern)
         self.assertFalse(regex.match(b"program\n", expected))
         self.assertTrue(regex.match(b"C comment\n", expected))
         self.assertEqual({"FORTRAN program, ASCII text"},
                          self.messages("0\tregex/100l\t!\\^[^Cc\\ \\t].*$\tFORTRAN program\n",
                                        b"C comment\n"))
+
+    def test_regex_reads_only_one_relational_operator(self):
+        """`!=foo` is the `!` relation over the pattern `=foo`, not a negated `foo`.
+
+        libmagic reads one operator off the front of the value and compiles the rest
+        (`file/src/apprentice.c:2383-2393`), so the `=` of a `!=` is a literal character of the
+        pattern. Stripping both made `!=abc` reject an input that libmagic accepts. The expected
+        column below is what `file -b` reports for each definition and input.
+        """
+        for specification, expected_pattern, accepted, rejected in (
+                ("abc", b"abc", (b"abc\n", b"=abc\n"), (b"zzz\n",)),
+                ("=abc", b"abc", (b"abc\n", b"=abc\n"), (b"zzz\n",)),
+                ("!abc", b"abc", (b"zzz\n",), (b"abc\n", b"=abc\n")),
+                ("!=abc", b"=abc", (b"abc\n", b"zzz\n"), (b"=abc\n",)),
+        ):
+            with self.subTest(specification=specification):
+                regex = RegexType.parse("regex")
+                self.assertEqual(expected_pattern, regex.parse_expected(specification).pattern)
+                definition = f"0\tregex\t{specification}\tHIT\n"
+                for data in accepted:
+                    self.assertIn("HIT", " ".join(self.messages(definition, data)), repr(data))
+                for data in rejected:
+                    self.assertNotIn("HIT", " ".join(self.messages(definition, data)), repr(data))
 
     def test_regex_reports_only_the_matched_extent(self):
         """`%s` used to report every byte from offset 0 through the end of the match.

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -742,6 +742,20 @@ class RegexSemanticsTest(TestCase):
         self.assertEqual(b"^[0-9]{1,50}", regex.parse_expected("=\\^[0-9]{1,50}").pattern)
         self.assertTrue(regex.match(self.DATA, regex.parse_expected("=[0-9]{1,3}")))
 
+    def test_regex_strips_and_applies_the_negation_operator(self):
+        """A leading `!` is a relation, so a non-matching regex is the successful test."""
+        regex = RegexType.parse("regex/100l")
+        expected = regex.parse_expected(r"!\^[^Cc\ \t].*$")
+
+        self.assertEqual(b"^[^Cc \t].*$", expected.pattern)
+        self.assertEqual("!", regex.relation(expected))
+        self.assertEqual(expected.pattern, regex.parse_expected(r"!=\^[^Cc\ \t].*$").pattern)
+        self.assertFalse(regex.match(b"program\n", expected))
+        self.assertTrue(regex.match(b"C comment\n", expected))
+        self.assertEqual({"FORTRAN program, ASCII text"},
+                         self.messages("0\tregex/100l\t!\\^[^Cc\\ \\t].*$\tFORTRAN program\n",
+                                       b"C comment\n"))
+
     def test_regex_reports_only_the_matched_extent(self):
         """`%s` used to report every byte from offset 0 through the end of the match.
 


### PR DESCRIPTION
Closes #3498.

This branch carries @LouisDeconinck's work from #3519, merged against `master`, plus one follow-up
fix. **The negation support is theirs** — they diagnosed the bug, wrote the implementation, and
signed the CLA. Their PR could not be merged directly only because `master` moved underneath it
while the agreement was pending.

## What #3519 does

libmagic reads a leading `!` on a `regex` value as the relational operator rather than as pattern
text (`file/src/apprentice.c:2383-2393`), and inverts the test's verdict. PolyFile compiled the `!`
into the pattern, so a negated test could never match. The visible consequence was that **FORTRAN
source went undetected**:

```console
$ printf 'C     a comment line\n      program main\n      end\n' > f.f
$ file -b f.f
FORTRAN program, ASCII text
$ polyfile f.f          # before
ascii text
$ polyfile f.f          # after
FORTRAN program, ASCII text
```

`MagicRegex` gained a `negated` flag, `RegexType.relation()` reports `!` for it, and
`RegexType.match` inverts the verdict.

## The merge

#3526 replaced `RegexType.match`'s line-by-line loop with a single search over `self.subject(data)`,
which is the region #3519 also edited. The resolution keeps `master`'s structure and layers the
negation onto it:

```python
        m = expected.search(self.subject(data))
        if expected.negated:
            return DataTypeMatch.INVALID if m is not None else DataTypeMatch(b"", "")
        if m is None:
            return DataTypeMatch.INVALID
        return self.matched_extent(m, 0)
```

## The follow-up fix

libmagic reads **exactly one** operator off the value. #3519 consumed a leading `!` and then stripped
a following `=` as well, so `!=abc` compiled the pattern `abc` where libmagic compiles `=abc`.

Measured against `file -b`, with `0 regex <spec> HIT` and each input newline-terminated:

| spec | `abc` | `zzz` | `=abc` |
| --- | --- | --- | --- |
| `abc` | hit | — | hit |
| `=abc` | hit | — | hit |
| `!abc` | — | hit | — |
| `!=abc` | **hit** | hit | — |

The `!=abc` / `abc` cell is the divergence: libmagic looks for the literal `=abc`, does not find it,
and the `!` relation turns that into a match. PolyFile reported nothing. Fixed by making the `=`
strip an `elif`, and `test_regex_reads_only_one_relational_operator` pins the whole table.

No shipped definition is affected — the only `!=` uses are the two commented-out lines in
`magic_defs/bioinformatics` — so this was latent rather than breaking anything.

## A second result worth noting

Parsing the relation correctly also corrects the test's **strength**, because `!` is in
`UNSELECTIVE_RELATIONS`. `magic_defs/fortran:6` scored 36 and now scores 2, which is what `file -l`
reports. That takes the strength parity measured in #3508 from 3863/3865 to 3864/3865, leaving only
`ctf:22` (#3476).

## Verification

- corpus differential: `NEWLY PASSING (14)`, `STILL FAILING (0)`, `REGRESSIONS (0)`; `KNOWN_FAILURES`
  still empty
- `pytest tests`: 1153 passed, 3 skipped, 866 subtests (master: 1151 / 3 / 862)
- flake8 blocking selection `E9,F63,F7,F82`: 0
- all nine cells of the table above agree with `file -b`, and reverting the `elif` fails exactly the
  `!=abc` subtest

## Still partial, deliberately

`apprentice.c` also reads `^`, `<`, `>` and `&` off a regex value. This handles `!` and `=` only.
All four such lines in the shipped definitions escape the operator, so nothing is affected today,
but the parse is not yet complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VS8hTTRQeG8ZCmCZ9KLHiV
