### PR TITLE
Guard byte-provenance dereferences in the PDF parser

### DIFF
--- a/polyfile/pdf.py
+++ b/polyfile/pdf.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Callable, Dict, Iterator, List, Optional, Type, TypeVar, Union
+from typing import Callable, Dict, Iterator, List, Optional, Tuple, Type, TypeVar, Union
 import zlib
 
 from pdfminer.ascii85 import ascii85decode, asciihexdecode
@@ -826,6 +826,106 @@ class RawPDFStream:
         return getattr(self._file_stream, item)
 
 
+def has_provenance(obj) -> bool:
+    """Reports whether a parsed object records where it came from in the file.
+
+    Every submatch PolyFile emits is positioned from the `pdf_offset` and `pdf_bytes` that this
+    module's instrumented token types carry. pdfminer hands back plain `int`, `str`, `list` and
+    `dict` objects on several of its recovery paths, and those cannot be mapped.
+
+    Args:
+        obj: Any object pdfminer produced while parsing.
+
+    Returns:
+        True if `obj` carries both byte-provenance attributes.
+    """
+    return hasattr(obj, "pdf_offset") and hasattr(obj, "pdf_bytes")
+
+
+def dict_value_with_provenance(dict_obj: "PDFDict", key, value):
+    """Resolves one PDF dictionary value to something that can be positioned in the file.
+
+    A value pdfminer returned as a plain list is reloaded as a `PDFList`, which recovers the
+    provenance of its members, and the dictionary is updated so that it stays self-consistent.
+
+    Args:
+        dict_obj: The dictionary that `key` belongs to.
+        key: The key whose value is being resolved, used only for logging.
+        value: The value to resolve.
+
+    Returns:
+        The value with byte provenance, or None when it has to be skipped.
+    """
+    if has_provenance(value):
+        return value
+    if not isinstance(value, list):
+        log.warning(f"Skipping unexpected PDF dictionary value {value!r} for key {key}")
+        return None
+    if not value:
+        log.debug(f"Skipping empty list value for key {key}")
+        return None
+    try:
+        value = PDFList.load(value)
+    except ValueError as e:
+        log.warning(f"Skipping malformed list value for key {key}: {e}")
+        return None
+    dict_obj[key] = value
+    return value
+
+
+def parse_dict(obj: "PDFDict", matcher: Matcher, parent: Optional[Match], pdf_header_offset: int):
+    """Yields the submatches that map a PDF dictionary and each of its key/value pairs.
+
+    Keys and values that carry no byte provenance are logged and skipped, so one unmappable
+    entry costs that entry rather than the rest of the match tree.
+
+    Args:
+        obj: The dictionary to map.
+        matcher: The matcher to use when recursing into values.
+        parent: The match that the dictionary is nested in.
+        pdf_header_offset: The offset of `%PDF` within the file being parsed.
+    """
+    dict_obj = Submatch(
+        "PDFDictionary",
+        '',
+        relative_offset=obj.pdf_offset - (parent.offset - pdf_header_offset),
+        length=obj.pdf_bytes - 1,
+        parent=parent
+    )
+    yield dict_obj
+    for key, value in obj.items():
+        value = dict_value_with_provenance(obj, key, value)
+        if value is None:
+            continue
+        if not has_provenance(key):
+            log.warning(f"Skipping PDF dictionary key {key!r} because it has no byte provenance")
+            continue
+        pair = Submatch(
+            "KeyValuePair",
+            '',
+            relative_offset=key.pdf_offset - (dict_obj.offset - pdf_header_offset) - 1,
+            length=value.pdf_offset + value.pdf_bytes - key.pdf_offset,
+            parent=dict_obj
+        )
+        yield pair
+        yield Submatch(
+            "Key",
+            key,
+            relative_offset=0,
+            length=key.pdf_bytes + 1,
+            parent=pair
+        )
+        value_match = Submatch(
+            "Value",
+            value,
+            relative_offset=value.pdf_offset - key.pdf_offset,
+            length=value.pdf_bytes,
+            parent=pair
+        )
+        yield value_match
+        yield from parse_object(value, matcher=matcher, parent=value_match, pdf_header_offset=pdf_header_offset)
+
+
 def parse_object(obj, matcher: Matcher, parent: Optional[Match] = None, pdf_header_offset: int = 0):
     if isinstance(obj, PDFStreamFilter):
         filter_obj = Submatch(
@@ -868,57 +968,7 @@ def parse_object(obj, matcher: Matcher, parent: Optional[Match] = None, pdf_head
         for item in obj:
             yield from parse_object(item, matcher=matcher, parent=list_obj, pdf_header_offset=pdf_header_offset)
     elif isinstance(obj, PDFDict):
-        dict_obj = Submatch(
-            "PDFDictionary",
-            '',
-            relative_offset=obj.pdf_offset - (parent.offset - pdf_header_offset),
-            length=obj.pdf_bytes - 1,
-            parent=parent
-        )
-        yield dict_obj
-        for key, value in obj.items():
-            if not hasattr(value, "pdf_offset") or not hasattr(value, "pdf_bytes"):
-                if isinstance(value, list):
-                    if not value:
-                        # Empty list - skip it as there's no data to parse
-                        log.debug(f"Skipping empty list value for key {key}")
-                        continue
-                    try:
-                        value = PDFList.load(value)
-                        # Keep the dictionary self-consistent
-                        obj[key] = value
-                    except ValueError as e:
-                        # Skip malformed list values instead of crashing
-                        log.warning(f"Skipping malformed list value for key {key}: {e}")
-                        continue
-                else:
-                    # Unexpected value type - log warning and skip instead of raising error
-                    log.warning(f"Skipping unexpected PDF dictionary value {value!r} for key {key}")
-                    continue
-            pair = Submatch(
-                "KeyValuePair",
-                '',
-                relative_offset=key.pdf_offset - (dict_obj.offset - pdf_header_offset) - 1,
-                length=value.pdf_offset + value.pdf_bytes - key.pdf_offset,
-                parent=dict_obj
-            )
-            yield pair
-            yield Submatch(
-                "Key",
-                key,
-                relative_offset=0,
-                length=key.pdf_bytes + 1,
-                parent=pair
-            )
-            value_match = Submatch(
-                "Value",
-                value,
-                relative_offset=value.pdf_offset - key.pdf_offset,
-                length=value.pdf_bytes,
-                parent=pair
-            )
-            yield value_match
-            yield from parse_object(value, matcher=matcher, parent=value_match, pdf_header_offset=pdf_header_offset)
+        yield from parse_dict(obj, matcher=matcher, parent=parent, pdf_header_offset=pdf_header_offset)
     elif isinstance(obj, PDFDeciphered):
         deciphered = Submatch(
             "PDFDeciphered",
@@ -958,7 +1008,7 @@ def parse_object(obj, matcher: Matcher, parent: Optional[Match] = None, pdf_head
         # recursively match against the deflated contents
         with Tempfile(obj) as f:
             yield from matcher.match(f, parent=match)
-    elif hasattr(obj, "pdf_offset") and hasattr(obj, "pdf_bytes"):
+    elif has_provenance(obj):
         yield Submatch(
             obj.__class__.__name__,
             obj,
@@ -1163,6 +1213,165 @@ def pdf_obj_parser(file_stream, obj, objid: int, parent: Match, pdf_header_offse
     log.clear_status()
 
 
+def parse_trailer(trailer, matcher: Matcher, parent: Match, pdf_header_offset: int):
+    """Yields the submatches that map a cross-reference section's trailer dictionary.
+
+    `InstrumentedPDFDocument` recovers from a missing `/Root` by patching `PDFXRef.get_trailer`,
+    and a PDF damaged enough to need that recovery usually reaches here with a trailer that is
+    empty or whose entries pdfminer rebuilt without byte provenance. Those entries are logged and
+    skipped so that the cross-reference table after them is still mapped.
+
+    Args:
+        trailer: The dictionary returned by `PDFBaseXRef.get_trailer`.
+        matcher: The matcher to use when recursing into values.
+        parent: The match that the trailer is nested in.
+        pdf_header_offset: The offset of `%PDF` within the file being parsed.
+    """
+    pairs = [(k, v) for k, v in trailer.items() if has_provenance(k) and has_provenance(v)]
+    if len(pairs) < len(trailer):
+        log.warning(f"Skipping {len(trailer) - len(pairs)} PDF trailer entries that have no byte provenance")
+    if not pairs:
+        log.debug("Skipping a PDF trailer that maps to no bytes in the file")
+        return
+    trailer_start = min(k.pdf_offset for k, _ in pairs)
+    trailer_end = max(v.pdf_offset + v.pdf_bytes for _, v in pairs)
+    t = Submatch(
+        "Trailer",
+        b"",
+        relative_offset=trailer_start,
+        length=trailer_end - trailer_start,
+        parent=parent
+    )
+    yield t
+    for k, v in pairs:
+        kvp = Submatch(
+            "KeyValuePair",
+            b"",
+            relative_offset=k.pdf_offset - trailer_start,
+            length=v.pdf_offset + v.pdf_bytes - k.pdf_offset,
+            parent=t
+        )
+        yield kvp
+        yield Submatch(
+            "Key",
+            k,
+            relative_offset=k.pdf_offset - k.pdf_offset,
+            length=k.pdf_bytes,
+            parent=kvp
+        )
+        value_match = Submatch(
+            "Value",
+            b"",
+            relative_offset=v.pdf_offset - k.pdf_offset,
+            length=v.pdf_bytes,
+            parent=kvp
+        )
+        yield value_match
+        yield from parse_object(v, matcher=matcher, parent=value_match, pdf_header_offset=pdf_header_offset)
+
+
+def xref_row_span(row) -> Optional[Tuple[int, int]]:
+    """Measures the bytes that one cross-reference row occupies in the file.
+
+    Args:
+        row: An object ID, position, and generation number triple from `PDFXRef.offsets`.
+
+    Returns:
+        The row's start and end offsets, or None when any of its cells has no byte provenance.
+    """
+    _, pos, gen_no = row
+    if not has_provenance(pos) or not has_provenance(gen_no):
+        return None
+    cells = [c for c in row if c is not None]
+    if not all(has_provenance(c) for c in cells):
+        return None
+    return min(c.pdf_offset for c in cells), max(c.pdf_offset + c.pdf_bytes for c in cells)
+
+
+def parse_xref(xref: PDFXRef, matcher: Matcher, parent: Match, pdf_header_offset: int):
+    """Yields the submatches that map a cross-reference table and each of its rows.
+
+    `PDFXRefFallback` subclasses `PDFXRef` but reconstructs the table with its own `load`, which
+    stores plain integer positions instead of the instrumented tokens that this module's
+    `load_xref` produces. Its rows therefore map to nothing and are logged and skipped.
+
+    Args:
+        xref: The cross-reference table to map.
+        matcher: The matcher to use when recursing into cells.
+        parent: The match that the table is nested in.
+        pdf_header_offset: The offset of `%PDF` within the file being parsed.
+    """
+    rows = [(row, span) for row in xref.offsets.values() if (span := xref_row_span(row)) is not None]
+    if len(rows) < len(xref.offsets):
+        log.warning(f"Skipping {len(xref.offsets) - len(rows)} rows of a {xref.__class__.__name__} "
+                    "cross-reference table that have no byte provenance")
+    if not rows:
+        log.debug("Skipping a PDF cross-reference table that maps to no bytes in the file")
+        return
+    xref_start = min(start for _, (start, _) in rows)
+    xref_end = max(end for _, (_, end) in rows)
+    x = Submatch(
+        "XRefTable",
+        b"",
+        relative_offset=xref_start,
+        length=xref_end - xref_start,
+        parent=parent
+    )
+    yield x
+    for row, (row_start, row_end) in rows:
+        row_match = Submatch(
+            "XRefRow",
+            b"",
+            relative_offset=row_start - xref_start,
+            length=row_end - row_start,
+            parent=x
+        )
+        yield row_match
+        yield from parse_xref_row(row, row_start, matcher=matcher, parent=row_match,
+                                  pdf_header_offset=pdf_header_offset)
+
+
+def parse_xref_row(row, row_start: int, matcher: Matcher, parent: Match, pdf_header_offset: int):
+    """Yields the submatches that map the cells of one cross-reference row.
+
+    Args:
+        row: An object ID, position, and generation number triple from `PDFXRef.offsets`.
+        row_start: The offset of the row within the file.
+        matcher: The matcher to use when recursing into cells.
+        parent: The match that the row is nested in.
+        pdf_header_offset: The offset of `%PDF` within the file being parsed.
+    """
+    obj_id, pos, gen_no = row
+    if obj_id is not None:
+        ret = Submatch(
+            "ObjectID",
+            b"",
+            relative_offset=obj_id.pdf_offset - row_start,
+            length=obj_id.pdf_bytes,
+            parent=parent
+        )
+        yield ret
+        yield from parse_object(obj_id, matcher=matcher, parent=ret, pdf_header_offset=pdf_header_offset)
+    ret = Submatch(
+        "Position",
+        b"",
+        relative_offset=pos.pdf_offset - row_start,
+        length=pos.pdf_bytes,
+        parent=parent
+    )
+    yield ret
+    yield from parse_object(ret, matcher=matcher, parent=ret, pdf_header_offset=pdf_header_offset)
+    ret = Submatch(
+        "Generation",
+        b"",
+        relative_offset=gen_no.pdf_offset - row_start,
+        length=gen_no.pdf_bytes,
+        parent=parent
+    )
+    yield ret
+    yield from parse_object(ret, matcher=matcher, parent=ret, pdf_header_offset=pdf_header_offset)
+
+
 # Note: PDF parser is registered lazily in __init__.py to defer pdfminer import
 def pdf_parser(file_stream, parent: Match):
     # pdfminer expects %PDF to be at byte offset zero in the file
@@ -1201,100 +1410,16 @@ def pdf_parser(file_stream, parent: Match):
                     continue
                 yielded.add((obj.objid, obj.genno))
             else:
-                if objid in yielded or not hasattr(obj, "pdf_offset") or not hasattr(obj, "pdf_bytes"):
+                if objid in yielded or not has_provenance(obj):
                     continue
                 yielded.add(objid)
             yield from pdf_obj_parser(file_stream, obj, objid, parent, pdf_header_offset=pdf_header_offset)
 
         trailer = xref.get_trailer()
         if trailer is not None:
-            trailer_start = min(k.pdf_offset for k in trailer.keys())
-            trailer_end = max(v.pdf_offset + v.pdf_bytes for v in trailer.values())
-            t = Submatch(
-                "Trailer",
-                b"",
-                relative_offset=trailer_start,
-                length=trailer_end - trailer_start,
-                parent=parent
-            )
-            yield t
-            for k, v in trailer.items():
-                kvp = Submatch(
-                    "KeyValuePair",
-                    b"",
-                    relative_offset=k.pdf_offset - trailer_start,
-                    length=v.pdf_offset + v.pdf_bytes - k.pdf_offset,
-                    parent=t
-                )
-                yield kvp
-                yield Submatch(
-                    "Key",
-                    k,
-                    relative_offset=k.pdf_offset - k.pdf_offset,
-                    length=k.pdf_bytes,
-                    parent=kvp
-                )
-                value_match = Submatch(
-                    "Value",
-                    b"",
-                    relative_offset=v.pdf_offset - k.pdf_offset,
-                    length=v.pdf_bytes,
-                    parent=kvp
-                )
-                yield value_match
-                yield from parse_object(v, matcher=parent.matcher, parent=value_match,
-                                        pdf_header_offset=pdf_header_offset)
+            yield from parse_trailer(trailer, matcher=parent.matcher, parent=parent,
+                                     pdf_header_offset=pdf_header_offset)
 
-        if not isinstance(xref, PDFXRef):
-            continue
-
-        xref_start = min(min(c.pdf_offset for c in row if c is not None) for row in xref.offsets.values())
-        xref_end = max(max(c.pdf_offset + c.pdf_bytes for c in row if c is not None) for row in xref.offsets.values())
-        x = Submatch(
-            "XRefTable",
-            b"",
-            relative_offset=xref_start,
-            length=xref_end - xref_start,
-            parent=parent
-        )
-        yield x
-        for row in xref.offsets.values():
-            row_start = min(c.pdf_offset for c in row if c is not None)
-            row_end = max(c.pdf_offset + c.pdf_bytes for c in row if c is not None)
-            row_match = Submatch(
-                "XRefRow",
-                b"",
-                relative_offset=row_start - xref_start,
-                length=row_end - row_start,
-                parent=x
-            )
-            yield row_match
-            obj_id, pos, gen_no = row
-            if obj_id is not None:
-                ret = Submatch(
-                    "ObjectID",
-                    b"",
-                    relative_offset=obj_id.pdf_offset - row_start,
-                    length=obj_id.pdf_bytes,
-                    parent=row_match
-                )
-                yield ret
-                yield from parse_object(obj_id, matcher=parent.matcher, parent=ret, pdf_header_offset=pdf_header_offset)
-            ret = Submatch(
-                "Position",
-                b"",
-                relative_offset=pos.pdf_offset - row_start,
-                length=pos.pdf_bytes,
-                parent=row_match
-            )
-            yield ret
-            yield from parse_object(ret, matcher=parent.matcher, parent=ret, pdf_header_offset=pdf_header_offset)
-            ret = Submatch(
-                "Generation",
-                b"",
-                relative_offset=gen_no.pdf_offset - row_start,
-                length=gen_no.pdf_bytes,
-                parent=row_match
-            )
-            yield ret
-            yield from parse_object(ret, matcher=parent.matcher, parent=ret, pdf_header_offset=pdf_header_offset)
+        if isinstance(xref, PDFXRef):
+            yield from parse_xref(xref, matcher=parent.matcher, parent=parent,
+                                  pdf_header_offset=pdf_header_offset)

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1,11 +1,55 @@
 """
 Unit tests for PDF parsing functionality, particularly edge cases with empty lists
-and malformed dictionary values that were causing crashes (issue #12).
+and malformed dictionary values that were causing crashes (issue #12), and the byte-provenance
+guards that keep a malformed PDF from truncating the match tree (issue #3464).
 """
+import base64
+import logging
 import unittest
+from tempfile import NamedTemporaryFile
+from typing import List, Tuple
 from unittest.mock import MagicMock, patch
 from polyfile.pdf import PDFList, parse_object, PDFDict
-from polyfile.polyfile import Match
+from polyfile.polyfile import Match, Matcher
+
+
+WELL_FORMED_PDF: bytes = base64.b64decode(
+    "JVBERi0xLjcKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5k"
+    "b2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFtdIC9Db3VudCAwID4+CmVuZG9i"
+    "agp4cmVmCjAgMwowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDAwMDkgMDAwMDAgbiAKMDAw"
+    "MDAwMDA1OCAwMDAwMCBuIAp0cmFpbGVyCjw8IC9TaXplIDMgL1Jvb3QgMSAwIFIgPj4Kc3Rh"
+    "cnR4cmVmCjExMAolJUVPRgo="
+)
+"""A two-object PDF with a correct cross-reference table, used as the control."""
+
+EMPTY_TRAILER_PDF: bytes = base64.b64decode(
+    "JVBERi0xLjcKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5k"
+    "b2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFtdIC9Db3VudCAwID4+CmVuZG9i"
+    "agp4cmVmCjAgMwowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDAwMDkgMDAwMDAgbiAKMDAw"
+    "MDAwMDA1OCAwMDAwMCBuIAp0cmFpbGVyCjw8Pj4Kc3RhcnR4cmVmCjExMAolJUVPRgo="
+)
+"""`WELL_FORMED_PDF` with an empty trailer, so pdfminer finds no `/Root`."""
+
+RECONSTRUCTED_XREF_PDF: bytes = base64.b64decode(
+    "JVBERi0xLjcKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5k"
+    "b2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFtdIC9Db3VudCAwID4+CmVuZG9i"
+    "agp4cmVmCjAgMwowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDAwMDkgMDAwMDAgbiAKMDAw"
+    "MDAwMDA1OCAwMDAwMCBuIAp0cmFpbGVyCjw8IC9TaXplIDMgL1Jvb3QgMSAwIFIgPj4Kc3Rh"
+    "cnR4cmVmCjAKJSVFT0YK"
+)
+"""`WELL_FORMED_PDF` with a `startxref` of 0, so pdfminer rebuilds the table with
+`PDFXRefFallback`."""
+
+INTEGER_KEY_PDF: bytes = base64.b64decode(
+    "JVBERi0xLjcKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgL0JhZCAz"
+    "IDAgUiA+PgplbmRvYmoKMiAwIG9iago8PCAvVHlwZSAvUGFnZXMgL0tpZHMgW10gL0NvdW50"
+    "IDAgPj4KZW5kb2JqCjMgMCBvYmoKPDwgNDIgKHZhbHVlKSA+PgplbmRvYmoKeHJlZgowIDQK"
+    "MDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMDA5IDAwMDAwIG4gCjAwMDAwMDAwNjkgMDAw"
+    "MDAgbiAKMDAwMDAwMDEyMSAwMDAwMCBuIAp0cmFpbGVyCjw8IC9TaXplIDQgL1Jvb3QgMSAw"
+    "IFIgPj4Kc3RhcnR4cmVmCjE1MwolJUVPRgo="
+)
+"""A PDF whose object 3 is `<< 42 (value) >>`; pdfminer names that key with `literal_name`,
+which returns a plain `str` for a key that is not a literal."""
 
 
 class TestPDFList(unittest.TestCase):
@@ -192,6 +236,123 @@ class TestPDFDictionaryParsing(unittest.TestCase):
         # Should have processed both key-value pairs
         # (at minimum: dict_obj, 2x KeyValuePair, 2x Key, 2x Value)
         self.assertGreater(len(results), 5)
+
+
+class CapturedWarnings(logging.Handler):
+    """Collects the warnings PolyFile's loggers emit while a file is matched."""
+
+    def __init__(self):
+        super().__init__(level=logging.WARNING)
+        self.records: List[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def messages(self, logger_name: str) -> List[str]:
+        """Returns the messages one logger emitted.
+
+        Args:
+            logger_name: The name the logger was created with, such as "PDF".
+
+        Returns:
+            Every warning that logger emitted, in the order it emitted them.
+        """
+        return [r.getMessage() for r in self.records if r.name == logger_name]
+
+
+class TestMalformedPDFMatchTree(unittest.TestCase):
+    """Regression tests for the byte-provenance guards in issue #3464.
+
+    `Matcher.handle_mimetype` catches every exception a parser raises and logs a warning, so an
+    unguarded dereference never reaches the user as a traceback: it abandons the rest of the match
+    tree instead. These tests therefore assert on the tree and on the warnings, not on exceptions.
+    """
+
+    def match(self, data: bytes) -> Tuple[List[str], CapturedWarnings]:
+        """Runs the full matcher over a PDF held in memory.
+
+        Args:
+            data: The contents of the PDF to match.
+
+        Returns:
+            The name of every match, in the order PolyFile produced them, and the warnings that
+            were logged while it did.
+        """
+        handler = CapturedWarnings()
+        root = logging.getLogger()
+        previous_level = root.level
+        root.addHandler(handler)
+        root.setLevel(logging.WARNING)
+        try:
+            with NamedTemporaryFile(suffix=".pdf") as f:
+                f.write(data)
+                f.flush()
+                return [m.name for m in Matcher(parse=True).match(f.name)], handler
+        finally:
+            root.removeHandler(handler)
+            root.setLevel(previous_level)
+
+    def assertParserFinished(self, warnings: CapturedWarnings):
+        """Asserts that no parser abandoned its match tree part way through."""
+        aborted = [m for m in warnings.messages("polyfile") if "raised an exception" in m]
+        self.assertEqual([], aborted)
+
+    def test_well_formed_pdf_is_mapped_completely(self):
+        """Every structure of an undamaged PDF is mapped, with nothing logged."""
+        names, warnings = self.match(WELL_FORMED_PDF)
+        self.assertParserFinished(warnings)
+        self.assertEqual([], warnings.messages("PDF"))
+        self.assertEqual(2, names.count("PDFObject"))
+        self.assertEqual(1, names.count("Trailer"))
+        self.assertEqual(1, names.count("XRefTable"))
+        self.assertEqual(2, names.count("XRefRow"))
+
+    def test_empty_trailer_still_maps_the_xref_table(self):
+        """An empty trailer no longer costs the cross-reference table.
+
+        `min()` over the trailer's keys raised `ValueError: min() arg is an empty sequence`, which
+        abandoned the match tree before any of the `XRefTable` submatches were produced.
+        """
+        names, warnings = self.match(EMPTY_TRAILER_PDF)
+        self.assertParserFinished(warnings)
+        self.assertEqual(2, names.count("PDFObject"))
+        self.assertEqual(0, names.count("Trailer"))
+        self.assertEqual(1, names.count("XRefTable"))
+        self.assertEqual(2, names.count("XRefRow"))
+
+    def test_reconstructed_xref_rows_are_skipped(self):
+        """A rebuilt cross-reference table is reported, not fatal.
+
+        `PDFXRefFallback` stores plain integer positions, so `c.pdf_offset` raised
+        `AttributeError: 'int' object has no attribute 'pdf_offset'` and discarded the rest of
+        the match tree.
+        """
+        names, warnings = self.match(RECONSTRUCTED_XREF_PDF)
+        self.assertParserFinished(warnings)
+        self.assertEqual(2, names.count("PDFObject"))
+        self.assertEqual(1, names.count("Trailer"))
+        self.assertEqual(0, names.count("XRefTable"))
+        skipped = [m for m in warnings.messages("PDF") if "PDFXRefFallback" in m]
+        self.assertEqual(1, len(skipped))
+        self.assertIn("Skipping 2 rows", skipped[0])
+
+    def test_dictionary_key_without_provenance_is_skipped(self):
+        """One unmappable dictionary key costs that key, not the rest of the file.
+
+        `key.pdf_offset` raised `AttributeError: 'str' object has no attribute 'pdf_offset'` for a
+        key that pdfminer named with `literal_name`, which abandoned the match tree before the
+        trailer and the cross-reference table were mapped.
+        """
+        names, warnings = self.match(INTEGER_KEY_PDF)
+        self.assertParserFinished(warnings)
+        self.assertEqual(3, names.count("PDFObject"))
+        self.assertEqual(1, names.count("Trailer"))
+        self.assertEqual(1, names.count("XRefTable"))
+        self.assertEqual(3, names.count("XRefRow"))
+        self.assertEqual(
+            ["Skipping PDF dictionary key '42' because it has no byte provenance"],
+            warnings.messages("PDF")
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #3464

## Merge order

Wave 1, alongside #3529, #3470, #3462, #3476, #3479, #3501, #3499, #3500, and #3506. This PR
touches only `polyfile/pdf.py` and `tests/test_pdf.py`, which no other PR in the wave touches, so
it can land at any point in the wave and nothing downstream has to rebase onto it.

## Reproducers

The issue was filed from code inspection with no reproducer, so the first step was to build one
for each of the three cases. All three reproduce, and none of them raises: `Matcher.handle_mimetype`
(`polyfile/polyfile.py:250-267`) catches every parser exception and logs a warning, so what the
user sees is a match tree that stops part way through.

The four PDFs are embedded as base64 constants in `tests/test_pdf.py`, following
`ISSUE_3374_PDF` in `tests/test_magic.py`. `WELL_FORMED_PDF` is the control; each malformed one is
that file with a single change.

| File | Change | Failure on `master` |
| --- | --- | --- |
| `INTEGER_KEY_PDF` | object 3 is `<< 42 (value) >>` | `AttributeError: 'str' object has no attribute 'pdf_offset'` |
| `EMPTY_TRAILER_PDF` | the trailer is `<<>>` | `ValueError: min() iterable argument is empty` |
| `RECONSTRUCTED_XREF_PDF` | `startxref` is `0` | `AttributeError: 'int' object has no attribute 'pdf_offset'` |

### Before

```
=== WELL_FORMED_PDF: 41 matches
=== INTEGER_KEY_PDF: 31 matches
    WARN: Parser _LazyPDFParser for MIME type application/pdf raised an exception while parsing
          PDF document: 'str' object has no attribute 'pdf_offset'
=== EMPTY_TRAILER_PDF: 25 matches
    WARN: Parser _LazyPDFParser for MIME type application/pdf raised an exception while parsing
          PDF document: min() iterable argument is empty
=== RECONSTRUCTED_XREF_PDF: 34 matches
    WARN: Parser _LazyPDFParser for MIME type application/pdf raised an exception while parsing
          PDF document: 'int' object has no attribute 'pdf_offset'
```

`INTEGER_KEY_PDF` loses its `Trailer` and its whole `XRefTable`; `EMPTY_TRAILER_PDF` loses its
`XRefTable`.

### After

```
=== WELL_FORMED_PDF: 41 matches
=== INTEGER_KEY_PDF: 50 matches
    WARN: Skipping PDF dictionary key '42' because it has no byte provenance
=== EMPTY_TRAILER_PDF: 32 matches
=== RECONSTRUCTED_XREF_PDF: 34 matches
    WARN: Skipping 2 rows of a PDFXRefFallback cross-reference table that have no byte provenance
```

The well-formed control is byte-for-byte unchanged. Each malformed file keeps everything it had and
gains back what the abandoned generator used to cost it.

## One correction to the issue

The issue expects case 2 to fail with an `AttributeError` on the synthetic `{"Root": {}}` trailer
that `InstrumentedPDFDocument` injects at `polyfile/pdf.py:983-984`. That dictionary never reaches
`pdf_parser`: `__init__` patches `PDFXRef.get_trailer` inside a `try` and restores it in the
`finally`, so by the time `pdf_parser` calls `xref.get_trailer()` it gets the document's real
trailer back. A PDF with no `/Root` does fail on the reported line, but with the
`ValueError: min() arg is an empty sequence` that the issue lists as the other failure mode for it.
The guard covers both, since a plain `str` key has no provenance either.

## What the fix does

`has_provenance(obj)` replaces the `hasattr(obj, "pdf_offset") and hasattr(obj, "pdf_bytes")` pairs
that were already spelled out in four places, and the three unguarded sites now use it:

- `parse_dict` checks the key as well as the value. The value guard's policy is unchanged, only
  moved into `dict_value_with_provenance`: an empty list is a `log.debug`, anything else that
  cannot be positioned is a `log.warning`, and either way the entry is skipped.
- `parse_trailer` keeps only the entries whose key and value both carry provenance, and returns
  without yielding when none do, instead of reducing an empty sequence.
- `parse_xref` keeps only the rows `xref_row_span` can measure. `PDFXRefFallback` subclasses
  `PDFXRef`, so it passes the `isinstance` check, but it reconstructs the table with its own `load`
  (`pdfminer/pdfdocument.py`, `self.offsets[objid] = (None, pos, genno)`) and bypasses this
  module's `load_xref` override, so every one of its rows holds plain integers. They are now
  counted and reported rather than fatal.

Extracting `parse_dict`, `parse_trailer`, `parse_xref` and `parse_xref_row` takes `parse_object`
from cyclomatic complexity 17 to 11 and `pdf_parser` from 14 to 11. Both were already over the
project's limit of 10 on `master`; getting them under it means restructuring the type dispatch and
the `PSBytes` branch, which is not what this issue asks for.

`parse_xref_row` moves the `Position` and `Generation` cells over verbatim, including the two calls
that pass the freshly created `Submatch` to `parse_object` instead of the cell. Those calls are
no-ops, and fixing them changes PolyFile's output rather than guarding it, so they are filed
separately as #3542.

### The catch-all is left alone

`Matcher.handle_mimetype` still catches `Exception` and logs a warning. It is shared by every
parser, and how PolyFile reports a parser that fails outright is a separate, cross-cutting
decision from whether the PDF parser should be failing on these inputs at all. What changes here is
that the PDF parser no longer reaches it: the degradation is reported per skipped entry, at
`WARNING`, by the code that knows what was skipped and why, which is strictly more informative than
one warning that discards the rest of the tree.

## What the tests pin

`TestMalformedPDFMatchTree` in `tests/test_pdf.py` runs the full `Matcher` over each of the four
PDFs and asserts on the resulting match names and on the warnings, not on exceptions. Every test
asserts that no `polyfile` warning contains `raised an exception`, which is the symptom, and then:

- `test_well_formed_pdf_is_mapped_completely` asserts the whole tree is there and nothing is
  logged, so the guards cannot quietly start dropping valid structures.
- `test_empty_trailer_still_maps_the_xref_table` asserts the `XRefTable` and both `XRefRow`
  submatches survive an empty trailer. They did not before.
- `test_reconstructed_xref_rows_are_skipped` asserts the objects and the trailer are still mapped,
  no `XRefTable` is claimed for a table that maps to nothing, and the warning names
  `PDFXRefFallback` and the row count.
- `test_dictionary_key_without_provenance_is_skipped` asserts all three objects, the trailer, and
  all three cross-reference rows are mapped, and that exactly one warning names the skipped key.

Reverting `polyfile/pdf.py` fails the three malformed cases with the three errors above, and leaves
the control passing.

## Verification

- Blocking lint: 0 findings.
- Complexity pass: 172 findings, identical to `master` except that `parse_object` drops from 17 to
  11 and `pdf_parser` from 14 to 11. No new finding.
- `uv run pytest tests --ignore=tests/test_corkami.py`: 253 passed, 866 subtests passed. This
  includes the 88-stem libmagic corpus in `tests/test_magic.py`, which the change cannot affect —
  no magic definition and no matching code is touched, only the PDF parser's submatch tree.
- `uvx pip-audit`: no known vulnerabilities.
- Parser differential over 15 PDFs (the 4 new fixtures, 5 more malformed variants,
  `testdata/javascript.pdf`, and 5 PDFs from `/usr/share/cups/ipptool/`), comparing every match's
  name, offset, and length: **zero regressions**. 13 files are byte-for-byte identical; the 2 that
  change only gain matches, and the gained matches are a suffix of the existing tree in both cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
