### PR TITLE
Trim trailing NULs before classifying a text encoding

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -4031,13 +4031,37 @@ def _eight_bit_encoding(data: bytes) -> Optional[str]:
         return "unknown-8bit"
 
 
+def _trim_trailing_nuls(data: bytes) -> bytes:
+    """The prefix of `data` that libmagic classifies, with its trailing NUL padding removed.
+
+    ``file_ascmagic`` strips the trailing NULs before it calls ``file_encoding``, leaving at least
+    one byte, and then puts one byte back when the trim ends on an odd offset and the buffer was
+    evenly sized, so that UTF-16LE text keeps its last character (``trim_nuls`` and
+    ``file_ascmagic`` in ``file/src/ascmagic.c``). The byte it puts back is itself a NUL, which
+    belongs to no text character class, so evenly sized ASCII that trims to an odd length is
+    binary to libmagic.
+
+    Args:
+        data: the bytes to trim.
+
+    Returns:
+        The prefix of `data` libmagic classifies.
+    """
+    trimmed = max(len(data.rstrip(b"\0")), 1)
+    if trimmed % 2 == 1 and len(data) % 2 == 0:
+        trimmed += 1
+    return data[:trimmed]
+
+
 def detect_text_encoding(data: bytes) -> Optional[str]:
     """Decides whether `data` is text, and names the character encoding family it belongs to.
 
     This mirrors ``file_encoding`` in libmagic's ``src/encoding.c``: membership in a text
     encoding is decided by character class alone, with no statistical inference. Every byte in
     ``0xA0``-``0xFF`` is a printable ISO-8859 character, so a buffer of ASCII with a handful of
-    accented characters is text.
+    accented characters is text. libmagic classifies the buffer `_trim_trailing_nuls` prepares
+    rather than the file's own bytes, so text that a fixed record size or a block boundary padded
+    out with NULs still counts as text.
 
     Args:
         data: the bytes to classify.
@@ -4045,6 +4069,7 @@ def detect_text_encoding(data: bytes) -> Optional[str]:
     Returns:
         The name of the encoding family, or None if `data` belongs to no text character class.
     """
+    data = _trim_trailing_nuls(data)
     if len(data) < 2:
         return None
     elif _only_contains(data, _ASCII_BYTES):
@@ -4167,6 +4192,10 @@ class TextEncodingDescription:
     def detect(cls, data: bytes) -> Optional["TextEncodingDescription"]:
         """Classifies `data` and measures the line shape libmagic would report for it.
 
+        ``file_ascmagic`` hands the same trimmed buffer to ``file_encoding`` and to
+        ``file_ascmagic_with_encoding``, so NUL padding counts towards neither the encoding nor the
+        longest line.
+
         Args:
             data: the bytes to classify.
 
@@ -4177,10 +4206,11 @@ class TextEncodingDescription:
             ValueError: if `detect_text_encoding` named an encoding that
                 `LIBMAGIC_ENCODING_NAMES` does not describe.
         """
-        encoding = detect_text_encoding(data)
+        buffer = _trim_trailing_nuls(data)
+        encoding = detect_text_encoding(buffer)
         if encoding is None:
             return None
