### PR TITLE
Make the libmagic corpus comparison exact outside two allowances

### DIFF
--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -98,8 +98,10 @@ def corpus_flags(test: str) -> str:
 def corpus_result_matches(expected: str, matches: Set[str]) -> bool:
     """Reports whether PolyFile's matches include libmagic's expected description.
 
-    The comparison ignores case and trailing whitespace, and it works around two known
-    formatting differences between PolyFile and libmagic.
+    Only trailing whitespace is ignored. Case is significant: libmagic's spelling of a
+    description is part of what the corpus pins, and every stem now reproduces it exactly. Two
+    stems need an allowance beyond an exact comparison, and each one is narrowed to the single
+    result it applies to.
 
     Args:
         expected: The contents of the test's `.result` file.
@@ -108,14 +110,22 @@ def corpus_result_matches(expected: str, matches: Set[str]) -> bool:
     Returns:
         True if one of `matches` corresponds to `expected`.
     """
-    expected = expected.rstrip().lower()
-    lowered = {match.rstrip().lower() for match in matches}
-    if "00000000" in expected and expected not in lowered:
+    expected = expected.rstrip()
+    reported = {match.rstrip() for match in matches}
+    if expected in reported:
+        return True
+    if "00000000" in expected:
         # Technically correct, but PolyFile formats a `%#8.8x` zero as "0x000000".
-        return expected.replace("00000000", "0x000000") in lowered
-    if expected.startswith("hancom hwp"):
-        return any(match.endswith(expected) for match in lowered)
-    return expected in lowered
+        return expected.replace("00000000", "0x000000") in reported
+    if expected == "Hancom HWP (Hangul Word Processor) file, version 5.0":
+        # libmagic prints this from its built-in compound-document reader, which runs ahead of
+        # soft magic and short-circuits it (`file/src/readcdf.c:633-646`). PolyFile has only the
+        # definitions' entry at `magic_defs/ole2compounddocs:269`, which nests the description
+        # under the OLE 2 header match, so the expected result is the tail of what PolyFile
+        # reports. Delete this once PolyFile can read compound documents: see
+        # https://github.com/trailofbits/polyfile/issues/3535.
+        return any(match.endswith(expected) for match in reported)
+    return False
 
 
 class MagicTest(TestCase):
@@ -487,6 +497,30 @@ class MagicTest(TestCase):
 
         test = UnimplementedTest(offset=polyfile.magic.AbsoluteOffset(0), message="unimplemented")
         self.assertEqual([], list(test.match(b"any data at all")))
