### PR TITLE
Check polyfile/magic_defs against the file submodule

### DIFF
--- a/docs/updating_libmagic_defs.md
+++ b/docs/updating_libmagic_defs.md
@@ -4,8 +4,14 @@ PolyFile's libmagic matchers are generated from a copy of upstream's pattern lib
 [`polyfile/magic_defs`](../polyfile/magic_defs). That copy is kept in sync by hand with the
 [`file`](https://github.com/file/file) git submodule at `file/`. This page describes the procedure.
 
-Follow it whenever you bump the `file` submodule. Nothing automates the copy, and nothing in CI
-detects that the two have drifted.
+Follow it whenever you bump the `file` submodule. Nothing automates the copy, but
+[`tests/test_magic_defs_drift.py`](../tests/test_magic_defs_drift.py) checks the result. It fails
+when a definition goes missing, when one upstream has deleted stays behind, when a copy stops being
+byte-identical, and when a local patch gets reverted, so run it after each step below:
+
+```bash
+pytest tests/test_magic_defs_drift.py
+```
 
 ## What lives in `polyfile/magic_defs`
 
@@ -23,17 +29,23 @@ The directory holds a byte-for-byte copy of `file/magic/Magdir/`, plus five entr
 `COPYING`, `magic.mgc`, `__pycache__`, and dotfiles. Adding a file is enough to load it; there is no
 list of filenames to update.
 
+Those five entries are also the `POLYFILE_OWNED` set in the drift test, which rejects any other
+entry `Magdir` does not ship. If you add a sixth definition of PolyFile's own, add its name there
+too.
+
 `file/magic/Header`, `file/magic/Localstuff`, and `file/magic/Makefile.am` sit one level above
 `Magdir/`, so a `Magdir/` sync never sees them. PolyFile doesn't need any of them.
 
 ## Local patches
 
-A definition file copied from `Magdir` may still carry a PolyFile-specific patch. As of libmagic
-5.48 there is one: `c-lang` rewrites the C++ class regex to remove exponential backtracking, because
-libmagic matches with a POSIX engine and PolyFile matches with Python's `re`. See
-[#3411](https://github.com/trailofbits/polyfile/issues/3411).
+A definition file copied from `Magdir` may still carry a PolyFile-specific patch. `LOCAL_PATCHES` in
+[`tests/test_magic_defs_drift.py`](../tests/test_magic_defs_drift.py) is the list of them, and it is
+the one place that list lives. Each name maps to the issue that justifies the patch, and the test
+enforces the mapping in both directions: a definition that differs without an entry fails, and an
+entry whose file has gone back to matching upstream fails as a reverted patch.
 
-The sync overwrites these patches. Before you copy, list them:
+The sync overwrites these patches, so read the list before you copy. To confirm it is complete
+against the submodule commit you are moving away from:
 
 ```bash
 # Compare each definition against the Magdir of the *currently pinned* submodule commit.
@@ -45,7 +57,23 @@ for f in /tmp/old-magdir/*; do
 done
 ```
 
-Run this **before** moving the submodule, while `file` still points at the old commit.
+Run this **before** moving the submodule, while `file` still points at the old commit. It should
+print exactly the names in `LOCAL_PATCHES`.
+
+### Adding an allowlist entry
+
+Patch a definition only when PolyFile cannot match upstream's text as written, such as a regex that
+a POSIX engine runs in linear time and Python's `re` does not. Then:
+
+1. File an issue, or use the one that sent you here, explaining what the patch changes and why
+   upstream's text does not work. `c-lang` carries the rewrite from
+   [#3411](https://github.com/trailofbits/polyfile/issues/3411).
+2. Add one line to `LOCAL_PATCHES`, mapping the definition's file name to that issue's URL.
+3. Run `pytest tests/test_magic_defs_drift.py`. The entry fails until the patch is actually in the
+   file, which is the point: the allowlist records patches that exist, not intentions.
+
+Dropping a patch is the same in reverse. Restore the definition from `Magdir` and delete its line,
+in the same commit.
 
 ## Procedure
 
@@ -99,22 +127,12 @@ Run this **before** moving the submodule, while `file` still points at the old c
    Then verify the result:
 
    ```bash
-   # Prints only the locally patched files, and nothing else.
-   for f in file/magic/Magdir/*; do
-     cmp -s "$f" "polyfile/magic_defs/$(basename "$f")" \
-       || echo "DIFFERS: $(basename "$f")"
-   done
-
-   # The only extra entries are PolyFile's own. Prints nothing when the sync is correct.
-   diff <(ls file/magic/Magdir | sort) \
-        <(ls polyfile/magic_defs \
-            | grep -vx -e __init__.py -e __pycache__ -e COPYING \
-                       -e csv -e json -e polyfile_zip \
-            | sort)
+   pytest tests/test_magic_defs_drift.py
    ```
 
-   The first loop should print exactly the list step 2 produced. Anything else means the sync went
-   wrong, and a shorter list means a patch did not get re-applied.
+   This is the check to run after both step 4 and step 5. It reports a definition that the mirror
+   dropped, an entry upstream no longer ships, a copy that is not byte-identical, and a patch from
+   `LOCAL_PATCHES` that the mirror reverted. A failure names the file and what to do about it.
 
 6. Confirm your diff matches upstream's, which catches a botched exclude list:
 
@@ -131,6 +149,9 @@ Run this **before** moving the submodule, while `file` still points at the old c
 ## Testing the update
 
 ```bash
+# The copy itself: nothing missing, nothing stale, nothing silently modified
+pytest tests/test_magic_defs_drift.py
+
 # Definition parsing, the text test partition, and the upstream corpus
 pytest tests/test_magic.py
 
@@ -138,7 +159,8 @@ pytest tests/test_magic.py
 pytest tests
 ```
 
-Three tests do the work:
+`tests/test_magic_defs_drift.py` covers the copy, and three tests in `tests/test_magic.py` cover
+what the copy says:
 
 - `test_parsing` calls `MagicMatcher.parse(*MAGIC_DEFS)`. A DSL construct PolyFile doesn't implement
   raises `ValueError` or `NotImplementedError` here, prefixed with the definition file and line
@@ -196,8 +218,9 @@ for the second case across the tree with `grep -rn '^!:strength' polyfile/magic_
 `tests/test_corkami.py` then compares PolyFile against a `file` binary built from the submodule. It
 runs `autoreconf`, `./configure`, and `make`, so it needs a C toolchain and autotools. Note that it
 compiles its oracle from `file/magic/Magdir`, not from `polyfile/magic_defs`: if the two have
-drifted, the differential silently compares PolyFile against a different rule set than the one it is
-running.
+drifted, the differential compares PolyFile against a different rule set than the one it is running,
+and says nothing about it. `tests/test_magic_defs_drift.py` is what tells you, so read its result
+before you trust a corkami run.
 
 The build tree it leaves behind in `file/` is ignored by git, so `git status` reports the submodule
 clean even when `configure` and the binary predate the release you just checked out. `make` normally

--- a/tests/test_magic_defs_drift.py
+++ b/tests/test_magic_defs_drift.py
@@ -1,0 +1,132 @@
+from pathlib import Path
+from typing import Dict, FrozenSet, Set
+from unittest import TestCase, skipUnless
+
+POLYFILE_DIR: Path = Path(__file__).absolute().parent.parent
+MAGIC_DEFS_DIR: Path = POLYFILE_DIR / "polyfile" / "magic_defs"
+UPSTREAM_MAGDIR: Path = POLYFILE_DIR / "file" / "magic" / "Magdir"
+UPSTREAM_COPYING: Path = POLYFILE_DIR / "file" / "COPYING"
+
+HAVE_MAGDIR: bool = UPSTREAM_MAGDIR.is_dir() and any(UPSTREAM_MAGDIR.iterdir())
+
+SYNC_DOC: str = "docs/updating_libmagic_defs.md"
+
+IGNORED: FrozenSet[str] = frozenset({"magic.mgc", "__pycache__"})
+"""Entries `polyfile.magic.MAGIC_DEFS` skips, so they are neither definitions nor PolyFile's own."""
+
+POLYFILE_OWNED: FrozenSet[str] = frozenset({
+    "__init__.py", "COPYING", "csv", "json", "polyfile_zip"
+})
+"""The entries of `polyfile/magic_defs` that PolyFile writes rather than copies from upstream."""
+
+LOCAL_PATCHES: Dict[str, str] = {
+    "c-lang": "https://github.com/trailofbits/polyfile/issues/3411",
+    "gentoo": "https://github.com/trailofbits/polyfile/issues/3473",
+}
+"""Definitions that deliberately differ from upstream, each mapped to the issue that justifies it.
+
+Add an entry only alongside the issue explaining why the patch has to exist, and delete it in the
+change that drops the patch. Anything not listed here has to be a byte-for-byte copy of upstream.
+"""
+
+PENDING_PATCHES: FrozenSet[str] = frozenset({"gentoo"})
+"""Allowlist entries whose patch is still in review, so the bundled file still matches upstream.
+
+The pull request for #3473 rewrites the `gentoo-manifest` regex. Until it merges, `gentoo` is an
+ordinary copy, and holding it to the allowlist would fail. Delete the name once that pull request
+merges; `test_shared_definitions_are_byte_identical` fails with that instruction the moment the
+patch lands, so the allowlist cannot stay disarmed by accident.
+"""
+
+
+def definition_names(directory: Path) -> Set[str]:
+    """Lists the entries of a definition directory that `MAGIC_DEFS` loads as definitions."""
+    return {
+        entry.name
+        for entry in directory.iterdir()
+        if entry.name not in IGNORED and not entry.name.startswith(".")
+    }
+
+
+@skipUnless(HAVE_MAGDIR, "the file submodule is not checked out")
+class TestMagicDefsDrift(TestCase):
+    """Guards the rule that `polyfile/magic_defs` is a copy of the `file` submodule's `Magdir`.
+
+    The copy is maintained by hand and is not append-only in either direction. Definitions upstream
+    deletes keep matching until someone notices, and a plain copy of `Magdir` silently reverts the
+    local patches. These tests fail on both, and on the third case the allowlist exists for:
+    upstream rewriting the lines a local patch touches.
+    """
+
+    def setUp(self):
+        self.upstream = definition_names(UPSTREAM_MAGDIR)
+        self.bundled = definition_names(MAGIC_DEFS_DIR)
+        self.assertTrue(self.upstream, f"{UPSTREAM_MAGDIR} holds no definitions")
+
+    def test_every_upstream_definition_is_bundled(self):
+        missing = self.upstream - self.bundled
+        self.assertEqual(
+            set(), missing,
+            f"{', '.join(sorted(missing))} is in file/magic/Magdir/ but not in"
+            f" polyfile/magic_defs/. Mirror the directory again, as {SYNC_DOC} describes"
+        )
+
+    def test_polyfile_s_own_entries_are_all_present(self):
+        missing = POLYFILE_OWNED - self.bundled
+        self.assertEqual(
+            set(), missing,
+            f"{', '.join(sorted(missing))} is PolyFile's own and is gone from polyfile/magic_defs/."
+            f" A mirror of Magdir has to exclude it, as {SYNC_DOC} describes"
+        )
+
+    def test_the_only_extra_entries_are_polyfile_s_own(self):
+        extras = self.bundled - self.upstream - POLYFILE_OWNED
+        self.assertEqual(
+            set(), extras,
+            f"{', '.join(sorted(extras))} is in polyfile/magic_defs/ but not in file/magic/Magdir/."
+            f" Upstream no longer ships it, so PolyFile matches a definition libmagic has dropped:"
+            f" mirror the directory with `rsync -a --delete`, as {SYNC_DOC} describes. If PolyFile"
+            f" owns the file, add it to POLYFILE_OWNED instead"
+        )
+
+    def test_shared_definitions_are_byte_identical(self):
+        allowed_to_differ = set(LOCAL_PATCHES) - PENDING_PATCHES
+        for name in sorted((self.upstream & self.bundled) - allowed_to_differ):
+            with self.subTest(definition=name):
+                if (UPSTREAM_MAGDIR / name).read_bytes() != (MAGIC_DEFS_DIR / name).read_bytes():
+                    self.fail(self.drift_message(name))
+
+    def test_local_patches_are_still_applied(self):
+        for name, issue in sorted(LOCAL_PATCHES.items()):
+            if name in PENDING_PATCHES:
+                continue
+            with self.subTest(definition=name):
+                if (UPSTREAM_MAGDIR / name).read_bytes() == (MAGIC_DEFS_DIR / name).read_bytes():
+                    self.fail(
+                        f"polyfile/magic_defs/{name} is identical to file/magic/Magdir/{name}, so"
+                        f" the patch from {issue} is gone. Mirroring Magdir reverts local patches;"
+                        f" re-apply it, as {SYNC_DOC} describes. If upstream has fixed the problem"
+                        f" the patch worked around, drop the entry from LOCAL_PATCHES instead"
+                    )
+
+    def test_copying_matches_upstream(self):
+        if UPSTREAM_COPYING.read_bytes() != (MAGIC_DEFS_DIR / "COPYING").read_bytes():
+            self.fail(
+                "polyfile/magic_defs/COPYING is not the license the definitions ship under."
+                " Copy it again: `cp file/COPYING polyfile/magic_defs/COPYING`"
+            )
+
+    @staticmethod
+    def drift_message(name: str) -> str:
+        """Explains one definition's disagreement with upstream, and what to do about it."""
+        if name in PENDING_PATCHES:
+            return (
+                f"polyfile/magic_defs/{name} now carries the patch from {LOCAL_PATCHES[name]}."
+                f" Delete {name!r} from PENDING_PATCHES, which arms the allowlist check that keeps"
+                f" the patch from being reverted"
+            )
+        return (
+            f"polyfile/magic_defs/{name} differs from file/magic/Magdir/{name}. If this is a"
+            f" deliberate local patch, add it to LOCAL_PATCHES along with the issue that justifies"
+            f" it; otherwise copy the definition again, as {SYNC_DOC} describes"
+        )


### PR DESCRIPTION
Closes #3479

## Merge order

Wave 1, alongside #3529, #3470, #3462, #3476, #3464, #3501, #3499, #3500, and #3506. This PR touches
only `tests/test_magic_defs_drift.py` and `docs/updating_libmagic_defs.md`, so it conflicts with
none of them.

The one coupling is with the pull request for **#3529**, which carries the #3473 patch to
`polyfile/magic_defs/gentoo`. The allowlist here names that patch, so the two PRs share one line.

`LOCAL_PATCHES` carries both entries as the issue asks, `c-lang` → #3411 and `gentoo` → #3473. On
today's tree `gentoo` is still a plain copy of upstream, so holding it to the allowlist would fail
until that PR merges. Rather than leave this PR red, the `gentoo` name also sits in `PENDING_PATCHES`,
which disarms the allowlist check for it. That gate is not fail-open: `gentoo` stays in the
byte-identity check while it is pending, so the moment the `gentoo` patch lands, the check fails with

```
polyfile/magic_defs/gentoo now carries the patch from
https://github.com/trailofbits/polyfile/issues/3473. Delete 'gentoo' from PENDING_PATCHES, which
arms the allowlist check that keeps the patch from being reverted
```

Deleting that one line is the whole follow-up, and it is the same one line either way:

- **If the #3529 PR merges first** (recommended), this PR rebases, its CI fails with the message above, and
  the rebase deletes the line. The allowlist lands armed, and the final state reaches `master` in
  one pass.
- **If this PR merges first**, `master` stays green — `gentoo` matches upstream, the byte-identity
  check passes, and the allowlist check skips it. The #3529 PR then sees the failure in its own CI before
  merging and deletes the line there, which lands the patch and its guard together.

Recommendation: merge the #3529 PR first. Its author gets to verify the guard against the patch it exists
to protect, and no intermediate commit on `master` claims a patch that is not there.

## Reproducer

Delete a bundled definition the submodule still ships. On `master`:

```
$ rm polyfile/magic_defs/partclone
$ uv run pytest tests/test_magic.py -q
154 passed, 216 subtests passed in 9.46s
```

The definition is gone and nothing notices. With this PR:

```
$ uv run pytest tests/test_magic_defs_drift.py -q
FAILED tests/test_magic_defs_drift.py::TestMagicDefsDrift::test_every_upstream_definition_is_bundled
AssertionError: partclone is in file/magic/Magdir/ but not in polyfile/magic_defs/. Mirror the
directory again, as docs/updating_libmagic_defs.md describes
1 failed, 5 passed, 356 subtests passed
```

## What the check does

`tests/test_magic_defs_drift.py` follows `tests/test_licensing.py`, which guards the analogous
invariant between `MANIFEST.in` and the Kaitai license allowlist. It is skipped with
`@skipUnless(HAVE_MAGDIR, ...)` when the `file` submodule is not checked out, matching what
`test_magic.py::test_file_corpus` already expects of a local run. CI checks out submodules
recursively, so it runs there.

The four invariants from the issue, plus one:

1. Every file in `file/magic/Magdir/` exists in `polyfile/magic_defs/`.
2. The only extra entries are the five PolyFile owns. Verified against the tree rather than taken
   from the issue: `comm` on the two listings reports exactly `__init__.py`, `COPYING`, `csv`,
   `json`, and `polyfile_zip`, plus `__pycache__`, which the test ignores alongside `magic.mgc` and
   dotfiles, the same set `polyfile.magic.MAGIC_DEFS` skips.
3. Every shared file is byte-identical, outside `LOCAL_PATCHES`.
4. `polyfile/magic_defs/COPYING` matches `file/COPYING`.
5. The five PolyFile owns are still present. A mirror that forgets an exclude deletes `polyfile_zip`
   and the ZIP polyglot search along with it, and invariant 2 alone does not see that.

`LOCAL_PATCHES` holds in both directions, which is the part worth having. A definition that differs
without an entry fails, and an entry whose file has gone back to matching upstream fails as a
reverted patch. That second case is what a plain `cp` of `Magdir` does to `c-lang`, undoing the
#3411 fix for the C++ class regex that does not terminate on CRLF headers. Today only
`test_magic.py::test_cpp_class_test_terminates` catches that, because someone wrote a targeted test
for it; nothing generalized. Now the allowlist does, and every entry names the issue that justifies
it, so the set of local patches is discoverable instead of folklore.

`docs/updating_libmagic_defs.md` loses the manual `cmp` and `diff` loops in step 5, which are what
this test automates, and gains a section on adding an allowlist entry.

## What the test pins

Each invariant was broken in turn and restored, and the check fails for each with a message naming
the file and the fix:

| Broken | Test that fails |
|---|---|
| `rm polyfile/magic_defs/partclone` | `test_every_upstream_definition_is_bundled` |
| `mv polyfile/magic_defs/polyfile_zip` away | `test_polyfile_s_own_entries_are_all_present` |
| add an entry `Magdir` does not ship | `test_the_only_extra_entries_are_polyfile_s_own` |
| truncate `polyfile/magic_defs/pdf` | `test_shared_definitions_are_byte_identical` |
| `cp file/magic/Magdir/c-lang polyfile/magic_defs/` | `test_local_patches_are_still_applied` |
| overwrite `polyfile/magic_defs/COPYING` | `test_copying_matches_upstream` |

The `gentoo` gate was exercised the same way: patching `gentoo` fails byte-identity with the
"delete from `PENDING_PATCHES`" message, deleting that line passes, and reverting the patch with the
line already deleted fails as a stale allowlist entry.

## Verification

- On the current tree the check passes: 6 tests, 357 subtests. The only definition that differs from
  upstream is `c-lang`, which is the #3411 patch. No unexpected drift, and nothing was added to the
  allowlist to make it pass.
- Blocking lint (`--select=E9,F63,F7,F82` over `polyfile polymerge tests build_backend.py
  compile_kaitai_parsers.py`): 0 findings.
- Complexity pass: clean. The new file is also clean at `--max-line-length=100`. The 35 `E501`
  findings in `polymerge/` are pre-existing and identical on `master`.
- `uv run pytest tests --ignore=tests/test_corkami.py`: 255 passed, 1223 subtests passed, up from
  249 and 866 by exactly the 6 tests and 357 subtests added here.
- `uvx pip-audit`: no known vulnerabilities.

No corpus differential: this change adds a test and edits a document, and alters no matching
behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC

