### PR TITLE
Detect EBCDIC text after the eight bit families

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -4073,6 +4073,43 @@ def _eight_bit_encoding(data: bytes) -> Optional[str]:
         return "unknown-8bit"
 
 
+EBCDIC_TO_ASCII: bytes = bytes.fromhex(
+    "000102039c09867f978d8e0b0c0d0e0f"
+    "101112139d8508871819928f1c1d1e1f"
+    "80818283840a171b88898a8b8c050607"
+    "909116939495960498999a9b14159e1a"
+    "20a0a1a2a3a4a5a6a7a8d52e3c282b7c"
+    "26a9aaabacadaeafb0b121242a293b7e"
+    "2d2fb2b3b4b5b6b7b8b9cb2c255f3e3f"
+    "babbbcbdbebfc0c1c2603a2340273d22"
+    "c3616263646566676869c4c5c6c7c8c9"
+    "ca6a6b6c6d6e6f7071725ecccdcecfd0"
+    "d1e5737475767778797ad2d3d45bd6d7"
+    "d8d9dadbdcdddedfe0e1e2e3e45de6e7"
+    "7b414243444546474849e8e9eaebeced"
+    "7d4a4b4c4d4e4f505152eeeff0f1f2f3"
+    "5c9f535455565758595af4f5f6f7f8f9"
+    "30313233343536373839fafbfcfdfeff"
+)
+"""libmagic's ``ebcdic_to_ascii`` table, one row of the C literal per line (``src/encoding.c``).
+
+The table comes from the rationale for ``dd(1)`` in draft 11.2 of POSIX P1003.2 and matches no one
+EBCDIC variant exactly. libmagic explains why a single table still identifies EBCDIC text: the five
+documented variants disagree only over ``|``, ``!``, ``~``, ``^``, ``[`` and ``]``, and all of them
+treat ``0x00``-``0x3F`` as control characters, ``0x41`` as a nonbreaking space, and the rest as
+printing characters. Its code page 1047 table sits behind ``#ifdef notdef`` and never runs.
+"""
+
+
+def _ebcdic_encoding(data: bytes) -> Optional[str]:
+    translated = data.translate(EBCDIC_TO_ASCII)
+    if _only_contains(translated, _ASCII_BYTES):
+        return "ebcdic"
+    elif _only_contains(translated, _ISO_8859_BYTES):
+        return "ebcdic-international"
+    return None
+
+
 def _trim_trailing_nuls(data: bytes) -> bytes:
     """The prefix of `data` that libmagic classifies, with its trailing NUL padding removed.
 
@@ -4105,6 +4142,9 @@ def detect_text_encoding(data: bytes) -> Optional[str]:
     rather than the file's own bytes, so text that a fixed record size or a block boundary padded
     out with NULs still counts as text.
 
+    EBCDIC comes last because most EBCDIC buffers are also valid eight bit buffers, so testing for
+    it any earlier would report ordinary ISO-8859 text as EBCDIC.
+
     Args:
         data: the bytes to classify.
 
@@ -4121,7 +4161,10 @@ def detect_text_encoding(data: bytes) -> Optional[str]:
     ucs_encoding = _looks_like_ucs(data)
     if ucs_encoding is not None:
         return ucs_encoding
-    return _eight_bit_encoding(data)
+    eight_bit_encoding = _eight_bit_encoding(data)
+    if eight_bit_encoding is not None:
+        return eight_bit_encoding
+    return _ebcdic_encoding(data)
 
 
 LIBMAGIC_ENCODING_NAMES: Dict[str, str] = {
@@ -4133,6 +4176,8 @@ LIBMAGIC_ENCODING_NAMES: Dict[str, str] = {
     "utf-32be": "Unicode text, UTF-32, big-endian",
     "iso-8859-1": "ISO-8859",
     "unknown-8bit": "Non-ISO extended-ASCII",
+    "ebcdic": "EBCDIC",
+    "ebcdic-international": "International EBCDIC",
 }
 """libmagic's name for each encoding `detect_text_encoding` reports, from ``src/encoding.c``."""
 
@@ -4143,6 +4188,8 @@ TEXT_ENCODING_MAX_BYTES: int = 64 * 1024
 """libmagic's ``FILE_ENCODING_MAX``: how many bytes it decodes to describe text (``src/file.h``)."""
 
 _EIGHT_BIT_ENCODINGS: FrozenSet[str] = frozenset({"ascii", "iso-8859-1", "unknown-8bit"})
