### PR TITLE
Parse the cells of a cross-reference row

### DIFF
--- a/polyfile/pdf.py
+++ b/polyfile/pdf.py
@@ -1360,7 +1360,7 @@ def parse_xref_row(row, row_start: int, matcher: Matcher, parent: Match, pdf_hea
         parent=parent
     )
     yield ret
-    yield from parse_object(ret, matcher=matcher, parent=ret, pdf_header_offset=pdf_header_offset)
+    yield from parse_object(pos, matcher=matcher, parent=ret, pdf_header_offset=pdf_header_offset)
     ret = Submatch(
         "Generation",
         b"",
@@ -1369,7 +1369,8 @@ def parse_xref_row(row, row_start: int, matcher: Matcher, parent: Match, pdf_hea
         parent=parent
     )
     yield ret
-    yield from parse_object(ret, matcher=matcher, parent=ret, pdf_header_offset=pdf_header_offset)
+    yield from parse_object(gen_no, matcher=matcher, parent=ret,
+                            pdf_header_offset=pdf_header_offset)
 
 
 # Note: PDF parser is registered lazily in __init__.py to defer pdfminer import

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1,7 +1,8 @@
 """
 Unit tests for PDF parsing functionality, particularly edge cases with empty lists
-and malformed dictionary values that were causing crashes (issue #12), and the byte-provenance
-guards that keep a malformed PDF from truncating the match tree (issue #3464).
+and malformed dictionary values that were causing crashes (issue #12), the byte-provenance
+guards that keep a malformed PDF from truncating the match tree (issue #3464), and the
+cross-reference row cells that were never parsed (issue #3542).
 """
 import base64
 import logging
@@ -353,6 +354,52 @@ class TestMalformedPDFMatchTree(unittest.TestCase):
             ["Skipping PDF dictionary key '42' because it has no byte provenance"],
             warnings.messages("PDF")
         )
+
+
+class TestXRefRowCells(unittest.TestCase):
+    """Regression tests for the cross-reference row cells in issue #3542."""
+
+    def match(self, data: bytes) -> List[Match]:
+        """Runs the full matcher over a PDF held in memory.
+
+        Args:
+            data: The contents of the PDF to match.
+
+        Returns:
+            Every match PolyFile produced, in the order it produced them. The list has to be
+            materialized before the tree is walked, because a match's children are appended as
+            the parser yields them.
+        """
+        with NamedTemporaryFile(suffix=".pdf") as f:
+            f.write(data)
+            f.flush()
+            return list(Matcher(parse=True).match(f.name))
+
+    def test_row_cells_map_the_integers_they_hold(self):
+        """Every cell of a cross-reference row parses its contents.
+
+        `parse_object` was handed the `Submatch` that had just been created for the cell instead
+        of the cell itself. A `Submatch` carries no `pdf_offset`, so the call fell through every
+        branch and yielded nothing: `Position` and `Generation` were leaves, and the offsets the
+        table records never reached the output.
+        """
+        cells = [m for m in self.match(WELL_FORMED_PDF) if m.name in ("Position", "Generation")]
+        self.assertEqual(4, len(cells))
+        for cell in cells:
+            self.assertEqual(["PSInt"], [c.name for c in cell.children])
+            self.assertEqual(cell.offset, cell.children[0].offset)
+            self.assertEqual(cell.length, cell.children[0].length)
+        # object 1 is at byte 9 and object 2 at byte 58, both of generation 0
+        self.assertEqual([9, 0, 58, 0], [cell.children[0].match for cell in cells])
+
+    def test_reconstructed_xref_yields_no_cells(self):
+        """A rebuilt table maps to nothing rather than dereferencing its plain integers.
+
+        `PDFXRefFallback` stores positions as `int`, which `parse_object` has to skip. The rows
+        are dropped before `parse_xref_row` sees them, so no cell reaches the tree at all.
+        """
+        matches = self.match(RECONSTRUCTED_XREF_PDF)
+        self.assertEqual([], [m.name for m in matches if m.name in ("Position", "Generation")])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #3542

## Merge order

Wave 2, alongside #3530, #3507, and #3503. This PR is independent of those three: it touches
only `polyfile/pdf.py` and `tests/test_pdf.py`, and no other open PR touches either file, so the
order within the wave does not matter. It builds on #3545 (issue #3464), which has merged, and
whose extracted `parse_xref`, `xref_row_span`, and `parse_xref_row` it edits. Nothing downstream
has to rebase onto it.

## The defect

`parse_xref_row` passed the `Submatch` it had just created to `parse_object` for the `Position`
and `Generation` cells of a cross-reference row, instead of passing the cell itself:

```python
ret = Submatch("Position", b"", relative_offset=pos.pdf_offset - row_start, length=pos.pdf_bytes,
               parent=parent)
yield ret
yield from parse_object(ret, matcher=matcher, parent=ret, pdf_header_offset=pdf_header_offset)
```

A `Submatch` carries no `pdf_offset`, so `parse_object` fell through every branch, including the
final `has_provenance(obj)` one, and yielded nothing. Both calls were no-ops. The `ObjectID` cell
immediately above passes `obj_id`, which is what the other three call sites of `parse_object` do
as well.

This predates #3464 and was deliberately left out of #3545, because fixing it changes PolyFile's
output rather than adding a guard.

## Reproducer

`tests/test_pdf.py:WELL_FORMED_PDF`, a two-object PDF with a classic cross-reference table.

Before:

```
XRefTable offset=139 length=36 children=['XRefRow', 'XRefRow']
  XRefRow offset=139 length=16 children=['Position', 'Generation']
    Position offset=139 length=10 children=[]
    Generation offset=150 length=5 children=[]
  XRefRow offset=159 length=16 children=['Position', 'Generation']
    Position offset=159 length=10 children=[]
    Generation offset=170 length=5 children=[]

Position/Generation cells: 4
cells with no children: 4
```

