### PR TITLE
Resolve a relative offset after a search from the declared length

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -2426,6 +2426,23 @@ class SearchType(StringType):
             return 0
         return vallen * max(STRENGTH_MULT // vallen, 1)
 
+    def declared_length(self, expected: StringTest) -> int:
+        """Zero under the ``s`` flag, and the declared length of the value otherwise.
+
+        ``REGEX_OFFSET_START`` zeroes the length libmagic adds to where the search found its value,
+        so a following relative (`&`) offset resolves against the start of the match
+        (``file/src/softmagic.c:966-968``), the same rule `RegexType.matched_extent` applies.
+
+        Args:
+            expected: The parsed value this search looks for.
+
+        Returns:
+            The number of bytes to add to the offset the value was found at.
+        """
+        if self.match_to_start:
+            return 0
+        return super().declared_length(expected)
+
     def match(self, data: bytes, expected: StringTest) -> DataTypeMatch:
         return expected.search(data)
 
@@ -3388,8 +3405,9 @@ class ConstantMatchTest(MagicTest, Generic[T]):
         relation resolves against the declared length of the magic value rather than the number of
         bytes the match consumed (`file/src/softmagic.c:904-905` and `966-968`). The two differ
         when the `w` flag matches fewer blanks than the value declares. Both types measure that
-        length from where they found the value, which is where `MatchedTest.offset` already sits.
-        A `pstring` carries its own length prefix, so neither rule takes this path.
+        length from where they found the value, which is where `MatchedTest.offset` already sits,
+        and `SearchType.declared_length` zeroes it under the `s` flag. A `pstring` carries its own
+        length prefix, so neither rule takes this path.
 
         Args:
             match: The match that this test's data type produced.

--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -2293,6 +2293,21 @@ class StringType(DataType[StringTest]):
     def relation(self, expected: StringTest) -> str:
         return expected.relation
 
+    def declared_length(self, expected: StringTest) -> int:
+        """The bytes a following relative (`&`) offset counts from the start of the match.
+
+        This is libmagic's ``m->vallen``, the length the magic value declares rather than the
+        length the match consumed; the ``w`` flag lets the two differ
+        (``file/src/softmagic.c:904-905``).
+
+        Args:
+            expected: The parsed value this type looks for.
+
+        Returns:
+            The number of bytes to add to the offset the value was found at.
+        """
+        return expected.value_length
+
     def allows_invalid_offsets(self, expected: StringTest) -> bool:
         return isinstance(expected, NegatedStringTest)
 
@@ -3369,13 +3384,12 @@ class ConstantMatchTest(MagicTest, Generic[T]):
         wins: the `regex` `s` flag uses it to resolve against the start of the match instead of its
         end (`file/src/softmagic.c:959-963`).
 
-        Failing that, a relative (`&`) offset after a `string` test with an `=` relation resolves
-        against the declared length of the magic value rather than the number of bytes the match
-        consumed (`file/src/softmagic.c:904-905`). The two differ when the `w` flag matches fewer
-        blanks than the value declares. A `search` measures from where it found its value, which
-        PolyFile records as the extent it matched; libmagic adds the declared length there too, but
-        zeroes it for the `s` flag (`file/src/softmagic.c:966-968`), which PolyFile does not model
-        yet. A `pstring` carries its own length prefix, so neither rule takes this path.
+        Failing that, a relative (`&`) offset after a `string` or a `search` test with an `=`
+        relation resolves against the declared length of the magic value rather than the number of
+        bytes the match consumed (`file/src/softmagic.c:904-905` and `966-968`). The two differ
+        when the `w` flag matches fewer blanks than the value declares. Both types measure that
+        length from where they found the value, which is where `MatchedTest.offset` already sits.
+        A `pstring` carries its own length prefix, so neither rule takes this path.
 
         Args:
             match: The match that this test's data type produced.
@@ -3387,13 +3401,10 @@ class ConstantMatchTest(MagicTest, Generic[T]):
         """
         result = MatchedTest(self, offset=absolute_offset + match.initial_offset,
                              length=len(match.raw_match), value=match.value, parent=parent_match)
-        declares_its_length = (isinstance(self.data_type, StringType)
-                               and not isinstance(self.data_type, SearchType)
-                               and isinstance(self.constant, StringMatch))
         if match.relative_base is not None:
             result.relative_base = absolute_offset + match.relative_base
-        elif declares_its_length:
-            result.relative_base = result.offset + len(self.constant.string)
+        elif isinstance(self.data_type, StringType) and isinstance(self.constant, StringMatch):
+            result.relative_base = result.offset + self.data_type.declared_length(self.constant)
         return result
 
     def test(self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]) -> TestResult:

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1213,6 +1213,19 @@ class StringDataTypeTest(TestCase):
         self.assertEqual({"version 5.5, ASCII text"},
                          self.messages(definition, b"xxx VERS 5.5\nnext line\n"))
 
+    def test_search_relative_base_is_the_declared_length(self):
+        """`>&0` under a `search/w` read from the bytes the match consumed, not the value's length.
+
+        libmagic adds the declared length of the magic value to where the search found it
+        (`file/src/softmagic.c:966-968`), so `A\\ B` counts three bytes wherever it matches, even
+        where the `w` flag lets it consume two. Reading `xxABCD` reported `CD` instead of `D`.
+        """
+        definition = "0\tsearch/16/w\tA\\ B\tfound\n>&0\tstring\tx\t%s\n"
+        for data, expected in ((b"xxABCD", "D"), (b"xxA BCD", "CD"), (b"xxA \tBCD", "BCD")):
+            with self.subTest(data=data):
+                self.assertEqual({f"found {expected}, ASCII text, with no line terminators"},
+                                 self.messages(definition, data))
+
     def test_wildcard_string_stops_at_a_line_break(self):
         """A wildcard value ran to the first null byte, so a `%s` leaked the rest of the file.
 

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1226,6 +1226,16 @@ class StringDataTypeTest(TestCase):
                 self.assertEqual({f"found {expected}, ASCII text, with no line terminators"},
                                  self.messages(definition, data))
 
+    def test_search_s_flag_resolves_from_the_start_of_the_match(self):
+        """`s` on a `search` was parsed but never applied, so `>&0` skipped the matched value.
+
+        `REGEX_OFFSET_START` zeroes the length libmagic adds to where the search found its value
+        (`file/src/softmagic.c:966-968`). Reading `xxABCD` reported `CD` instead of `ABCD`.
+        """
+        definition = "0\tsearch/16/ws\tA\\ B\tfound\n>&0\tstring\tx\t%s\n"
+        self.assertEqual({"found ABCD, ASCII text, with no line terminators"},
+                         self.messages(definition, b"xxABCD"))
+
     def test_wildcard_string_stops_at_a_line_break(self):
         """A wildcard value ran to the first null byte, so a `%s` leaked the rest of the file.
 


### PR DESCRIPTION
Closes #3503

## Merge order

Wave 2, alongside #3530, #3507, and #3542. None of those touches the string or offset machinery, so
this can land in any order relative to them.

#3504 is blocked by this one and lands next. Its edit site is `StringMatch.matches`, about 1,200
lines away in `polyfile/magic.py`, so the source files do not conflict, but both add cases to
`StringDataTypeTest` in `tests/test_magic.py`. Rebase #3504 onto this before opening it.

**Helper #3504 should reuse:** this adds `StringType.declared_length(expected)`, which returns
libmagic's `m->vallen` for a string-family test and which `SearchType` overrides to return zero
under the `s` flag. It delegates to `StringTest.value_length`, which already existed. If #3504 needs
the declared length of a value, use `value_length` (or `declared_length` when the type's flags
matter) rather than adding a second spelling.

## Reproducer

```console
$ printf '0\tsearch/16/w\tA\\ B\tfound\n>&0\tstring\tx\t%%s\n' > searchlen.magic
$ printf 'xxABCD' > searchlen.bin
$ TZ=UTC ./file/src/file -b -m searchlen.magic searchlen.bin
found D, ASCII text, with no line terminators
```

The value `A\ B` declares three bytes, and the `w` flag lets it match the two bytes `AB` at offset
2. libmagic resolves `>&0` to `2 + 3 = 5` and reports `D`.

Before, PolyFile resolved it to `2 + 2 = 4`:

```
{'found CD, ASCII text, with no line terminators'}
```

After:

```
{'found D, ASCII text, with no line terminators'}
```

The same definition with the `s` flag (`search/16/ws`) is a second case this fixes. libmagic reports
`found ABCD`; PolyFile reported `found CD` before this change and reports `found ABCD` after. Three
more spellings were checked against the reference binary and agree byte for byte:

| definition | data | `file` 5.48 | before | after |
| --- | --- | --- | --- | --- |
| `search/16/w` `A\ B` | `xxABCD` | `found D` | `found CD` | `found D` |
| `search/16/w` `A\ B` | `xxA BCD` | `found CD` | `found CD` | `found CD` |
| `search/16/w` `A\ B` | `xxA \tBCD` | `found BCD` | `found CD` | `found BCD` |
| `search/16/ws` `A\ B` | `xxABCD` | `found ABCD` | `found CD` | `found ABCD` |

## What the fix does

`ConstantMatchTest.matched_test` excluded `SearchType` from the declared-length rule that #3483
introduced, because applying the rule to a search regressed `gedcom`. The observation was right and
the explanation was wrong: the regression came from measuring the declared length from the test's
**start offset** rather than from **where the search found its value**. Those differ by the search
distance.

libmagic measures from the match for both types:

- `FILE_STRING` with `reln == '='`: `o = ms->offset + m->vallen` (`file/src/softmagic.c:904-905`).
- `FILE_SEARCH`: `vlen = m->vallen; o = ms->search.offset + vlen - offset`
  (`file/src/softmagic.c:966-968`), where `ms->search.offset` has already been advanced to the found
  position by `magiccheck` (`file/src/softmagic.c:2351` and `2366`).

`MatchedTest.offset` already sits at the found position, because `matched_test` builds it from
`DataTypeMatch.initial_offset` and `StringMatch.search` records `m.start()` there. So dropping the
`SearchType` exclusion and keeping the existing `result.offset + <declared length>` expression is
enough, and it is what libmagic does for both types.

The declared length now comes from `StringType.declared_length`, which names libmagic's `m->vallen`
in one place. `SearchType` overrides it to return zero when the `s` flag is set:
`REGEX_OFFSET_START` zeroes the length libmagic adds, so a following relative offset resolves
against the start of the match. `SearchType` already parsed the flag but never acted on it;
`RegexType.matched_extent` applies the same rule for `regex`, through
`DataTypeMatch.relative_base`.

## What the tests pin

Both tests live in `StringDataTypeTest` in `tests/test_magic.py`, beside the two the exclusion was
added with.

- `test_search_relative_base_is_the_declared_length` pins the reproducer and its two siblings from
  the table above. Restoring the `SearchType` exclusion makes the `xxABCD` and `xxA \tBCD` subtests
  fail with `found CD` instead of `found D` and `found BCD`.
- `test_search_s_flag_resolves_from_the_start_of_the_match` pins the `s` flag. Deleting the
  `match_to_start` branch from `SearchType.declared_length` makes it fail with `found D` instead of
  `found ABCD`; restoring the exclusion makes it fail with `found CD`.

Both failures were confirmed by breaking each half of the fix separately and rerunning.

## Verification

- Corpus differential over all 88 `file/tests/*.testfile` stems, with the same normalization as
  `corpus_result_matches`, sidecar globbing, and `.flags` handling: **88 passing before, 88 passing
  after, zero regressions, and not one stem's message text changed.**
- `gedcom` is the canary, because it is what regressed under the naive form of this fix. It still
  reports `GEDCOM genealogy text version 5.5, ASCII text`, matching `file/tests/gedcom.result`
  exactly. `test_gedcom_reports_one_version_and_not_four_lines` also still passes.
- `uv run pytest tests --ignore=tests/test_corkami.py`: 280 passed, 1247 subtests passed.
- Blocking lint pass (`--select=E9,F63,F7,F82`): 0 findings.
- Complexity pass over `polyfile/magic.py` and `tests/test_magic.py`: identical to `master`, no new
  findings.
- `uvx pip-audit`: no known vulnerabilities.

## Note on the `x`, `<`, and `>` relations

libmagic's `FILE_SEARCH` case reads `m->vallen` without checking the relation, while its
`FILE_STRING` case checks for `=` or `!` first. This change keeps PolyFile's existing restriction to
a `StringMatch` constant, which is the `=` relation, so a `search` with a wildcard or a length
relation is unchanged. No shipped definition pairs one with a relative offset, and widening it is a
separate behavior change that this issue does not authorize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