+
+_EBCDIC_ENCODINGS: FrozenSet[str] = frozenset({"ebcdic", "ebcdic-international"})
 
 _UCS_BOM_LENGTHS: Dict[str, int] = {
     encoding: len(bom) for bom, encoding, _ in _UCS_BYTE_ORDER_MARKS
@@ -4157,7 +4204,9 @@ def _decode_text(data: bytes, encoding: str) -> str:
     libmagic decodes at most ``FILE_ENCODING_MAX`` bytes into the buffer that
     ``file_ascmagic_with_encoding`` scans, so a line that only grows long past that point does not
     count as a long line. Each eight bit encoding it names copies a byte's value straight into that
-    buffer, which is what decoding as Latin-1 does.
+    buffer, which is what decoding as Latin-1 does. For an EBCDIC buffer it fills the buffer with
+    the translation `EBCDIC_TO_ASCII` produces, the one whose character classes it counted, so the
+    line terminators and escape sequences it reports are the translated ones.
 
     Args:
         data: the bytes to decode.
@@ -4167,7 +4216,9 @@ def _decode_text(data: bytes, encoding: str) -> str:
         The decoded characters, dropping any character the byte limit cut in half.
     """
     prefix = data[:TEXT_ENCODING_MAX_BYTES]
-    if encoding in _EIGHT_BIT_ENCODINGS:
+    if encoding in _EBCDIC_ENCODINGS:
+        return prefix.translate(EBCDIC_TO_ASCII).decode("latin-1")
+    elif encoding in _EIGHT_BIT_ENCODINGS:
         return prefix.decode("latin-1")
     prefix = prefix[_UCS_BOM_LENGTHS.get(encoding, 0):]
     return codecs.getincrementaldecoder(encoding)().decode(prefix, final=False)

--- a/tests/test_corkami.py
+++ b/tests/test_corkami.py
@@ -17,10 +17,6 @@ FILE_PATH = FILE_DIR / "src" / "file"
 MAGIC_FILE_PATH = SCRIPT_DIR / "magic.mgc"
 
 KNOWN_BAD_FILES = {
-    "d1531b1622de54fe3a0187c3344600e9",  # elf.bin
-                                         # `file` reads this as International EBCDIC text and
-                                         # reports `text/plain`. PolyFile has no EBCDIC detection,
-                                         # so it reports `application/octet-stream`. See #3507
     "bdb7963176bdaa12a17d98db9cbf384b",  # make.py
                                          # `file` reports both `text/x-script.python` and
                                          # `text/plain`. PolyFile reports only

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -507,6 +507,86 @@ class MagicTest(TestCase):
         self.assertEqual(1, description.lf)
         self.assertEqual("Unicode text, UTF-16, little-endian text", description.describe(""))
 
+    def test_ebcdic_to_ascii_table(self):
+        """Tests the properties libmagic's `ebcdic_to_ascii` comment names for its table.
+
+        The comment at `file/src/encoding.c` records what every EBCDIC variant agrees on: codes
+        0x00 through 0x3F are control characters, 0x41 is a nonbreaking space, and the rest are
+        printing characters. Checking those alongside the letter and digit runs catches a
+        transcription error in the 256 byte table that the end to end cases might still classify
+        correctly.
+        """
+        table = polyfile.magic.EBCDIC_TO_ASCII
+        self.assertEqual(256, len(table))
+        self.assertEqual(0x20, table[0x40])
+        self.assertEqual(0xA0, table[0x41])
+        for ebcdic, ascii_start in ((0x81, "a"), (0x91, "j"), (0xC1, "A"), (0xD1, "J")):
+            for offset in range(9):
+                self.assertEqual(ord(ascii_start) + offset, table[ebcdic + offset],
+                                 f"EBCDIC {ebcdic + offset:#04x}")
+        for offset in range(8):
+            self.assertEqual(ord("s") + offset, table[0xA2 + offset])
+            self.assertEqual(ord("S") + offset, table[0xE2 + offset])
+        for digit in range(10):
+            self.assertEqual(ord("0") + digit, table[0xF0 + digit])
+
+    def test_ebcdic_text_is_not_binary(self):
+        """Tests that a buffer only EBCDIC makes sense of is text rather than binary.
+
+        This is a regression test for trailofbits/polyfile#3507. `file_encoding` translates the
+        buffer through `ebcdic_to_ascii` and re-tests it once the ASCII, UTF-8, UCS and eight bit
+        families have all failed (`file/src/encoding.c`). `detect_text_encoding` stopped at the
+        eight bit families, so it reported no encoding for these buffers and `MagicMatcher.match`
+        fell through to `application/octet-stream`.
+
+        The first three buffers hold an EBCDIC double quote (0x7F) or tab (0x05), both of which
+        belong to no text character class in their own right, which is what keeps them out of the
+        eight bit families. The last is the corkami corpus file `pocs-master/mocks/elf.bin`.
+        """
+        ebcdic = (
+            (b"\x7f\xc3\xe4\xe2\xe3\xd6\xd4\xc5\xd9\x7f\x6b\x7f\xc2\xc1\xd3\xc1\xd5"
+             b"\xc3\xc5\x7f\x25", "ebcdic", "EBCDIC text"),
+            (b"\xd5\xc1\xd4\xc5\x05\xe5\xc1\xd3\xe4\xc5\x25", "ebcdic", "EBCDIC text"),
+            (b"\x7f\x83\x81\x86\xcb\x7f\x25", "ebcdic-international",
+             "International EBCDIC text"),
+            (b"\x7fELF", "ebcdic-international",
+             "International EBCDIC text, with no line terminators"),
+        )
+        for data, expected_encoding, expected_description in ebcdic:
+            with self.subTest(data=data):
+                self.assertEqual(expected_encoding, polyfile.magic.detect_text_encoding(data))
+                description = polyfile.magic.TextEncodingDescription.detect(data)
+                self.assertIsNotNone(description)
+                self.assertEqual(expected_description, description.describe(""))
+                mimetypes = {
+                    mimetype
+                    for match in MagicMatcher.DEFAULT_INSTANCE.match(
+                        polyfile.magic.MatchContext(data, only_match_mime=True))
+                    for mimetype in match.mimetypes
+                }
+                self.assertEqual({"text/plain"}, mimetypes)
+
+    def test_eight_bit_text_is_not_reclassified_as_ebcdic(self):
+        """Tests that the EBCDIC branch runs last, where `file_encoding` runs it.
+
+        This is a regression test for trailofbits/polyfile#3507. Most EBCDIC buffers are also
+        valid eight bit buffers, so the two families overlap and only the order separates them:
+        `file_encoding` reaches `from_ebcdic` in the `else` of the chain that `looks_latin1` and
+        `looks_extended` come earlier in (`file/src/encoding.c`). Testing for EBCDIC any sooner
+        reports ordinary ISO-8859 and extended-ASCII text as EBCDIC, and each of these buffers
+        translates to something `looks_latin1` still accepts.
+        """
+        eight_bit = (
+            (b"\xc3\xe4\xe2\xe3\xd6\xd4\xc5\xd9\x40\xd9\xc5\xc3\xd6\xd9\xc4\x25",
+             "iso-8859-1"),
+            (b"\xc8\x85\x93\x93\x96\x6b\x40\xa6\x96\x99\x93\x84\x25", "unknown-8bit"),
+            ("caf\xe9 na\xefve\n".encode("latin-1"), "iso-8859-1"),
+            (b"plain ASCII text\n", "ascii"),
+        )
+        for data, expected_encoding in eight_bit:
+            with self.subTest(data=data):
+                self.assertEqual(expected_encoding, polyfile.magic.detect_text_encoding(data))
+
     @staticmethod
     def messages(matcher: MagicMatcher, data: bytes) -> Set[str]:
         return {str(match) for match in matcher.match(data)}


### PR DESCRIPTION
Closes #3507

## Merge order

Wave 2, alongside #3548 (issue #3503), #3549 (issue #3542), and the pull request for issue #3530.
None of them touches `detect_text_encoding`, so the order within the wave does not matter.

This branch starts at `16cb294`, which already contains #3506. That pull request added
`_trim_trailing_nuls` and made `detect_text_encoding` apply it before classifying, so the EBCDIC
branch reads the already trimmed buffer.

Downstream: issue #3537 adds a UTF-8 byte-order-mark case to `detect_text_encoding` and a name to
`LIBMAGIC_ENCODING_NAMES`, the same function and the same table. It should rebase onto this. Two
things here are worth building on rather than duplicating:

- The dispatch chain now ends with a named local, `eight_bit_encoding`, followed by
  `return _ebcdic_encoding(data)`. A new branch belongs above that tail, not after it.
- `_EBCDIC_ENCODINGS` sits beside `_EIGHT_BIT_ENCODINGS` and selects the translation path in
  `_decode_text`. A new encoding whose decoded buffer differs from the file's bytes needs the same
  treatment.

Issue #3533 is blocked by this one and can proceed once it lands.

## Reproducer

```console
$ printf '\x7fELF' > elf.bin
$ ./file/src/file -m file/magic/magic.mgc -i --keep-going elf.bin
elf.bin: text/plain; charset=ebcdic
$ ./file/src/file -m file/magic/magic.mgc --keep-going elf.bin
elf.bin: ELF\012- , International EBCDIC text, with no line terminators
```

Before:

```python
>>> detect_text_encoding(open("elf.bin", "rb").read())
None
>>> {mt for m in matcher.match(MatchContext.load("elf.bin", only_match_mime=True))
...     for mt in m.mimetypes}
{'application/octet-stream'}
```

After:

```python
>>> detect_text_encoding(open("elf.bin", "rb").read())
'ebcdic-international'
>>> {mt for m in matcher.match(MatchContext.load("elf.bin", only_match_mime=True))
...     for mt in m.mimetypes}
{'text/plain'}
```

## What the fix does

`file_encoding` translates the buffer through `ebcdic_to_ascii` and re-tests it in the `else` of its
dispatch chain, once `looks_ascii`, `looks_utf8_with_BOM`, `file_looks_utf8`, `looks_ucs32`,
`looks_ucs16`, `looks_latin1` and `looks_extended` have all failed
(`file/src/encoding.c:150-173`). It then reports `EBCDIC` when the translation looks ASCII and
`International EBCDIC` when it looks Latin-1, both under the `ebcdic` MIME charset.
`detect_text_encoding` stopped at the eight bit families and returned `None`, so `MagicMatcher.match`
took its `OctetStreamTest` fall-through.

The change ports `ebcdic_to_ascii` as `EBCDIC_TO_ASCII` and adds `_ebcdic_encoding` at the tail of
the dispatch chain, in libmagic's order. That order is the whole of the fix's safety: most EBCDIC
buffers are also valid eight bit buffers, so testing for EBCDIC any earlier reports ordinary
ISO-8859 and extended-ASCII text as EBCDIC. `file` itself demonstrates the overlap. The EBCDIC
encoding of `CUSTOMER RECORD\n` is `ISO-8859 text` and the EBCDIC encoding of `Hello, world\n` is
`Non-ISO extended-ASCII text`; neither reaches `from_ebcdic` at all.

Only one of the two tables in `encoding.c` is ported. `ebcdic_1047_to_8859` sits inside
`#ifdef notdef` and never compiles, and the comment at `file/src/encoding.c:583-597` explains why the
one table suffices: the five documented EBCDIC variants disagree only over `|`, `!`, `~`, `^`, `[`
and `]`, and all of them treat 0x00 through 0x3F as control characters, 0x41 as a nonbreaking space,
and the rest as printing characters.

`_decode_text` gets an EBCDIC branch as well. `file_encoding` fills `ubuf` with the translated
characters, and `file_ascmagic_with_encoding` counts line terminators, escape sequences and line
lengths in that buffer rather than in the file's bytes (`file/src/ascmagic.c`), so
`TextEncodingDescription` has to measure the translation. Without it, `\x7fELF` would report
`International EBCDIC text` and lose libmagic's `, with no line terminators`.

One gap remains, unchanged by this pull request: `MatchContext.text_test_context` re-encodes only for
the UCS encodings, so PolyFile's text pass runs against the file's bytes where libmagic's runs
against the UTF-8 rendering of `ubuf`. That divergence already applies to the eight bit families,
where the two buffers differ above 0x7F, and this change leaves it as it found it.

## What the tests pin

`tests/test_magic.py`:

- `test_ebcdic_text_is_not_binary` covers both encodings and the reported description. The buffers
  are EBCDIC text holding a double quote (0x7F) or a tab (0x05), bytes that belong to no text
  character class in their own right, which is what keeps them out of the eight bit families, plus
  `\x7fELF` itself. Each expected description is what `file` 5.48 prints for the same bytes. With
  the branch removed, all four cases fail with `!= None`.
- `test_eight_bit_text_is_not_reclassified_as_ebcdic` is the negative test, and it is the one that
  matters most here, since reclassifying ordinary text is the risk this change carries. Moving
  `_ebcdic_encoding` above `_eight_bit_encoding` in the chain makes the two EBCDIC-encoded buffers
  in it report `ebcdic` instead of `iso-8859-1` and `unknown-8bit`.
- `test_ebcdic_to_ascii_table` checks the invariants the `encoding.c` comment names, along with the
  letter and digit runs. Transposing two bytes in the hex literal makes it fail; the end to end
  cases do not necessarily catch that.

`tests/test_corkami.py`: the `elf.bin` entry (MD5 `d1531b1622de54fe3a0187c3344600e9`) is removed from
`KNOWN_BAD_FILES`. That list is a plain `skipTest` with no unexpectedly-passing guard, so the removal
plus a green suite is the proof.

## Verification

- `flake8 ... --select=E9,F63,F7,F82`: 0 findings. The `--max-complexity=10 --max-line-length=127`
  pass reports nothing new for `polyfile/magic.py` or `tests/test_magic.py`.
- `pytest tests --ignore=tests/test_corkami.py`: 281 passed, 1252 subtests passed, up from 280 and
  1252 on `16cb294`.
- `pytest tests/test_corkami.py`: 906 passed, 1 skipped, up from 905 passed and 2 skipped. The
  remaining skip is `make.py`, which belongs to #3488.
- Corpus differential over all 88 `file/tests/*.testfile` stems, comparing every reported match and
  MIME type before and after, with `.magic` sidecars and the `k` flag honored: 0 stems changed.
- `pip-audit`: no known vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
