### PR TITLE
Read an untyped indirect offset in host byte order

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -594,7 +594,7 @@ class IndirectOffset(Offset):
         self.signed: bool = signed
         self.post_process: Callable[[int], int] = post_process
         self.is_id3: bool = is_id3
-        if self.endianness != Endianness.LITTLE and self.endianness != endianness.BIG:
+        if self.endianness not in (Endianness.NATIVE, Endianness.LITTLE, Endianness.BIG):
             raise ValueError(f"Invalid endianness: {endianness!r}")
         elif num_bytes not in (1, 2, 4, 8, IndirectOffset.OctalIndirectOffset):
             raise ValueError(f"Invalid number of bytes: {num_bytes}")
@@ -625,9 +625,7 @@ class IndirectOffset(Offset):
         fmt = IndirectOffset.STRUCT_FORMATS[self.num_bytes]
         if self.signed:
             fmt = fmt.lower()
-        if self.endianness == Endianness.LITTLE:
-            return f"<{fmt}"
-        return f">{fmt}"
+        return f"{self.endianness.value}{fmt}"
 
     def to_absolute(self, data: bytes, last_match: Optional[TestResult], allow_invalid: bool = False) -> int:
         if self.num_bytes == IndirectOffset.OctalIndirectOffset:
@@ -685,8 +683,9 @@ class IndirectOffset(Offset):
 
         The type character selects the width and byte order of the field to read, following
         libmagic's `parse_type` in `src/apprentice.c`: `l`/`L` are four-byte integers, `i`/`I`
-        are four-byte ID3v2 synchsafe integers, and an absent type defaults to a four-byte
-        integer. A lowercase character means little endian and an uppercase one big endian.
+        are four-byte ID3v2 synchsafe integers, and an absent type defaults to `FILE_LONG`, the
+        four-byte integer in the host's byte order (`src/apprentice.c:2154`). A lowercase
+        character means little endian and an uppercase one big endian.
 
         Args:
             offset: The parenthesized text of the offset, including its surrounding parentheses.
@@ -703,8 +702,9 @@ class IndirectOffset(Offset):
             raise ValueError(f"Invalid indirect offset: {offset!r}")
         t = m.group("type")
         if t is None:
-            t = "L"
-        if t == "m":
+            endianness = Endianness.NATIVE
+            t = "l"
+        elif t == "m":
             raise NotImplementedError("TODO: Add support for middle endianness")
         elif t.islower():
             endianness = Endianness.LITTLE
@@ -738,12 +738,15 @@ class IndirectOffset(Offset):
 INDIRECT_OFFSET_TYPES: Dict[Tuple[int, Endianness], str] = {
     (1, Endianness.LITTLE): "byte", (1, Endianness.BIG): "byte",
     (2, Endianness.LITTLE): "leshort", (2, Endianness.BIG): "beshort",
+    (4, Endianness.NATIVE): "long",
     (4, Endianness.LITTLE): "lelong", (4, Endianness.BIG): "belong",
     (8, Endianness.LITTLE): "lequad", (8, Endianness.BIG): "bequad",
 }
 """The type libmagic reads an indirect offset through, by width and byte order.
 
-See the character it comes from in ``file/src/apprentice.c:2158-2215``.
+See the character it comes from in ``file/src/apprentice.c:2158-2215``. An offset written
+without a type character keeps the ``FILE_LONG`` default from ``file/src/apprentice.c:2154``,
+which reads four bytes in the host's byte order.
 """
 
 

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1,6 +1,7 @@
 import base64
 import gzip
 import os
+import struct
 import subprocess
 import sys
 import time
@@ -188,6 +189,59 @@ class MagicTest(TestCase):
         for spec in ("(6.l+10)", "(6.L+10)", "(6+10)"):
             with self.subTest(offset=spec):
                 self.assertFalse(polyfile.magic.IndirectOffset.parse(spec).is_id3)
