### PR TITLE
Keep a !:strength factor that a comment follows

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -5037,8 +5037,8 @@ class MagicMatcher:
                     continue
                 try:
                     line = raw_line.decode("utf-8")
-                except UnicodeDecodeError:
-                    continue
+                except UnicodeDecodeError as e:
+                    raise ValueError(f"{def_file!s} line {line_number}: {e!s}")
                 test = MagicMatcher.parse_test(line, def_file, line_number, current_test, matcher)
                 if test is not None:
                     if test.mime is not None:

--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -4955,16 +4955,29 @@ class MagicMatcher:
     }
 
     @staticmethod
-    def parse_strength(specification: bytes, current_test: MagicTest):
+    def parse_strength(
+            specification: bytes, current_test: MagicTest, def_file: Union[str, Path],
+            line_number: int
+    ):
         """Records a ``!:strength`` factor on the entry that the directive applies to.
 
         libmagic assigns the factor to ``me->mp[0]``, the level-0 test of the entry, whatever depth
         the directive appears at, and keeps the first factor an entry declares
         (``file/src/apprentice.c:2470-2497``). A ``name`` entry rejects the directive outright.
 
+        The factor is the first whitespace-delimited token after the operator, because libmagic
+        reads it with ``strtoul`` and then requires whatever follows the digits to be whitespace
+        (``file/src/apprentice.c:2507-2517``). That is what makes a trailing comment harmless,
+        as on ``magic_defs/ctf:23``.
+
         Args:
             specification: The rest of the line after ``!:strength``.
             current_test: The most recently parsed test, which locates the entry.
+            def_file: The definition file the directive came from.
+            line_number: The line the directive is on.
+
+        Raises:
+            ValueError: If the directive carries no factor, or one that is not an integer.
         """
         entry = current_test
         while entry.parent is not None:
@@ -4980,9 +4993,10 @@ class MagicMatcher:
         else:
             factor_str = spec[1:].strip()
         try:
-            entry.strength_factor = int(factor_str)
-        except ValueError:
-            return
+            entry.strength_factor = int(factor_str.split(maxsplit=1)[0])
+        except (IndexError, ValueError):
+            raise ValueError(f"{def_file!s} line {line_number}: Invalid strength factor "
+                             f"{factor_str!r}")
         entry.strength_op = op
 
     @staticmethod
@@ -5017,7 +5031,9 @@ class MagicMatcher:
                     continue
                 elif raw_line.startswith(b"!:strength"):
                     if current_test is not None:
-                        MagicMatcher.parse_strength(raw_line[10:], current_test)
+                        MagicMatcher.parse_strength(
+                            raw_line[10:], current_test, def_file, line_number
+                        )
                     continue
                 try:
                     line = raw_line.decode("utf-8")

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -137,6 +137,19 @@ class MagicTest(TestCase):
         print(f"# MIME Types:      {len(matcher.mimetypes)}")
         print(f"# File Extensions: {len(matcher.extensions)}")
 
+    def test_an_undecodable_definition_line_is_reported(self):
+        """A definition line that is not valid UTF-8 used to be skipped without a word.
+
+        `MagicMatcher._parse_file` dropped the test and moved on, so a mis-encoded definition file
+        lost entries invisibly. This is the sibling swallow trailofbits/polyfile#3476 reports
+        beside the discarded `!:strength` factor. No shipped definition triggers it.
+        """
+        with TemporaryDirectory() as tmp_dir:
+            magic_file = Path(tmp_dir) / "undecodable"
+            magic_file.write_bytes(b"0\tstring\tabcd\tvalid\n0\tstring\tcaf\xe9\tlatin-1\n")
+            with self.assertRaisesRegex(ValueError, "line 2: .*utf-8"):
+                MagicMatcher.parse(magic_file)
+
     def test_guid_data_types(self):
         """libmagic 5.48 added `leguid` and `beguid` beside `guid`, differing only in byte order."""
         data = bytes(range(16))

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1367,6 +1367,54 @@ class TestStrengthTest(TestCase):
         definition = "0\tstring/wt\t#!\\ \ta\n>&-1\tstring/T\tx\t%s script text executable\n!:strength / 3\n"
         self.assertEqual(20, self.strength(definition))
 