+
+    def test_corpus_comparison_is_exact_outside_two_allowances(self):
+        """Tests that the corpus comparison is exact apart from its two documented allowances.
+
+        `corpus_result_matches` used to lower-case both sides and to accept a suffix match for
+        any result starting with `Hancom HWP`. The fold hid the class of divergence #3488 fixed,
+        where PolyFile reported `ascii text` for libmagic's `ASCII text`, and the broad suffix
+        rule weakened the two Hancom stems that do match exactly. Each allowance now applies to
+        one result, and only when the exact comparison has already failed.
+        """
+        hwp5 = "Hancom HWP (Hangul Word Processor) file, version 5.0"
+        ole2 = "OLE 2 Compound Document, v3.62, SecID 0x2, Mini FAT start sector 0x6"
+        uf2 = "UF2 firmware image, family ESP32-S2, base address 00000000, 4829 total blocks"
+        self.assertTrue(corpus_result_matches("ASCII text\n", {"data", "ASCII text"}))
+        self.assertFalse(corpus_result_matches("ASCII text", {"ascii text"}))
+        self.assertTrue(corpus_result_matches(hwp5, {f"{ole2} : {hwp5}"}))
+        self.assertFalse(corpus_result_matches(hwp5, {f"{ole2} : {hwp5.lower()}"}))
+        for hancom in ("Hancom HWP (Hangul Word Processor) file, version 3.0",
+                       "Hancom HWP (Hangul Word Processor) file, HWPX"):
+            with self.subTest(expected=hancom):
+                self.assertTrue(corpus_result_matches(hancom, {hancom}))
+                self.assertFalse(corpus_result_matches(hancom, {f"Zip archive : {hancom}"}))
+        self.assertTrue(corpus_result_matches(uf2, {uf2.replace("00000000", "0x000000")}))
+        self.assertFalse(corpus_result_matches(uf2, {"UF2 firmware image"}))
 
     def test_file_corpus(self):
         self.assertTrue(FILE_TEST_DIR.exists(), "Make sure to run `git submodule init && git submodule update` in the "


### PR DESCRIPTION
Closes #3501

## Merge order

Wave 1, alongside #3529, #3470, #3462, #3476, #3464, #3479, #3499, #3500, and #3506. This PR is
independent of all of them and can merge in any position within the wave. Five other Wave 1 PRs add
cases to `tests/test_magic.py`, but in distant regions; this is the only one that edits
`corpus_result_matches`, so the overlap resolves as a textual merge.

One thing to know downstream: the corpus comparison no longer folds case, so a later change that
alters a match description's capitalization now fails `test_file_corpus` instead of passing
silently. That is the point of the change, but a PR that rebases onto this and starts failing a
corpus stem should check its casing against `file` first.

## What this issue had left

The dead `ASCII text` branch that #3501 opened with is already gone, removed by #3510, and
`KNOWN_FAILURES` is an empty dict with all 88 stems passing. What remained was one undocumented
branch in the module-level helper `corpus_result_matches`:

```python
if expected.startswith("hancom hwp"):
    return any(match.endswith(expected) for match in lowered)
```

It accepted a suffix match where every other stem gets a containment check, and nothing recorded
why.

## What the branch hides

Three stems expect a `Hancom HWP` description, and only one needs an allowance:

| stem | expected | PolyFile reports |
| --- | --- | --- |
| `HWP97.hwp` | `Hancom HWP (Hangul Word Processor) file, version 3.0` | the same, exactly |
| `HWP2016.hwpx.zip` | `Hancom HWP (Hangul Word Processor) file, HWPX` | the same, exactly |
| `HWP2016.hwp` | `Hancom HWP (Hangul Word Processor) file, version 5.0` | `OLE 2 Compound Document, v3.62, SecID 0x2, Mini FAT start sector 0x6 : Hancom HWP (Hangul Word Processor) file, version 5.0` |

The prefix is not a PolyFile invention, and it is not a definitions-handling bug. `file -d` shows
libmagic's description arriving before soft magic ever runs:

```console
$ TZ=UTC ./file/src/file -d -m file/magic/magic.mgc file/tests/HWP2016.hwp.testfile
[try cdf 1]
file/tests/HWP2016.hwp.testfile: Hancom HWP (Hangul Word Processor) file, version 5.0
```

`file_buffer` calls `file_trycdf` ahead of the soft-magic pass and a hit ends the run unless
`MAGIC_CONTINUE` is set (`file/src/funcs.c:443-452`). `file_trycdf` parses the compound document,
reads its `FileHeader` user stream, compares the first bytes against the `HWP Document File`
signature, and prints the description itself (`file/src/readcdf.c:633-646`). The definitions'
only version 5.0 entry is `polyfile/magic_defs/ole2compounddocs:269`, which matches the directory
entry name as a `lestring16` relative to the OLE 2 header and therefore carries the `: `
continuation prefix. PolyFile reports exactly what the definitions say; what it lacks is the
built-in reader that short-circuits them.

So the allowance stays, and I filed #3535 for the missing reader. It also records the MIME
divergence that comes with it: `file` reports `application/x-hwp` from `readcdf.c`, PolyFile
reports `application/hwp+zip` from the definitions.

## What changed

`corpus_result_matches` now compares exactly first and reaches for an allowance only when that
fails. Each allowance is narrowed to the single result it covers, and the Hancom one carries a
comment naming its cause and pointing at #3535, the way the `00000000` allowance already named
its own.

The case fold is gone as well. It is vestigial: a survey of all 88 stems on this branch shows 86
matching exactly, one needing the `00000000` allowance (`uf2`), one needing the Hancom allowance
(`HWP2016.hwp`), and **zero** stems that pass only because of the fold. Meanwhile the fold hides
exactly the class of divergence #3488 fixed, where PolyFile reported `ascii text` for libmagic's
`ASCII text`.

## Before and after

Both before and after, all 88 corpus stems pass — the corpus is a regression guard here, not the
proof. What changes is what the helper accepts. Before:

```python
>>> corpus_result_matches("ASCII text", {"ascii text"})
True
>>> corpus_result_matches("Hancom HWP (Hangul Word Processor) file, HWPX",
...                       {"Zip archive : Hancom HWP (Hangul Word Processor) file, HWPX"})
True
```

After, both are `False`, while the one stem that needs the allowance still passes:

```python
>>> corpus_result_matches("Hancom HWP (Hangul Word Processor) file, version 5.0",
...                       {"OLE 2 Compound Document, v3.62, SecID 0x2, Mini FAT start sector "
...                        "0x6 : Hancom HWP (Hangul Word Processor) file, version 5.0"})
True
```

## What the test pins

`MagicTest.test_corpus_comparison_is_exact_outside_two_allowances` pins both narrowings. Verified
by breaking each one separately:

- Restore the case fold, and `assertFalse(corpus_result_matches("ASCII text", {"ascii text"}))`
  fails with `AssertionError: True is not false`.
- Widen the Hancom condition back to `expected.startswith("Hancom HWP")`, and both subtests for
  the HWP 3.0 and HWPX results fail, because a `Zip archive : ` prefix is then accepted for stems
  that match exactly.

Restoring the helper makes both pass again.

## Verification

- `uv run pytest tests --ignore=tests/test_corkami.py`: 250 passed, 868 subtests passed, in 17 s.
  That includes `test_file_corpus` over all 88 stems under the stricter comparison, so no stem
  regresses.
- Corpus survey under the new rules: 86 exact, 1 `00000000` allowance, 1 Hancom allowance, 0
  case-only, 0 failures.
- `flake8 ... --select=E9,F63,F7,F82`: 0 findings. Complexity and line-length pass: no new
  findings, the five `polymerge/polytracker.py` E501s are unchanged from master. Every added line
  is at most 96 characters.
- `uvx pip-audit`: no known vulnerabilities.

Test-only change; no source file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
