### PR TITLE
Report Unicode text where a JSON match diverges from libmagic

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -1130,6 +1130,24 @@ class MagicTest(ABC):
         """
         return not self.precedes_soft_magic and bool(self.subtest_type() & TestType.TEXT)
 
+    def diverges_from_libmagic(self, data: bytes) -> bool:
+        """Whether this test matches `data` where libmagic's own copy of the check does not.
+
+        A check `precedes_soft_magic` names ends libmagic's run as soon as it matches, so
+        ``file_buffer`` never reaches ``file_ascmagic`` and never describes the text encoding.
+        Where PolyFile's version of such a check accepts a buffer libmagic's version rejects,
+        libmagic takes no such short circuit: its run continues, and ``file_ascmagic`` describes
+        the file. `MagicMatcher.match` reports that description alongside the match, so neither
+        verdict is lost.
+
+        Args:
+            data: the file's own bytes.
+
+        Returns:
+            False, because a check that reads the same bytes reaches the same verdict.
+        """
+        return False
+
     @test_type.setter
     def test_type(self, value: TestType):
         if self._type != TestType.UNKNOWN:
@@ -3709,6 +3727,11 @@ def parse_json(raw: bytes) -> ParsedJSON:
     * If more data follows the first value, it is newline-delimited JSON as long as the next byte
       equals the first byte of the first value and a second value parses there. libmagic stops
       after that second value, so trailing garbage does not disqualify the buffer.
+    * The encoding is the one `json.detect_encoding` names, so a byte order mark, UTF-16 and
+      UTF-32 all parse. libmagic reads raw bytes and reports such a document as Unicode text
+      instead. RFC 8259 section 8.1 permits either reading, and PolyFile reports every match
+      rather than picking a winner, so `JSONTest.diverges_from_libmagic` keeps libmagic's answer
+      alongside this one.
 
     Args:
         raw: the bytes to parse, starting at the first byte of the candidate JSON value.
@@ -3764,6 +3787,22 @@ class JSONTest(MagicTest):
 
     def subtest_type(self) -> TestType:
         return TestType.TEXT
+
+    def diverges_from_libmagic(self, data: bytes) -> bool:
+        """``file_is_json`` walks raw bytes, so an encoding it cannot read is not JSON to it.
+
+        It advances a byte pointer over the file's own bytes and rejects the first byte outright
+        (``file/src/is_json.c:421-455``), so UTF-8 with a byte order mark, UTF-16 and UTF-32 are
+        all non-JSON to libmagic, which reports them as Unicode text. `parse_json` decodes with
+        `json.detect_encoding`, which reads every one of them.
+
+        Args:
+            data: the file's own bytes.
+
+        Returns:
+            True if `data` is in an encoding libmagic's byte-level parser cannot read.
+        """
+        return json.detect_encoding(data) != "utf-8"
 
     @property
     def precedes_soft_magic(self) -> bool:
@@ -4811,10 +4850,18 @@ class MagicMatcher:
             # hands them rather than against the file's bytes
             text_context = to_match.text_test_context(text_encoding.encoding)
             text_tests = [test for test in self.text_tests if test not in matched_on_the_files_bytes]
-            for _, m in self._run_tests(text_tests, text_context, text_encoding, "text matching",
-                                        file_context=to_match):
+            # a match that carries the encoding description already reports it, and so does a
+            # binary pass match, which is where `file_buffer` stops before `file_ascmagic`
+            described = bool(matched_on_the_files_bytes)
+            diverged = False
+            for test, m in self._run_tests(text_tests, text_context, text_encoding, "text matching",
+                                           file_context=to_match):
+                described = described or m.text_encoding is not None
+                diverged = diverged or test.diverges_from_libmagic(to_match.data)
                 yield m
                 yielded = True
+            if diverged and not described:
+                yield text_matcher
         if not yielded:
             if is_text:
                 yield text_matcher

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -427,6 +427,77 @@ class MagicTest(TestCase):
         messages = self.messages(MagicMatcher.DEFAULT_INSTANCE, b"42")
         self.assertNotIn("JSON text data", messages)
 
+    def test_json_without_a_byte_order_mark_reports_only_json(self):
+        """Tests that plain UTF-8 JSON reports the single verdict libmagic reports.
+
+        ``file_is_json`` ends libmagic's run before soft magic, so ``file_ascmagic`` never
+        describes the encoding and `file` prints ``JSON text data`` alone. The text description
+        that `test_bom_prefixed_json_also_reports_unicode_text` expects must not leak into every
+        JSON file.
+        """
+        self.assertEqual({"JSON text data"}, self.messages(MagicMatcher.DEFAULT_INSTANCE, b'{"a": 1}'))
+
+    def test_bom_prefixed_json_also_reports_unicode_text(self):
+        """Tests that JSON in an encoding libmagic cannot read reports both verdicts.
+
+        This is a regression test for trailofbits/polyfile#3500. `parse_json` decodes with
+        `json.detect_encoding`, so PolyFile reads a byte order mark, UTF-16 and UTF-32 as JSON,
+        where ``file_is_json`` advances a byte pointer over the file's own bytes and rejects the
+        first byte outright (`file/src/is_json.c`). For the five buffers below, `file` reports only
+        the text encoding:
+
+        * ``Unicode text, UTF-8 (with BOM) text, with no line terminators``
+        * ``Unicode text, UTF-16, little-endian text, with no line terminators``
+        * ``Unicode text, UTF-16, big-endian text, with no line terminators``
+        * ``Unicode text, UTF-32, little-endian``
+        * ``Unicode text, UTF-32, big-endian``
+
+        PolyFile deliberately diverges and reports both, because a JSON document with a byte order
+        mark is JSON in practice and PolyFile reports every match rather than picking a winner.
+        RFC 8259 section 8.1 permits either reading. Before the fix the JSON match suppressed the
+        text description, so the answer `file` gives was lost.
+
+        PolyFile's UTF-8 description omits libmagic's ``(with BOM)`` clause, which is the separate
+        gap in `detect_text_encoding` tracked in trailofbits/polyfile#3537. The UTF-32 cases carry
+        no trailing clauses because their description comes from a soft magic definition in
+        `polyfile/magic_defs/` rather than from the text encoding machinery, which is also where
+        `file` gets it.
+        """
+        document = '{"a": 1}'
+        cases = (
+            ("utf-8-sig", b"\xef\xbb\xbf" + document.encode("utf-8"),
+             "Unicode text, UTF-8 text, with no line terminators"),
+            ("utf-16-le", f"\ufeff{document}".encode("utf-16-le"),
+             "Unicode text, UTF-16, little-endian text, with no line terminators"),
+            ("utf-16-be", f"\ufeff{document}".encode("utf-16-be"),
+             "Unicode text, UTF-16, big-endian text, with no line terminators"),
+            ("utf-32-le", f"\ufeff{document}".encode("utf-32-le"),
+             "Unicode text, UTF-32, little-endian"),
+            ("utf-32-be", f"\ufeff{document}".encode("utf-32-be"),
+             "Unicode text, UTF-32, big-endian"),
+        )
+        for encoding, data, description in cases:
+            with self.subTest(encoding=encoding):
+                messages = self.messages(MagicMatcher.DEFAULT_INSTANCE, data)
+                self.assertEqual({"JSON text data", description}, messages)
+
+    def test_bom_prefixed_newline_delimited_json_also_reports_unicode_text(self):
+        """Tests that newline-delimited JSON reports both verdicts under the same rule.
+
+        `NDJSONTest` inherits `JSONTest.diverges_from_libmagic`, so the two JSON test types stay
+        consistent: `file` reports ``Unicode text, UTF-8 (with BOM) text`` for the first buffer and
+        ``Unicode text, UTF-16, little-endian text`` for the second, and PolyFile reports its
+        NDJSON match alongside each description.
+        """
+        self.assertEqual(
+            {"New Line Delimited JSON text data", "Unicode text, UTF-8 text"},
+            self.messages(MagicMatcher.DEFAULT_INSTANCE, b"\xef\xbb\xbf{}\n{}\n")
+        )
+        self.assertEqual(
+            {"New Line Delimited JSON text data", "Unicode text, UTF-16, little-endian text"},
+            self.messages(MagicMatcher.DEFAULT_INSTANCE, "\ufeff{}\n{}\n".encode("utf-16-le"))
+        )
+
     def test_der_certificate(self):
         with gzip.open(DER_CERTIFICATE, "rb") as f:
             certificate = f.read()

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -2070,17 +2070,16 @@ class UCSTextBufferTest(TestCase):
         CSV match libmagic does not report.
 
         The `JSON text data` this expects for the UTF-16 document is a separate divergence that
-        predates the decoding: `JSONTest` reads the bytes through `json.loads`, which sniffs a
-        UTF-16 byte order mark, and `file_is_json` does not. It stands in for the encoding
-        description because `MagicMatcher.match` reports the plain text match only when no other
-        test matched.
+        predates the decoding: `parse_json` reads the bytes through `json.detect_encoding`, which
+        sniffs a UTF-16 byte order mark, and `file_is_json` does not. PolyFile reports the encoding
+        description alongside it, which is the decision recorded in trailofbits/polyfile#3500.
         """
         document = '{"a": 1, "b": 2}\n'
         self.assertIn("CSV text (excel dialect)", {
             str(match) for match in MagicMatcher.DEFAULT_INSTANCE.match(document.encode("utf-8"))
         })
         self.assertEqual(
-            {"JSON text data"},
+            {"JSON text data", "Unicode text, UTF-16, little-endian text"},
             {str(match) for match in
              MagicMatcher.DEFAULT_INSTANCE.match(self.encode(document, "utf-16le"))}
         )