+    def test_a_comment_after_the_factor_leaves_the_factor_alone(self):
+        """A trailing comment used to discard the factor, and the operator with it.
+
+        `int()` was handed the comment along with the digits, raised, and the exception was
+        dropped by a bare `except ValueError`. libmagic reads the factor with `strtoul` and asks
+        only that whatever follows the digits be whitespace (`file/src/apprentice.c:2507-2517`),
+        which is why the comment is harmless there. Both the branch that reads an operator and
+        the one that does not take the first whitespace-delimited token.
+        """
+        test = self.only_test("0\tstring\tabcd\tdesc\n!:strength + 15\t\t# beat the others\n")
+        self.assertEqual(polyfile.magic.StrengthOp.PLUS, test.strength_op)
+        self.assertEqual(15, test.strength_factor)
+        self.assertEqual(85, test.compute_strength())
+        self.assertEqual(23, self.strength("0\tstring\tabcd\tdesc\n!:strength / 3  # comment\n"))
+        self.assertEqual(85, self.strength("0\tstring\tabcd\tdesc\n!:strength 15\t# no op\n"))
+
+    def test_the_shipped_ctf_entry_scores_what_libmagic_scores(self):
+        """`magic_defs/ctf:23` is the one shipped directive with a trailing comment.
+
+        `file -l` reports `Strength = 105@22` for it: the 20 baseline, 70 for the seven-byte
+        value, 10 for the `=` relation, and the 5 the directive adds. PolyFile scored 100 while
+        the factor was being discarded, and this was the last entry whose strength disagreed with
+        `file -l`.
+        """
+        instance = MagicMatcher.DEFAULT_INSTANCE
+        ctf = [
+            test for test in instance.text_tests | instance.non_text_tests
+            if test.source_info is not None and test.source_info.path.name == "ctf"
+            and test.source_info.line == 22
+        ]
+        self.assertEqual(1, len(ctf), "the CTF plain text metadata entry moved")
+        self.assertEqual(polyfile.magic.StrengthOp.PLUS, ctf[0].strength_op)
+        self.assertEqual(5, ctf[0].strength_factor)
+        self.assertEqual(105, ctf[0].compute_strength())
+
+    def test_a_factor_that_is_not_an_integer_is_reported(self):
+        """A factor that still does not parse is a malformed definition, not something to ignore.
+
+        `MagicMatcher._parse_file` names the file and the line for every other malformed line, so
+        this one does too, rather than keeping a test whose declared strength went missing.
+        libmagic rejects the last of these as well: its `strtoul` stops at the `#`, and the
+        character after the digits is not whitespace.
+        """
+        for spec in ("+five", "+", "5#nospace"):
+            with self.subTest(spec=spec):
+                with self.assertRaisesRegex(ValueError, "line 2: Invalid strength factor"):
+                    self.strength(f"0\tstring\tabcd\tdesc\n!:strength {spec}\n")
+
     def test_multiple_magic_sidecars_match_libmagic(self):
         """`file/tests/multiple.testfile` needs its four matches in descending strength order.
 


### PR DESCRIPTION
Closes #3476

## Merge order

Wave 1, alongside #3529, #3470, #3462, #3464, #3479, #3501, #3499, #3500, and #3506. It can merge
in any position within the wave: the change is confined to `polyfile/magic.py:4957-5039`
(`MagicMatcher.parse_strength` and the two lines of `_parse_file` that call it), over 900 lines
away from the nearest other Wave 1 edit, #3506 at `:4034-4057`. Nothing downstream has to rebase
onto it.

## Reproducer

The script from the issue, on `master` at 906d916:

```
op=StrengthOp.NONE factor=0 strength=100
```

With this change:

```
op=StrengthOp.PLUS factor=5 strength=105
```

`file -l` reports `Strength = 105@22: Common Trace Format (CTF) plain text metadata` for the same
entry.

The issue body predicted 20 and 25 for these numbers. #3477 has landed since it was filed, so the
baseline is now 100: 20 for the baseline, 70 for the seven-byte value, and 10 for the `=`
relation. The 5 this change restores is the whole of the remaining difference. The issue also
expected the operator to survive; it does not, because the assignment to `strength_op` follows the
`int()` call that raises.

## What the fix does

`MagicMatcher.parse_strength` handed everything after the operator to `int()`. For
`magic_defs/ctf:23`, that is `5\t\t\t# this is to make sure we beat C`, so `int()` raised and a
bare `except ValueError` discarded the factor and the operator with it.

libmagic reads the factor with `strtoul` and then asks only that the character after the digits be
whitespace (`file/src/apprentice.c:2507-2517`), which is what makes the comment harmless there. So
the factor is now the first whitespace-delimited token, in the branch that reads an operator and
in the fallback branch alike.

A factor that still does not parse after that is a malformed definition, so it raises a
`ValueError` naming the file and the line, the way every other parse failure in `_parse_file`
does. libmagic rejects the same input, warning `Bad factor` when a non-space character follows the
digits.

The second commit addresses the sibling swallow the issue reports: a definition line that is not
valid UTF-8 was skipped by `except UnicodeDecodeError: continue`, dropping a test with no error
and no log record. It now raises with the file and the line. The `except UnicodeDecodeError: pass`
in the comment branch stays as it is: a comment carries documentation only, libmagic ignores
comments outright, and an undecodable one costs nothing but the `Comment` object. No shipped
definition triggers either path.

## What the tests pin

In `TestStrengthTest`:

- `test_a_comment_after_the_factor_leaves_the_factor_alone` fails with `StrengthOp.NONE != PLUS`
  if the tokenizing is reverted. It covers a comment after `+ 15`, after `/ 3`, and after a bare
  factor with no operator.
- `test_the_shipped_ctf_entry_scores_what_libmagic_scores` pins the shipped `magic_defs/ctf:23`
  entry at the 105 `file -l` reports, so a future definition sync that moves the entry is caught.
- `test_a_factor_that_is_not_an_integer_is_reported` pins the `ValueError` for `+five`, for a bare
  `+`, and for `5#nospace`, which libmagic rejects too.

In `MagicTest`, `test_an_undecodable_definition_line_is_reported` writes a Latin-1 definition line
and asserts the `ValueError` names line 2.

Each of the four fails with the fix reverted.

## Verification

- Strength parity with the reference binary: 3841 level-0 tests over 352 definition files, 0
  mismatches against `file -l`, down from the 1 (`ctf:22`) on `master`. `c-lang` carries a local
  patch and `csv`, `json`, and `polyfile_zip` are PolyFile's own, so those four are excluded. This
  was the last disagreement in the bundled definitions.
- Corpus differential over all 88 `file/tests` stems, with the same normalization as
  `corpus_result_matches`, `<stem>*.magic` sidecars, and `<stem>.flags` honored: 0 regressions, 88
  passing before and after. No stem changed its match order or its strongest match.
- `tests/test_corkami.py`: 904 passed, 3 skipped.
- `uv run pytest tests --ignore=tests/test_corkami.py`: 253 passed, 869 subtests passed.
- Blocking lint (`--select=E9,F63,F7,F82`) reports 0. `MagicMatcher._parse_file` stays at
  complexity 22, unchanged from `master`, and `parse_strength` is under 8.
- `uvx pip-audit`: no known vulnerabilities.

`MatchOrderTest` and `TestStrengthTest` both pass unchanged. The `ctf` entry does move: it goes
from index 1109 to index 1047 of the 3451 tests in the binary pass, ahead of the 62 tests that
score between 101 and 105. `MatchOrderTest` asserts ordering properties rather than specific
positions, so the move does not disturb it, and no corpus stem reports a different match order
because of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