and, directly:

```python
>>> m = Match("Position", b"", relative_offset=0, length=10, matcher=matcher)
>>> list(parse_object(m, matcher=matcher, parent=m, pdf_header_offset=0))
[]
```

After:

```
XRefTable offset=139 length=36 children=['XRefRow', 'XRefRow']
  XRefRow offset=139 length=16 children=['Position', 'Generation']
    Position offset=139 length=10 children=['PSInt']
      PSInt offset=139 length=10 children=[]
    Generation offset=150 length=5 children=['PSInt']
      PSInt offset=150 length=5 children=[]
  XRefRow offset=159 length=16 children=['Position', 'Generation']
    Position offset=159 length=10 children=['PSInt']
      PSInt offset=159 length=10 children=[]
    Generation offset=170 length=5 children=['PSInt']
      PSInt offset=170 length=5 children=[]

Position/Generation cells: 4
cells with no children: 0
```

## The fix

Pass `pos` and `gen_no`. Each cell now gets one `PSInt` submatch at the cell's own offset and
length, carrying the value the table records. The `--format json` output for the fixture above
goes from cells whose `value` is `b''` to:

```
Position value="b''" offset=139 size=10
  PSInt value='9' offset=139 size=10
Generation value="b''" offset=150 size=5
  PSInt value='0' offset=150 size=5
```

Object 1 is at byte 9 and object 2 at byte 58, both of generation 0, which is what the table says.

The fix adds no dereference. `parse_object` positions its submatch from `obj.pdf_offset` only
inside the `has_provenance(obj)` branch, so a cell holding a plain integer is still skipped.
`PDFXRefFallback` rows never reach `parse_xref_row` in the first place, because `xref_row_span`
drops them in `parse_xref`, which is the guard #3545 added.

## Output change

This is the reason the issue was filed separately, so here is the size of it. Every match's name,
offset, and length across 15 PDFs, before and after: the four `tests/test_pdf.py` fixtures, five
malformed or unusual variants, `testdata/javascript.pdf`, and the five PDFs in
`/usr/share/cups/ipptool/` (which ship gzipped, and were decompressed first).

| PDF | matches before | matches after | delta | `XRefRow`s |
| --- | ---: | ---: | ---: | ---: |
| `cups/document-a4.pdf` | 3609 | 3833 | +224 | 112 |
| `cups/document-letter.pdf` | 3574 | 3798 | +224 | 112 |
| `cups/onepage-a4.pdf` | 1845 | 1997 | +152 | 76 |
| `cups/onepage-letter.pdf` | 1867 | 2021 | +154 | 77 |
| `cups/testfile.pdf` | 2658 | 2818 | +160 | 80 |
| `WELL_FORMED_PDF` | 41 | 45 | +4 | 2 |
| `EMPTY_TRAILER_PDF` | 32 | 36 | +4 | 2 |
| `INTEGER_KEY_PDF` | 50 | 56 | +6 | 3 |
| `RECONSTRUCTED_XREF_PDF` | 34 | 34 | 0 | 0 |
| `testdata/javascript.pdf` | 136 | 136 | 0 | 0 |
| variant: leading preamble before `%PDF` | 43 | 47 | +4 | 2 |
| variant: truncated tail | 34 | 34 | 0 | 0 |
| variant: two-subsection table | 46 | 52 | +6 | 3 |
| variant: incremental update, two tables | 64 | 70 | +6 | 3 |
| variant: free entries only | 10 | 10 | 0 | 0 |
| **total** | **14043** | **14987** | **+944** | **472** |

- 944 matches gained, 0 lost. Every existing match keeps its name, offset, and length.
- Every gained match is a `PSInt`: 472 under `Position` and 472 under `Generation`, which is
  exactly two per cross-reference row, and every one of the 944 has the same offset and length as
  the cell it sits under.
- A representative PDF gains two matches per cross-reference row: 6.2% more matches for
  `cups/document-a4.pdf`, 9.8% for `WELL_FORMED_PDF`.
- The five PDFs that gain nothing are the ones with no mappable table: three where pdfminer
  rebuilds the table with `PDFXRefFallback`, one whose table holds only free entries, and one with
  a truncated tail. They confirm the guards from #3545 still hold.

`docs/json_format.md` and `polyfile/templates/` name no node types, so neither needs a change; the
HTML hex viewer renders the new nodes without one.

No corpus differential: this PR touches no libmagic matching, only the PDF parser's match tree.

## What the test pins

`TestXRefRowCells.test_row_cells_map_the_integers_they_hold` asserts that each of the four cells
of `WELL_FORMED_PDF` has exactly one `PSInt` child, at the cell's offset and length, and that the
four values are `[9, 0, 58, 0]`. Restoring the `ret` argument fails it with
`AssertionError: Lists differ: ['PSInt'] != []`.

`TestXRefRowCells.test_reconstructed_xref_yields_no_cells` asserts that
`RECONSTRUCTED_XREF_PDF` still produces no `Position` or `Generation` at all, so the plain
integers `PDFXRefFallback` stores are never dereferenced.

## Verification

- `flake8 --select=E9,F63,F7,F82` over `polyfile polymerge tests build_backend.py
  compile_kaitai_parsers.py`: 0 findings.
- `flake8 --max-complexity=10 --max-line-length=127`: 172 findings, of which 14 are in
  `polyfile/pdf.py`. Both counts are identical to master's, so this change introduces none.
- `pytest tests --ignore=tests/test_corkami.py`: 280 passed, 1244 subtests passed.
- `pytest tests/test_pdf.py`: 14 passed, which includes the three malformed-PDF tests #3545 added.
- `pip-audit`: no known vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
