### PR TITLE
Remove superlinear regex backtracking from two definitions

### DIFF
--- a/docs/updating_libmagic_defs.md
+++ b/docs/updating_libmagic_defs.md
@@ -29,9 +29,15 @@ list of filenames to update.
 ## Local patches
 
 A definition file copied from `Magdir` may still carry a PolyFile-specific patch. As of libmagic
-5.48 there is one: `c-lang` rewrites the C++ class regex to remove exponential backtracking, because
-libmagic matches with a POSIX engine and PolyFile matches with Python's `re`. See
-[#3411](https://github.com/trailofbits/polyfile/issues/3411).
+5.48 there are two, and both exist for the same reason: libmagic matches with a POSIX engine, while
+PolyFile matches with Python's `re`, which backtracks. A pattern that costs libmagic one pass can
+cost PolyFile superlinear time, so each patch rewrites a pattern into one that accepts and rejects
+the same inputs without the backtracking.
+
+| File | Patch | Issue |
+|---|---|---|
+| `c-lang` | The C++ class regex, which backtracked exponentially on a header with CRLF line endings. | [#3411](https://github.com/trailofbits/polyfile/issues/3411) |
+| `gentoo` | The `gentoo-manifest` regex, whose `[[:print:]]` overlaps `[[:space:]]` and backtracked quartically on a run of whitespace. | [#3473](https://github.com/trailofbits/polyfile/issues/3473) |
 
 The sync overwrites these patches. Before you copy, list them:
 

--- a/polyfile/http/matcher.py
+++ b/polyfile/http/matcher.py
@@ -12,8 +12,17 @@ HTTP_MIME_TYPE: str = "message/x-http"
 HTTP_11_MIME_TYPE: str = f"{HTTP_MIME_TYPE}; version=1.1"
 
 
-# Register a magic matcher for HTTP 1.1 headers:
-with ExactNamedTempfile(b"""0 regex/s [^\\\\n]*?\\\\s+HTTP/1.1\\\\s*$ HTTP 1.1
+# Register a magic matcher for HTTP 1.1 headers.
+#
+# The pattern reads "a line whose last whitespace-separated token is HTTP/1.1". A carriage return
+# satisfies both `[^\n]` and `\s`, so without the anchor and the lookbehind a run of them splits
+# between the two quantifiers in quadratically many ways, and Python's backtracking engine tries
+# every one (issue #3527). `\^` keeps the search from restarting inside a line it has already
+# rejected, and `(?<!\s)` pins `\s+` to the whole whitespace run. Neither changes which byte ranges
+# the pattern matches: a match that starts mid-line can always be extended left to the line start,
+# and a split that leaves whitespace at the end of `[^\n]*?` is reached earlier by the shorter one
+# that gives that whitespace to `\s+`.
+with ExactNamedTempfile(b"""0 regex/s \\^[^\\\\n]*?(?<!\\\\s)\\\\s+HTTP/1.1\\\\s*$ HTTP 1.1
 !:mime """ + HTTP_11_MIME_TYPE.encode("utf-8") + b"""
 >0 string GET GET request header
 >0 string POST POST request header

--- a/polyfile/magic_defs/gentoo
+++ b/polyfile/magic_defs/gentoo
@@ -35,7 +35,7 @@
 # <tag> <filename> <size> <hash-name> <hash-value>...
 # (<tag>'s already been matched prior to calling)
 0	name	gentoo-manifest
->&0	regex	[[:space:]]+[[:print:]]+[[:space:]]+[[:digit:]]+[[:space:]]+[[:alnum:]]+[[:space:]]+[[:xdigit:]]{32}	Gentoo Manifest (GLEP 74)
+>&0	regex	(?<![[:space:]])([[:space:]]+[[:graph:]]([[:print:]]*[[:graph:]])?|[[:space:]][\t\n\v\f\r]*\040)[[:space:]]+[[:digit:]]+[[:space:]]+[[:alnum:]]+[[:space:]]+[[:xdigit:]]{32}	Gentoo Manifest (GLEP 74)
 !:mime	application/vnd.gentoo.manifest
 
 # Summary: Gentoo ebuild and eclass files

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -3,7 +3,6 @@ import gzip
 import os
 import subprocess
 import sys
-import time
 import zlib
 from itertools import chain
 from pathlib import Path
@@ -589,18 +588,30 @@ class MagicTest(TestCase):
 
 MATCH_TIMEOUT_SECONDS: int = 60
 
+MATCH_BUDGET_SECONDS: float = 5.0
+"""The seconds a classification may take before `match_in_subprocess` fails the test.
+
+Every input these tests classify takes well under a tenth of a second once its definition is fixed,
+and tens of seconds or more while it is broken, so the budget is loose enough to survive a loaded
+runner and still separate the two.
+"""
+
 MATCH_SCRIPT: str = """
 import sys
+import time
 from polyfile.magic import MagicMatcher
 with open(sys.argv[1], "rb") as f:
     data = f.read()
-for match in MagicMatcher.DEFAULT_INSTANCE.match(data):
+matcher = MagicMatcher.DEFAULT_INSTANCE
+started = time.monotonic()
+for match in matcher.match(data):
     _ = set(match.mimetypes)
+print(f"elapsed {time.monotonic() - started}")
 """
 
 
 class MagicMatchingRegressionTest(TestCase):
-    """Regression tests for the matching hang reported in issue #3411."""
+    """Regression tests for the matching hangs reported in issues #3411, #3473, and #3527."""
 
     # This header uses CRLF line endings, so the `}` that closes the class is never the last
     # character on a line and the `c-lang` C++ class test can never succeed. Reduced from the
@@ -658,43 +669,62 @@ class MagicMatchingRegressionTest(TestCase):
 
         return Match(MagicMatcher.DEFAULT_INSTANCE, MatchContext(b""), results()), produced
 
-    def match_in_subprocess(self, data: bytes, timeout: int = MATCH_TIMEOUT_SECONDS) -> float:
-        """Matches `data` in a subprocess, so that a hang fails the test instead of stalling CI.
+    def definition_matcher(self, name: str) -> MagicMatcher:
+        """Builds a matcher from one shipped definition file, so that only its tests can match.
+
+        Args:
+            name: The file name in `polyfile/magic_defs`.
+
+        Returns:
+            A matcher holding just that file's tests.
+        """
+        for magic_def in MAGIC_DEFS:
+            if magic_def.name == name:
+                return MagicMatcher.parse(magic_def)
+        self.fail(f"Could not find the {name} definitions")
+
+    def match_in_subprocess(self, data: bytes, budget: float = MATCH_BUDGET_SECONDS) -> float:
+        """Matches `data` in a subprocess and fails unless the match fits in `budget` seconds.
+
+        The subprocess keeps a hang from stalling CI, and it times the match alone, so the budget
+        does not have to cover interpreter startup or building the default matcher.
 
         Args:
             data: The bytes to hand to the default matcher.
-            timeout: The number of seconds to wait before failing the test.
+            budget: The number of seconds the match may take.
 
         Returns:
-            The wall-clock seconds the subprocess took.
+            The seconds the match took.
         """
         with TemporaryDirectory() as tmp_dir:
             input_path = Path(tmp_dir) / "input"
             input_path.write_bytes(data)
             command = [sys.executable, "-c", MATCH_SCRIPT, str(input_path)]
-            started = time.monotonic()
             try:
-                subprocess.run(command, capture_output=True, check=True, timeout=timeout)
+                run = subprocess.run(command, capture_output=True, check=True,
+                                     timeout=MATCH_TIMEOUT_SECONDS)
             except subprocess.TimeoutExpired:
-                self.fail(f"Matching {len(data)} bytes took longer than {timeout} seconds")
+                self.fail(f"Matching {len(data)} bytes did not finish within "
+                          f"{MATCH_TIMEOUT_SECONDS} seconds")
             except subprocess.CalledProcessError as e:
                 error = e.stderr.decode("utf-8", "replace")
                 self.fail(f"Matching {len(data)} bytes failed: {error}")
-            return time.monotonic() - started
+        reported = [line for line in run.stdout.split(b"\n") if line.startswith(b"elapsed ")]
+        self.assertTrue(reported, f"The matching subprocess reported no time: {run.stdout!r}")
+        elapsed = float(reported[-1].split()[1])
+        self.assertLessEqual(elapsed, budget, (
+            f"Matching {len(data)} bytes took {elapsed:.3f} seconds, over the {budget} second "
+            f"budget"
+        ))
+        return elapsed
 
     def test_cpp_class_test_terminates(self):
         """Matching a C++ header used to backtrack exponentially in the `c-lang` class test."""
-        elapsed = self.match_in_subprocess(self.CRLF_CPP_HEADER)
-        print(f"Matched {len(self.CRLF_CPP_HEADER)} bytes in {elapsed:.3f} seconds")
+        self.match_in_subprocess(self.CRLF_CPP_HEADER)
 
     def test_cpp_class_test_semantics(self):
         """The rewritten `c-lang` class test accepts and rejects the same sources as before."""
-        for magic_def in MAGIC_DEFS:
-            if magic_def.name == "c-lang":
-                break
-        else:
-            self.fail("Could not find the c-lang definitions")
-        matcher = MagicMatcher.parse(magic_def)
+        matcher = self.definition_matcher("c-lang")
         source = b"class Foo {\n\tint x;\n};\n"
         self.assertIn("text/x-c++", self.mimetypes(matcher, source))
         self.assertNotIn("text/x-c++", self.mimetypes(matcher, source.replace(b"\n", b"\r\n")))

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -14,6 +14,7 @@ from uuid import UUID
 # from polyfile import logger
 import polyfile.der
 import polyfile.magic
+from polyfile.http.matcher import HTTP_11_MIME_TYPE
 from polyfile.magic import (
     DataType, MagicMatcher, MAGIC_DEFS, Match, MatchContext, RegexType, SearchType, StringType,
     TestResult
@@ -728,6 +729,21 @@ class MagicMatchingRegressionTest(TestCase):
         source = b"class Foo {\n\tint x;\n};\n"
         self.assertIn("text/x-c++", self.mimetypes(matcher, source))
         self.assertNotIn("text/x-c++", self.mimetypes(matcher, source.replace(b"\n", b"\r\n")))
+
+    def test_http_11_test_terminates(self):
+        """A run of carriage returns used to backtrack cubically in PolyFile's HTTP 1.1 test."""
+        self.match_in_subprocess(b"\r" * 8192)
+
+    def test_http_11_test_semantics(self):
+        """The rewritten HTTP 1.1 test accepts and rejects the same requests as before."""
+        matcher = MagicMatcher.DEFAULT_INSTANCE
+        self.assertIn(HTTP_11_MIME_TYPE, self.mimetypes(matcher, b"GET /x HTTP/1.1\r\nHost: h\r\n"))
+        self.assertIn(HTTP_11_MIME_TYPE, self.mimetypes(matcher, b"junk\nPOST / \t HTTP/1.1 \n"))
+        # the pattern anchors on the end of a line, not on the end of the data
+        self.assertIn(HTTP_11_MIME_TYPE, self.mimetypes(matcher, b"PUT / HTTP/1.1\nbody\n"))
+        self.assertNotIn(HTTP_11_MIME_TYPE, self.mimetypes(matcher, b"GET /x HTTP/1.1 y\r\n"))
+        self.assertNotIn(HTTP_11_MIME_TYPE, self.mimetypes(matcher, b"GET /xHTTP/1.1\r\n"))
+        self.assertNotIn(HTTP_11_MIME_TYPE, self.mimetypes(matcher, b"\r" * 32))
 
     def test_match_results_are_lazy(self):
         """Reading one result used to drain the whole result iterator."""

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -745,6 +745,24 @@ class MagicMatchingRegressionTest(TestCase):
         self.assertNotIn(HTTP_11_MIME_TYPE, self.mimetypes(matcher, b"GET /xHTTP/1.1\r\n"))
         self.assertNotIn(HTTP_11_MIME_TYPE, self.mimetypes(matcher, b"\r" * 32))
 
+    def test_gentoo_manifest_test_terminates(self):
+        """Whitespace after a Manifest tag used to backtrack quartically in `gentoo`."""
+        self.match_in_subprocess(b"DIST " + b" " * 500 + b"\n")
+
+    def test_gentoo_manifest_test_semantics(self):
+        """The rewritten `gentoo-manifest` test accepts and rejects the same lines as before."""
+        matcher = self.definition_matcher("gentoo")
+        mime = "application/vnd.gentoo.manifest"
+        entry = b"DIST foo-1.0.tar.gz 12345 BLAKE2B " + b"0123456789abcdef" * 4 + b"\n"
+        self.assertIn(mime, self.mimetypes(matcher, entry))
+        # `[[:print:]]` holds a space, so upstream's pattern also accepts a file name made only of
+        # whitespace, and the rewrite keeps accepting it
+        self.assertIn(mime, self.mimetypes(matcher, b"DIST   1 a " + b"0" * 32 + b"\n"))
+        self.assertNotIn(mime, self.mimetypes(matcher, b"DIST \t1 a " + b"0" * 32 + b"\n"))
+        self.assertNotIn(mime, self.mimetypes(matcher, entry.replace(b" 12345", b" x12345")))
+        self.assertNotIn(mime, self.mimetypes(matcher, b"DIST foo 1 BLAKE2B " + b"0" * 31 + b"\n"))
+        self.assertNotIn(mime, self.mimetypes(matcher, b"DIST " + b" " * 500 + b"\n"))
+
     def test_match_results_are_lazy(self):
         """Reading one result used to drain the whole result iterator."""
         data = b"#!/bin/sh\nexec cat \"$@\"\n"


### PR DESCRIPTION
Closes #3529
Closes #3527
Closes #3473

Both sub-issues are the same bug in two definitions: a pattern whose adjacent character classes
overlap, so a run of whitespace divides between two quantifiers in many ways and Python's
backtracking engine tries all of them. libmagic is unaffected, because it compiles its tests with a
POSIX engine (`file/src/softmagic.c:2160` into `regcomp` at `file/src/funcs.c:761`) rather than a
backtracking one. They are bundled because the fix for each needs the same thing from the test
suite: a bound on how long a classification may take.

## Merge order

Last in Wave 1. The other nine PRs (#3470, #3462, #3476, #3464, #3479, #3501, #3499, #3500, and
#3506) are all on `master`, and this branch is merged up to `d96dd09`, so it carries every one of
them. Nothing downstream has to rebase onto this.

The merge conflicted in one file, `docs/updating_libmagic_defs.md`. #3538 rewrote its local-patch
section around the new drift test, which now owns the list of patched definitions, so the resolution
keeps master's text and only names `gentoo` alongside `c-lang` in the worked example, rather than
repeating the list in prose.

Five sibling PRs changed `tests/test_magic.py`; that file merged clean.

## What this completes for #3538

The patch to `polyfile/magic_defs/gentoo` makes that file differ from `file/magic/Magdir/gentoo`.
#3538 anticipated this: its `LOCAL_PATCHES` already maps `gentoo` to #3473, and its
`PENDING_PATCHES` disarmed the allowlist check while `gentoo` was still a plain copy of upstream.
Its `test_shared_definitions_are_byte_identical` fails the moment the patch lands, with an error
telling you to delete the name.

This PR does that: `PENDING_PATCHES` is now an empty `frozenset`, which arms the allowlist check for
`gentoo`. The symbol stays, since it is the general mechanism for adding an allowlist entry ahead of
the patch it describes, and its docstring no longer narrates the #3473 case that has closed.
`pytest tests/test_magic_defs_drift.py` passes: 6 tests, 357 subtests.

## Reproducers

### #3527, PolyFile's HTTP 1.1 test

The reproducer from the issue, classifying a file of carriage returns end to end:

| Carriage returns | Before | After |
| --- | --- | --- |
| 400 | 0.085 s | 0.015 s |
| 800 | 0.191 s | 0.015 s |
| 1,600 | 1.428 s | 0.016 s |
| 3,200 | 11.263 s | 0.017 s |
| 8,192 | 191.1 s | 0.022 s |

Each doubling used to cost about eight times as much. It now costs nothing measurable: the 0.015 s
floor is the rest of the matcher running over the file.

### #3473, the `gentoo-manifest` test

The issue's end-to-end reproducer, `b"DIST " + b" " * 500 + b"\n"`, went from 23.4 s to 0.014 s.
Against the pattern alone, on a buffer of spaces:

| Spaces | Before | After |
| --- | --- | --- |
| 100 | 0.041 s | < 0.0001 s |
| 200 | 0.614 s | < 0.0001 s |
| 400 | 9.697 s | < 0.0001 s |
| 800 | 152.737 s | < 0.0001 s |

Each doubling used to cost about sixteen times as much, so the 8 KiB regex window was never going to
finish. Classifying 8,198 bytes of the same shape now takes 0.021 s.

## What the fixes do

### `polyfile/http/matcher.py`

The pattern was `[^\n]*?\s+HTTP/1.1\s*$`, which reads "a line whose last whitespace-separated token
is `HTTP/1.1`". A carriage return satisfies both `[^\n]` and `\s`, so for every starting position
the lazy prefix and the greedy `\s+` can divide the run between them in quadratically many ways.

It is now `\^[^\n]*?(?<!\s)\s+HTTP/1.1\s*$`. Neither addition changes the span the pattern reports:

- A match that starts inside a line extends left one character at a time, because `[^\n]*?` accepts
  anything the prefix has already crossed. So the leftmost match, which is the one
  `re.search` returns, starts at a line start already, and `\^` only prunes positions that cannot
  be leftmost. `\^` also keeps its meaning under libmagic's own engine, which compiles with
  `REG_NEWLINE`.
- A division that ends `[^\n]*?` on whitespace is preceded, in the lazy ordering, by the shorter one
  that hands that whitespace to `\s+` and reaches the same `HTTP/1.1`. The engine therefore accepts
  the shorter one first and never reaches the division `(?<!\s)` removes.

### `polyfile/magic_defs/gentoo`

The `gentoo-manifest` test was
`[[:space:]]+[[:print:]]+[[:space:]]+[[:digit:]]+[[:space:]]+[[:alnum:]]+[[:space:]]+[[:xdigit:]]{32}`.
`[[:alnum:]]`, `[[:digit:]]`, and `[[:xdigit:]]` are all disjoint from `[[:space:]]`, so the only
overlap is the space character, which `[[:print:]]` holds: the first three quantifiers can divide a
run of spaces, from every starting position, which is the fourth-power growth above.

Since the space is the only shared character, the pattern accepts exactly two shapes, and writing
them out removes the ambiguity:

- `[[:graph:]]([[:print:]]*[[:graph:]])?` is the file name as a printable run that begins and ends
  with a non-space. Any leading or trailing spaces it had belong to the `[[:space:]]+` on either
  side, which accepts them just as well, so nothing is lost.
- `[[:space:]][\t\n\v\f\r]*\040` is the remaining shape: a file name made only of spaces, which
  collapses to one space with the rest of the whitespace on either side of it. Taking the first
  space that is not the run's first character finds a division whenever one exists, because the
  valid positions for that space are exactly those with at least one whitespace character on each
  side.

`(?<![[:space:]])` then keeps the search from restarting inside a whitespace run it has already
tried, on the same reasoning as the HTTP anchor: the leading `[[:space:]]+` accepts every character
it crosses, so a match starting inside a run extends left to the run's start. The region PolyFile
hands the pattern begins at the test's own offset (`RegexType.subject`, mirroring
`file/src/softmagic.c:2393-2405`), where a lookbehind is vacuously true, so this only prunes
positions that cannot be leftmost.

This makes `gentoo` the second locally patched definition after `c-lang`, and
`docs/updating_libmagic_defs.md` now lists both in a table so a `Magdir` sync does not silently
revert them. The lookbehind is Python-only syntax, which is fine here: nothing ever hands
`polyfile/magic_defs/` to libmagic, and `tests/test_corkami.py` builds its oracle from
`file/magic/Magdir` instead.

## Semantic equivalence

`test_cpp_class_test_semantics` is the model, and both rewrites get the same treatment: a test that
pins the behavior, plus a differential over generated inputs.

`tests/test_magic.py::MagicMatchingRegressionTest::test_http_11_test_semantics` and
`::test_gentoo_manifest_test_semantics` **pass against `master`'s definitions as well as the
rewritten ones**, which is what makes them equivalence tests rather than assertions about the new
patterns. The `gentoo` one deliberately pins the whitespace-only file name that upstream's
`[[:print:]]` accepts, and that the rewrite keeps accepting, alongside the tab that neither accepts.

The differential compared `re.search` results, both whether a match was found and the exact span:

| Pattern | Exhaustive | Randomized | Disagreements |
| --- | --- | --- | --- |
| HTTP 1.1 | 12,093,235 inputs: every string of at most 9 bytes over {newline, carriage return, space, `H`, other} | 200,000 inputs built from HTTP fragments, whitespace, and control bytes | 0 |
| `gentoo-manifest` | 53,804,809 inputs: every string of at most 9 bytes over one representative of each class the pattern distinguishes | 200,000 inputs built from Manifest fields and whitespace | 0 |

The exhaustive runs shorten the fixed-length tail (`HTTP/1.1` to `H`, `{32}` to `{1}`) so that
enumeration reaches inputs long enough to match; neither rewrite touches that tail. The randomized
runs use the real patterns. An earlier candidate for the HTTP fix was rejected by this differential:
it agreed on every accept and reject, but reported a longer span when a second `HTTP/1.1` followed
on a later line.

The reference binary still reports `Gentoo Manifest (GLEP 74)` for a real Manifest entry, and
PolyFile reports it from the same offset, 4, for the same 62 bytes. The existing
`tests/unit/test_http.py::test_matching`, which pins the HTTP match to offset 0 and length 22, is
unchanged and still passes.

One consequence worth recording: both rewrites add characters that libmagic's `nonmagic`
(`file/src/apprentice.c:813-849`) counts as literals, so the strength these two tests score changes.
The HTTP 1.1 test, a level 0 test, goes from 40 to 45. The `gentoo-manifest` regex is a level 1 test
inside a named test, and `MagicMatcher._sort_tests` orders level 0 tests only, so its strength is
never read. Nothing observable moves: the corpus differential below reports the same matches in the
same order, and so does an HTTP request and a Manifest file.

## What the tests pin

`MATCH_BUDGET_SECONDS` and the rewritten `match_in_subprocess` turn the existing helper into a real
bound. It used to fail only when the subprocess ran past 60 seconds and threw away the elapsed time
it measured, so its one caller asserted nothing. The script now times the match alone, so the budget
does not have to cover interpreter startup or building the default matcher, and the helper fails the
test unless the match fits in five seconds. The 60-second process timeout stays as the guard against
a match that never returns.

Three tests sit on it, and each one fails with the fix reverted:

| Test | With the fix | Reverted |
| --- | --- | --- |
| `test_cpp_class_test_terminates` (#3411, pre-existing) | passes | n/a |
| `test_http_11_test_terminates`, 8,192 carriage returns | passes | `Matching 8192 bytes did not finish within 60 seconds` |
| `test_gentoo_manifest_test_terminates`, the issue's 506-byte input | passes | `Matching 506 bytes took 23.843 seconds, over the 5.0 second budget` |

Five seconds is more than two orders of magnitude above what any of these inputs costs now, so the
budget separates a working definition from a broken one without being sensitive to a loaded runner.

## Verification

- Blocking lint pass clean, and `flake8 --max-complexity=10 --max-line-length=127` clean on both
  changed Python files.
- `pytest tests --ignore=tests/test_corkami.py`: 278 passed, 1,244 subtests passed, including
  the four tests this PR adds.
- `pytest tests/test_magic_defs_drift.py`: 6 passed, 357 subtests passed, with the allowlist check
  armed for `gentoo`.
- `uvx pip-audit`: no known vulnerabilities.
- **Corpus differential: zero regressions across all 88 stems.** Both changes alter matching, so
  every `file/tests/*.testfile` was classified with `master`'s definitions at `d96dd09` and
  again with the rewritten ones, keeping every match description, the joined `-k` result where a `.flags` file asks
  for it, and the full MIME set for each stem. The two dumps are byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