+
+    def test_untyped_indirect_offset_reads_in_host_byte_order(self):
+        """Tests that an indirect offset without a type character reads its field natively.
+
+        This is a regression test for trailofbits/polyfile#3499. libmagic leaves `in_type` at
+        `FILE_LONG` when a definition writes no type character (`file/src/apprentice.c:2154`),
+        and `FILE_LONG` is the four-byte integer in the host's byte order. PolyFile substituted
+        an explicit big-endian read, so every untyped offset parsed to `Endianness.BIG`.
+
+        The second half pins the resolution separately from the enum, because every host the
+        tests run on is little endian: an assertion on the resolved value alone would also hold
+        if the default were fixed to `Endianness.LITTLE` rather than to the host's order.
+        """
+        for spec in ("(6+10)", "(144)", "(0x38+0xcc)", "(&-4)"):
+            with self.subTest(offset=spec):
+                offset = polyfile.magic.IndirectOffset.parse(spec)
+                self.assertIs(polyfile.magic.Endianness.NATIVE, offset.endianness)
+                self.assertEqual("long", polyfile.magic.libmagic_indirect_type(offset))
+        field = b"\x00\x00\x01\x00"
+        offset = polyfile.magic.IndirectOffset.parse("(0)")
+        host_order = "<" if sys.byteorder == "little" else ">"
+        swapped_order = ">" if sys.byteorder == "little" else "<"
+        self.assertEqual(struct.unpack(f"{host_order}I", field)[0], offset.to_absolute(field, None))
+        self.assertNotEqual(struct.unpack(f"{swapped_order}I", field)[0],
+                            offset.to_absolute(field, None))
+
+    def test_untyped_indirect_offset_locates_pa_risc_dynamic_link_marker(self):
+        """Tests that `magic_defs/hp` resolves its untyped `>(144)` the way libmagic does.
+
+        This is a regression test for trailofbits/polyfile#3499. `hp` reaches a PA-RISC 1.1
+        executable's dynamic-link marker through `>(144) belong 0x054ef630`, an offset with no
+        type character. Reading the field big endian instead of natively inverts the verdict on
+        a little-endian host: PolyFile called the byte-swapped file dynamically linked and the
+        other one not, which is the opposite of what `file` reports for both.
+        """
+        def pa_risc_executable(offset_field: bytes) -> bytes:
+            data = bytearray(288)
+            data[0:4] = struct.pack(">I", 0x02100107)
+            data[96:100] = struct.pack(">I", 1)
+            data[144:148] = offset_field
+            data[256:260] = struct.pack(">I", 0x054EF630)
+            return bytes(data)
+
+        stored_little = pa_risc_executable(struct.pack("<I", 256))
+        stored_big = pa_risc_executable(struct.pack(">I", 256))
+        if sys.byteorder == "little":
+            resolves, misses = stored_little, stored_big
+        else:
+            resolves, misses = stored_big, stored_little
+        self.assertIn("PA-RISC1.1 executable dynamically linked - not stripped",
+                      {str(match) for match in MagicMatcher.DEFAULT_INSTANCE.match(resolves)})
+        self.assertIn("PA-RISC1.1 executable - not stripped",
+                      {str(match) for match in MagicMatcher.DEFAULT_INSTANCE.match(misses)})
 
     def test_id3v2_tag_locates_its_audio_frames(self):
         """Tests that an ID3v2 tag's indirect offset lands on the MPEG frame that follows it.


### PR DESCRIPTION
Closes #3499

## Merge order

Wave 1, alongside #3529, #3470, #3462, #3476, #3464, #3479, #3501, #3500, and #3506. This PR
touches `polyfile/magic.py:576-746` and adds two tests to `tests/test_magic.py`. The nearest other
Wave 1 edit to `magic.py` is #3500 at `:3700-3737`, so this merges in any order relative to the
rest of the wave. Nothing downstream has to rebase onto it.

## Reproducer

An indirect offset written without a type character read its field big endian:

```python
from polyfile.magic import IndirectOffset

print(IndirectOffset.parse("(6+10)").endianness)
```

Before:

```
Endianness.BIG
```

After:

```
Endianness.NATIVE
```

The divergence is observable end to end. `magic_defs/hp` reaches a PA-RISC 1.1 executable's
dynamic-link marker through the untyped `>(144)`, so two headers whose offset field differs only in
byte order get opposite verdicts. Both files are 288 bytes with `0x02100107` at offset 0,
`0x054ef630` at offset 256, and the value 256 at offset 144, stored little endian in one and big
endian in the other:

| file | `file` 5.48 | PolyFile before | PolyFile after |
|---|---|---|---|
| field stored little endian | `PA-RISC1.1 executable dynamically linked - not stripped` | `PA-RISC1.1 executable - not stripped` | `PA-RISC1.1 executable dynamically linked - not stripped` |
| field stored big endian | `PA-RISC1.1 executable - not stripped` | `PA-RISC1.1 executable dynamically linked - not stripped` | `PA-RISC1.1 executable - not stripped` |

PolyFile's two verdicts were exactly inverted with respect to the oracle.

## Is it latent or active?

The issue asked to establish this before changing the default. Both answers apply, so the change is
low risk in practice and a real fidelity gap in principle:

- `polyfile/magic_defs/` holds **1,095 indirect offsets, of which 20 are untyped**: nine in `hp`,
  four in `olf`, three each in `bioinformatics` and `gnu`, and one in `pack`. The libmagic corpus
  sidecars (`file/tests/*.magic`) contain none.
- Instrumenting `IndirectOffset.to_absolute` across all 88 corpus stems shows **none of those 20
  offsets is ever evaluated**: 1,335 indirect reads happen, and not one comes from an untyped
  offset. With respect to the corpus, the bug is latent.
- It is not latent in general. Reaching any of the 20 takes a file that matches its parent test, and
  the `hp` case above is one. The change is therefore worth making rather than documenting away.

## What the fix does

libmagic sets `m->in_type = FILE_LONG` as soon as it sees the `INDIR` flag, and only a type
character overwrites it (`file/src/apprentice.c:2154`). `FILE_LONG` is the four-byte integer in the
host's byte order, distinct from `FILE_BELONG` and `FILE_LELONG`, which the type table names
`long`, `belong`, and `lelong` (`file/src/apprentice.c:223-230`).

`IndirectOffset.parse` substituted an explicit big-endian type for the absent one, so the default
never reached the host's byte order. The fix carries `Endianness.NATIVE` instead. That member
already existed for `NumericDataType`, and its value is `=`, which is what Python's `struct` module
spells native byte order with standard sizes as. Since the widths come from `TYPE_NUM_BYTES` rather
than from the platform, `=` is the right spelling and `_struct_format` needs no translation of its
own: it now interpolates `self.endianness.value` the way `NumericDataType.match` already does.

Two smaller changes follow from that:

- `IndirectOffset.__init__` rejected anything that was not `LITTLE` or `BIG`, so it now takes an
  allowlist of the three orders an indirect offset can carry. This also drops an accidental
  attribute read on the parameter (`endianness.BIG`) in the old condition.
- `INDIRECT_OFFSET_TYPES` maps `(4, NATIVE)` to `long`, which is what libmagic stores in `in_type`
  for an untyped offset, so `libmagic_indirect_type` keeps reporting the name libmagic uses instead
  of falling through to its default.

## What the tests pin

`test_untyped_indirect_offset_reads_in_host_byte_order` asserts the parsed enum member and the
resolved value separately. Every platform in CI is little endian, so asserting the resolved value
alone would pass for the wrong reason: it would also hold if the default were fixed to
`Endianness.LITTLE` rather than to the host's order. The value assertion derives its expectation
from `sys.byteorder`, and it asserts inequality against the opposite order as well, so it is not
vacuous on either kind of host.

`test_untyped_indirect_offset_locates_pa_risc_dynamic_link_marker` runs the shipped definitions over
the two crafted PA-RISC headers and asserts the verdicts in the table above, selecting which header
should resolve by `sys.byteorder`.

Both tests were verified by breaking the fix:

| break | result |
|---|---|
| restore `endianness = Endianness.BIG` (the bug) | 6 failures: both tests, all 4 subtests |
| hard-code `endianness = Endianness.LITTLE` | 4 failures: the enum subtests only, which is the case the end-to-end test cannot catch on a little-endian host |
| fix restored | 2 passed, 4 subtests passed |

## Verification

- **Corpus differential**: all 88 stems, matches normalized as `corpus_result_matches` does, with
  `<stem>*.magic` sidecars and `<stem>.flags` of `k` compared against `join_matches`. The match sets
  are byte-identical before and after: **0 regressions across 88 stems**, 0 failing on either side.
- `uv run pytest tests --ignore=tests/test_corkami.py`: 251 passed, 870 subtests passed (249 and 866
  before; the additions account for the difference).
- `flake8 --select=E9,F63,F7,F82`: 0 findings.
- `flake8 --max-complexity=10 --max-line-length=127`: 172 findings, identical to the count on
  `master`, and none in `polyfile/magic.py:576-746` or in the added tests.
- `uvx pip-audit`: no known vulnerabilities.

Verified against `file` 5.48 built from the `file` submodule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