### PR DESCRIPTION
Closes #3500

## Merge order

Wave 1, alongside #3529, #3470, #3462, #3476, #3464, #3479, #3501, #3499, and #3506. This PR sits
anywhere within that wave. The `polyfile/magic.py` region it touches (`parse_json`, `JSONTest`, and
the text pass in `MagicMatcher.match`) does not overlap any other Wave 1 edit, and the test
insertion point sits beside the existing JSON cases rather than in #3506's method. Nothing
downstream needs to rebase onto it.

## Reproducer

Before:

```console
$ printf '\xef\xbb\xbf{}' > bom.json
$ TZ=UTC ./file/src/file -b -m file/magic/magic.mgc bom.json
Unicode text, UTF-8 (with BOM) text, with no line terminators
$ polyfile bom.json
JSON text data
```

After:

```console
$ polyfile bom.json
JSON text data
Unicode text, UTF-8 text, with no line terminators
```

The same divergence covers UTF-16 in both byte orders, where PolyFile's second line now reads
exactly what `file` prints:

```console
$ TZ=UTC ./file/src/file -b -m file/magic/magic.mgc u16le.json
Unicode text, UTF-16, little-endian text, with no line terminators
$ polyfile u16le.json
JSON text data
Unicode text, UTF-16, little-endian text, with no line terminators
```

