### PR TITLE
Do not re-match Constant struct fields as embedded files

### DIFF
--- a/polyfile/structmatcher.py
+++ b/polyfile/structmatcher.py
@@ -2,7 +2,7 @@ from typing import Iterator, Optional
 
 from .fileutils import Tempfile
 from .polyfile import InvalidMatch, Match, Matcher, Submatch
-from .structs import Field, Struct, StructError
+from .structs import Constant, Field, Struct, StructError
 
 
 class PolyFileStruct(Struct):
@@ -16,6 +16,21 @@ class PolyFileStruct(Struct):
             return self.__class__.__name__
 
     def match(self, matcher: Matcher, parent: Optional[Match] = None) -> Iterator[Submatch]:
+        """Yields a match for this struct, one for each of its fields, and any embedded files.
+
+        A field holding raw bytes can itself contain a file, so it is written to a temporary
+        file and handed back to `matcher`. :class:`polyfile.structs.Constant` fields are
+        exempt: their contents are the fixed signature that identified this struct, so
+        matching them only rediscovers the struct's own file type at the offset of its magic.
+
+        Args:
+            matcher: The matcher to use for fields that may contain embedded files.
+            parent: The match that contains this struct, if any.
+
+        Yields:
+            The match for this struct, followed by the matches for its fields and their
+            contents, depth first.
+        """
         m = Submatch(
             self.match_name,
             match_obj=self,
@@ -39,7 +54,7 @@ class PolyFileStruct(Struct):
             try:
                 if isinstance(value, PolyFileStruct):
                     yield from value.match(matcher, s)
-                elif isinstance(value, bytes):
+                elif isinstance(value, bytes) and not isinstance(value, Constant):
                     with Tempfile(value) as tmp:
                         yield from matcher.match(tmp, parent=s)
             except (InvalidMatch, StructError):

--- a/tests/test_zipmatcher.py
+++ b/tests/test_zipmatcher.py
@@ -9,6 +9,7 @@ import zipfile
 from polyfile.fileutils import FileStream
 from polyfile.magic import MagicMatcher, MatchContext
 from polyfile.polyfile import Match, Matcher
+from polyfile.structs import Constant
 from polyfile.zipmatcher import EndOfCentralDirectory, parse_zip
 
 MEMBERS: Dict[str, bytes] = {
@@ -67,10 +68,13 @@ class TestZipMatcher(TestCase):
                 cd.local_file_header(stream).file_name for cd in eocd.central_directories(stream)
             ]
 
-    def parsed_names(self, data: bytes) -> List[str]:
-        parent = Match("application/zip", None, 0, length=len(data), matcher=Matcher(parse=False))
+    def parsed_matches(self, data: bytes, parse: bool = False) -> List[Match]:
+        parent = Match("application/zip", None, 0, length=len(data), matcher=Matcher(parse=parse))
         with temporary_file(data) as path, FileStream(str(path)) as stream:
-            return [match.name for match in parse_zip(stream, parent)]
+            return list(parse_zip(stream, parent))
+
+    def parsed_names(self, data: bytes) -> List[str]:
+        return [match.name for match in self.parsed_matches(data)]
 
     def matched_mime_types(self, data: bytes) -> Set[str]:
         with temporary_file(data) as path, FileStream(str(path)) as stream:
@@ -112,6 +116,25 @@ class TestZipMatcher(TestCase):
 
     def test_parse_zip_with_prepended_data(self):
         self.assert_structure_parsed(build_zip(PNG))
+
+    def test_no_matches_inside_constant_fields(self):
+        """Regression test for #3470.
+
+        Every bytes field used to be written to a temporary file and re-matched to find
+        embedded files, including the fixed signatures declared as Constant fields. The four
+        bytes of `EndOfCentralDirectory.magic` matched as an empty archive, so each ZIP
+        reported a nested `application/zip` on its own magic, and the magic of the other two
+        records reported a nested `application/octet-stream`.
+        """
+        constants = [match for match in self.parsed_matches(build_zip()) if isinstance(match.match, Constant)]
+        self.assertEqual(2 * len(MEMBERS) + 1, len(constants))
+        for match in constants:
+            self.assertEqual((), match.children, f"{match.name} at offset {match.offset} was re-matched")
+
+    def test_no_parser_warning_for_constant_fields(self):
+        """The nested match on the magic ran parse_zip on four bytes, which logged a warning."""
+        with self.assertNoLogs("polyfile", "WARNING"):
+            self.parsed_matches(build_zip(), parse=True)
 
     def test_jar_with_prepended_data(self):
         """RelaxedJarMatcher reads local file headers, so it needs the archive offset too."""


### PR DESCRIPTION
Closes #3470

## Merge order

Wave 1, alongside #3529, #3462, #3476, #3464, #3479, #3501, #3499, #3500, and #3506. This PR
conflicts with none of them: it is the only change to `polyfile/structmatcher.py`.

**#3530 must rebase onto this.** `structmatcher.py` calls `Matcher.match` for every bytes field,
and #3466 rewrites that method, so the two changes disagree about how many submatches that call
yields unless this one lands first.

## Reproducer

```bash
python -c "import zipfile; zipfile.ZipFile('a.zip','w').writestr('a.txt', b'hello\n')"
polyfile --debug --format sbud a.zip
```

### Before

On stderr:

```
Parser parse_zip for MIME type application/zip raised an exception while parsing Zip archive data
(empty) in /var/folders/.../tmpm5za9xze: Reached the end of stream while expecting 2-byte unsigned
integer for EndOfCentralDirectory.disk_number
```

In the SBUD tree, three spurious nested matches, one per record:

```
application/zip @0 +114
  LocalFileHeader @0 +41
    magic @0 +4
      application/octet-stream @0 +4     <- false positive
    ...
  CentralDirectory @41 +51
    magic @41 +4
      application/octet-stream @41 +4    <- false positive
    ...
  EndOfCentralDirectory @92 +22
    magic @92 +4
      application/zip @92 +4             <- false positive
    ...
```

### After

No warning on stderr, and the three `magic` fields carry no children:

```
application/zip @0 +114
  LocalFileHeader @0 +41
    magic @0 +4
    ...
  CentralDirectory @41 +51
    magic @41 +4
    ...
  EndOfCentralDirectory @92 +22
    magic @92 +4
    ...
```

Every other nested match is unchanged: `file_name` still reports `text/plain`, and
`compressed_data` still reports the decompressed member.

## What the fix does

`PolyFileStruct.match` writes each bytes field to a temporary file and hands it back to the matcher,
which is how PolyFile finds files embedded in a struct's payload. `Constant` is a `bytes` subclass
(`polyfile/structs.py:210`, via `ByteField(bytes, Field, ...)` at `:159`), so the signature that
identified the struct went through the same path as its payload.

For ZIP that signature is self-satisfying. The relaxed ZIP test in `polyfile/zipmatcher.py:15-20`
searches for `PK\x05\x06` anywhere in a file rather than requiring the archive to start at offset
zero, so a four-byte file containing exactly that sequence matches as an empty archive. `parse_zip`
then ran on those four bytes and raised `StructReadError` on the field after the magic, which
`Matcher.handle_mimetype` reports as a parser warning. The other two records' magic fields fell
through to libmagic's catch-all `application/octet-stream`.

The fix skips the recursion when the field is a `Constant`. A `Constant` holds a signature the
struct definition already fixed, so re-matching it can only rediscover the enclosing struct's own
file type at the offset of its magic; it can never find an embedded file, because nothing embedded
could vary. This is the general form of the bug: any struct whose magic satisfies a matcher shows
the symptom, so raising the minimum size of the relaxed ZIP test would have fixed ZIP alone and left
the mechanism in place.

The ZIP records are the only structs in the tree that this reaches today. `Constant` appears in
three places, all in `polyfile/zipmatcher.py`, and `PolyFileStruct` has no other subclass in the
package. Nothing outside `polyfile/structmatcher.py` inspects the `Constant` fields' children, so
removing them changes no other output.

This touches no part of libmagic matching. `polyfile/structmatcher.py` runs during parsing, after a
MIME type is already resolved, and the corpus tests drive `MagicMatcher` directly.

## What the tests pin

Both tests are in `tests/test_zipmatcher.py`, and both fail when the guard is reverted.

`test_no_matches_inside_constant_fields` walks the matches that `parse_zip` yields, selects every
one whose match object is a `Constant`, and asserts that each has no children. It states the
property generally rather than naming the end of central directory record, so a new `Constant`
field in any struct is covered as soon as the struct is parsed. The test first asserts that it found
`2 * len(MEMBERS) + 1` `Constant` fields, so it cannot pass by finding none. Reverted, it fails on
`magic at offset 0 was re-matched` with the nested `OctetStreamTest` match in the message.

`test_no_parser_warning_for_constant_fields` runs the same parse with `Matcher(parse=True)` inside
`assertNoLogs("polyfile", "WARNING")`. Reverted, it fails with the `parse_zip ... Reached the end of
stream while expecting 2-byte unsigned integer for EndOfCentralDirectory.disk_number` warning, which
is the stderr line from the issue.

`parsed_names` is refactored into `parsed_matches`, which returns the matches rather than only their
names, so the new tests can reach the tree. The existing callers keep the old behavior through a
one-line wrapper.

## Verification

- Blocking lint (`--select=E9,F63,F7,F82`): 0 findings.
- Complexity lint (`--max-complexity=10 --max-line-length=127`): clean on both changed files. The
  repository-wide count is 172 findings both before and after, all pre-existing in `polymerge/`.
- `uv run pytest tests --ignore=tests/test_corkami.py`: 251 passed, 866 subtests passed.
- Corpus differential: `test_file_corpus` passes all 88 stems, zero regressions, `KNOWN_FAILURES`
  still empty.
- `uvx pip-audit`: no known vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