-        return cls(encoding, _decode_text(data, encoding))
+        return cls(encoding, _decode_text(buffer, encoding))
 
     def _splice(self, message: str) -> Tuple[str, bool]:
         """Replaces a soft magic message's trailing ``text`` with the separator libmagic uses.

--- a/tests/test_corkami.py
+++ b/tests/test_corkami.py
@@ -17,11 +17,6 @@ FILE_PATH = FILE_DIR / "src" / "file"
 MAGIC_FILE_PATH = SCRIPT_DIR / "magic.mgc"
 
 KNOWN_BAD_FILES = {
-    "79f509d30245f6c7574a1ace1696be1a",  # card.bin
-                                         # `file` trims the trailing NULs before classifying the
-                                         # encoding, reads the rest as ISO-8859 text, and reports
-                                         # `text/plain`. PolyFile does not trim, so it reports
-                                         # `application/octet-stream`. See #3506
     "d1531b1622de54fe3a0187c3344600e9",  # elf.bin
                                          # `file` reads this as International EBCDIC text and
                                          # reports `text/plain`. PolyFile has no EBCDIC detection,

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -364,6 +364,72 @@ class MagicTest(TestCase):
         }
         self.assertIn("text/plain", mimetypes)
 
+    def test_nul_padded_text_is_text(self):
+        """Tests that trailing NUL padding does not make text binary.
+
+        This is a regression test for trailofbits/polyfile#3506. `file_ascmagic` trims the
+        trailing NULs before it calls `file_encoding` (`file/src/ascmagic.c`), so the padding a
+        fixed record size, a string table, or a block boundary leaves behind does not reach the
+        character class check. Without the trim the NULs fail `_only_contains`, PolyFile reports
+        no encoding, and `MagicMatcher.match` falls through to `application/octet-stream`.
+        """
+        padded = (
+            (b"\xde\xca\xff\xed" + b"\x00" * 4, "iso-8859-1"),
+            (b"padded record" + b"\x00" * 2, "ascii"),
+            (b"a record.\n" + b"\x00" * 502, "ascii"),
+            ("café naïve\n".encode("latin-1") + b"\x00" * 4, "iso-8859-1"),
+        )
+        for data, expected_encoding in padded:
+            with self.subTest(data=data[:16]):
+                self.assertEqual(expected_encoding, polyfile.magic.detect_text_encoding(data))
+                mimetypes = {
+                    mimetype
+                    for match in MagicMatcher.DEFAULT_INSTANCE.match(data)
+                    for mimetype in match.mimetypes
+                }
+                self.assertIn("text/plain", mimetypes)
+
+    def test_nul_padding_does_not_lengthen_a_line(self):
+        """Tests that the padding counts towards neither the encoding nor the longest line.
+
+        This is a regression test for trailofbits/polyfile#3506. `file_ascmagic` hands the same
+        trimmed buffer to `file_encoding` and to `file_ascmagic_with_encoding`, so 400 NULs after
+        an eleven character line leave `file` reporting `ASCII text, with no line terminators`.
+        Classifying the trimmed buffer but measuring the untrimmed one adds `with very long
+        lines`, because the padding runs past `MAXLINELEN`.
+        """
+        description = polyfile.magic.TextEncodingDescription.detect(b"hello world" + b"\x00" * 400)
+        self.assertIsNotNone(description)
+        self.assertEqual("ASCII text, with no line terminators", description.describe(""))
+
+    def test_an_even_buffer_that_trims_odd_keeps_a_nul(self):
+        """Tests the odd byte adjustment libmagic applies after it trims the trailing NULs.
+
+        This is a regression test for trailofbits/polyfile#3506. `file_ascmagic` puts one byte
+        back when the trim ends on an odd offset and the buffer was evenly sized, so that UTF-16LE
+        text keeps its last character (`file/src/ascmagic.c`). The byte it restores is a NUL,
+        which belongs to no text character class, so `file` reports `data` for `abc\\0` and
+        `ASCII text` for `abc\\0\\0`. Trimming without the adjustment reports text for both.
+        """
+        self.assertIsNone(polyfile.magic.detect_text_encoding(b"abc\x00"))
+        self.assertIsNone(polyfile.magic.detect_text_encoding(b"The quick brown fox.\n"
+                                                              + b"\x00" * 491))
+        self.assertEqual("ascii", polyfile.magic.detect_text_encoding(b"abc\x00\x00"))
+
+    def test_the_odd_byte_adjustment_keeps_the_last_utf_16le_character(self):
+        """Tests that UTF-16LE text does not lose its last character to the NUL trim.
+
+        This is a regression test for trailofbits/polyfile#3506. The low byte of an ASCII
+        character in UTF-16LE is followed by a NUL, so trimming alone drops it: the trailing LF of
+        `hi\\n` disappears and PolyFile appends `, with no line terminators` where `file` appends
+        nothing. The odd byte adjustment restores the NUL and with it the character.
+        """
+        data = b"\xff\xfe" + "hi\n".encode("utf-16le")
+        description = polyfile.magic.TextEncodingDescription.detect(data)
+        self.assertIsNotNone(description)
+        self.assertEqual(1, description.lf)
+        self.assertEqual("Unicode text, UTF-16, little-endian text", description.describe(""))
+
     @staticmethod
     def messages(matcher: MagicMatcher, data: bytes) -> Set[str]:
         return {str(match) for match in matcher.match(data)}


### PR DESCRIPTION
Closes #3506.

## Merge order

Wave 1, alongside #3529, #3470, #3462, #3476, #3464, #3479, #3501, #3499, and #3500. There are no
conflicts with any of them: this is the only change in `detect_text_encoding` and the only one that
touches `tests/test_corkami.py`, so it can merge in any order relative to the rest of the wave.

**#3507 rewrites the same function and branches from master after this merges.** It adds an EBCDIC
branch to the same ten-line dispatch chain. The shared step it should build on is
`_trim_trailing_nuls`, which `detect_text_encoding` now applies before the `len(data) < 2` guard, so
an EBCDIC branch reads the trimmed buffer without repeating the trim.

## Reproducer

```console
$ printf '\xde\xca\xff\xed\x00\x00\x00\x00' > card.bin
$ file -m file/magic/magic.mgc -i --keep-going card.bin
card.bin: text/plain; charset=binary
$ file -m file/magic/magic.mgc --keep-going card.bin
card.bin: ISO-8859 text, with no line terminators
```

```python
from polyfile.magic import MAGIC_DEFS, MagicMatcher, MatchContext, detect_text_encoding

matcher = MagicMatcher.parse(*MAGIC_DEFS)
print(detect_text_encoding(open("card.bin", "rb").read()))
print({mt for m in matcher.match(MatchContext.load("card.bin", only_match_mime=True))
       for mt in m.mimetypes})
```

Before:

```
None
{'application/octet-stream'}
```

After:

```
iso-8859-1
{'text/plain'}
```

`polyfile --format mime card.bin` goes from `application/octet-stream` to `text/plain`.

`file`'s `text/plain; charset=binary` looks self-contradictory but is intended, and it is the type
half that is at issue here. `file_buffer` classifies the buffer twice: `funcs.c:369` calls
`file_encoding` on the **untrimmed** buffer, which fails, so the `; charset=` suffix keeps its
`binary` default, while `funcs.c:498` calls `file_ascmagic`, which classifies the **trimmed** buffer
and supplies `text/plain`. PolyFile emits no charset at all, which is #3488's territory and already
merged, so only the type is compared here.

## The fix

`file_ascmagic` copies the buffer and strips its trailing NULs before it calls `file_encoding`
(`file/src/ascmagic.c:82-89`):

```c
bb = *b;
bb.flen = trim_nuls(CAST(const unsigned char *, b->fbuf), b->flen);
/*
 * Avoid trimming at an odd byte if the original buffer was evenly
 * sized; this avoids losing the last character on UTF-16 LE text
 */
if ((bb.flen & 1) && !(b->flen & 1))
        bb.flen++;
```

`trim_nuls` (`file/src/ascmagic.c:62-67`) leaves at least one byte. PolyFile classified the file's
own bytes, so `_only_contains(data, _TEXT_BYTES)` failed on the padding, `detect_text_encoding`
returned `None`, and `MagicMatcher.match` fell through to `OctetStreamTest`.

`_trim_trailing_nuls` ports both halves, and `detect_text_encoding` applies it before its
`len(data) < 2` guard, because a NUL-padded one-byte buffer trims to nothing.

The odd-byte adjustment is not cosmetic in either direction:

- The byte it restores is itself a NUL, which belongs to no text character class, so an evenly
  sized buffer that trims to an odd length stays binary. `file` reports `data` for `abc\0` and
  `ASCII text` for `abc\0\0`, and the adjustment is the only thing that separates them.
- Without it, UTF-16LE text loses its last character, because the high byte of an ASCII character
  is a NUL. `\xff\xfehi\n` in UTF-16LE loses its LF, and PolyFile would append
  `, with no line terminators` where `file` appends nothing.

`TextEncodingDescription.detect` now classifies and measures the same trimmed buffer, as
`file_ascmagic` does when it hands `bb` to both `file_encoding` and `file_ascmagic_with_encoding`.
Trimming only for the classification adds a divergence of its own: 400 NULs after an eleven
character line run past `MAXLINELEN`, so PolyFile would report
`ASCII text, with very long lines (411), with no line terminators` where `file` reports
`ASCII text, with no line terminators`.

## What the tests pin

Four new tests in `tests/test_magic.py`, each verified to fail with the relevant half of the fix
removed:

| test | fails without |
| --- | --- |
| `test_nul_padded_text_is_text` | the trim; four padded inputs report no encoding and `application/octet-stream` |
| `test_nul_padding_does_not_lengthen_a_line` | the trim, or the trim in `TextEncodingDescription.detect`; the description gains `with very long lines (411)` |
| `test_an_even_buffer_that_trims_odd_keeps_a_nul` | the odd byte adjustment; `abc\0` and a 512 byte block-padded line report `ascii` instead of binary |
| `test_the_odd_byte_adjustment_keeps_the_last_utf_16le_character` | the odd byte adjustment; `description.lf` is 0 and the description gains `, with no line terminators` |

The inputs cover the general case the issue describes, not only `card.bin`: a padded record, a line
padded to a 512 byte block boundary, and Latin-1 text with trailing NULs.

`card.bin`'s entry is removed from `KNOWN_BAD_FILES` in `tests/test_corkami.py`. That list is a
plain `skipTest` with no unexpectedly-passing guard, so removing the entry is what proves the fix
against the corpus.

## Verification

- Lint: both passes produce exactly the same 172 findings as `master`, none of them in a changed
  file.
- `uv run pytest tests --ignore=tests/test_corkami.py`: 253 passed, 870 subtests passed (up from
  249 and 866).
- `uv run pytest tests/test_corkami.py`: 905 passed, 2 skipped. The remaining skips are `elf.bin`
  (#3507) and `make.py` (#3488).
- `uvx pip-audit`: no known vulnerabilities found.
- Corpus differential over all 88 `file/tests/*.testfile` stems, applying the same normalization as
  `corpus_result_matches` and honoring each `<stem>.flags` and `<stem>*.magic` sidecar: **0
  regressions**. 88/88 stems pass before and after, and not one stem's match set changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