UTF-32 already reported both, because a soft magic definition in `polyfile/magic_defs/` names the
encoding in the binary pass, which is also where `file` gets it. That case is unchanged.

## What the fix does

The decision recorded on #3500 is to report both, because a JSON document with a byte order mark is
JSON in practice and PolyFile reports every match rather than picking a winner. RFC 8259 section 8.1
permits either reading, so both tools stay in spec.

`parse_json` decodes with `json.detect_encoding`, which accepts UTF-8 with a byte order mark,
UTF-16, and UTF-32. libmagic's `file_is_json` advances a `const unsigned char *` over the file's own
bytes and rejects the first byte outright (`file/src/is_json.c:421-455`), so none of those documents
is JSON to it.

`JSONTest.precedes_soft_magic` models libmagic returning from `file_buffer` before `file_ascmagic`
runs (`file/src/funcs.c`), which is what makes `appends_text_encoding` false and keeps
`JSON text data, ASCII text` from appearing. That model is right whenever libmagic's own check
matches. Where it does not, libmagic takes no short circuit: soft magic prints nothing, and
`file_ascmagic` describes the file as Unicode text. PolyFile matched JSON and dropped that answer.

The fix adds `MagicTest.diverges_from_libmagic(data)`, which returns `False` by default because a
check that reads the same bytes reaches the same verdict. `JSONTest` answers it from the encoding
`json.detect_encoding` names, and `NDJSONTest` inherits it. `MagicMatcher.match` then yields the
plain text match alongside a diverging match, unless the description is already reported: either by
a text pass match that carries it, or by a binary pass match, which is where `file_buffer` stops
before `file_ascmagic`. `appends_text_encoding` keeps its current meaning for every test that sets
it, so the one-line-per-match output for a plain UTF-8 JSON file is untouched.

## What the tests pin

`test_bom_prefixed_json_also_reports_unicode_text` asserts the exact message set for all five
encodings: the JSON match and the text description together. Its docstring records what `file`
reports for the same bytes and says the divergence is deliberate.
`test_bom_prefixed_newline_delimited_json_also_reports_unicode_text` pins the same rule for NDJSON.
`test_json_without_a_byte_order_mark_reports_only_json` is the control: plain UTF-8 JSON reports
`JSON text data` alone.

The specific failure they prevent, verified by breaking the fix both ways:

* With `JSONTest.diverges_from_libmagic` forced to `False`, the UTF-8, UTF-16-LE, and UTF-16-BE
  subtests and the NDJSON test fail, because the text description disappears. The two UTF-32
  subtests still pass, which is why the docstring explains where their description comes from.
* With it forced to `True`, `test_json_without_a_byte_order_mark_reports_only_json` fails, because
  the text description leaks into plain UTF-8 JSON.

`UCSTextBufferTest.test_the_json_and_csv_checks_read_the_files_own_bytes` pinned the old behavior
for a UTF-16 document, and its docstring named the suppression as the reason. It now expects both
messages, and the docstring points at the decision instead. The CSV half of that test is unchanged.

## Verification

* Blocking lint (`--select=E9,F63,F7,F82`): 0 findings.
* Complexity pass on `polyfile/magic.py`: 16 findings before and after, all pre-existing, none in
  the changed code. `MagicMatcher.match` stays under the limit.
* `uv run pytest tests --ignore=tests/test_corkami.py`: 252 passed, 871 subtests passed.
* `uvx pip-audit`: no known vulnerabilities.
* Corpus differential over all 88 stems, with the same normalization as `corpus_result_matches`,
  `<stem>*.magic` sidecars, and `<stem>.flags` honored: 88 passing before, 88 after, **zero
  regressions**, and zero stems whose match set changed at all. All nine JSON stems (`json1`
  through `json8` and `jsonlines1`) still pass.

## Follow-up filed

#3537: PolyFile describes a BOM-prefixed UTF-8 file as `Unicode text, UTF-8` where `file` says
`Unicode text, UTF-8 (with BOM)`. `detect_text_encoding` has no case for the mark and
`LIBMAGIC_ENCODING_NAMES` has no name for it, so the clause never appears. That gap is pre-existing
and independent of JSON (a BOM-prefixed plain text file shows it too), which is why it is a separate
issue rather than part of this PR. It is the only reason the UTF-8 line above differs from `file`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
