### PR TITLE
Refuse a string test whose value is longer than the buffer

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -2324,6 +2324,23 @@ class StringType(DataType[StringTest]):
         )
 
     def match(self, data: bytes, expected: StringTest) -> DataTypeMatch:
+        """Applies this test, refusing a value that declares more bytes than the buffer holds.
+
+        libmagic bounds-checks the declared length before it evaluates a string-family test, with
+        ``offset_oob(nbytes, offset, m->vallen)`` (``file/src/softmagic.c:1936-1942``). The check
+        is observable only when a flag lets a value consume fewer bytes than it declares, which is
+        what ``w`` does: it turns each declared blank into an optional one
+        (``file/src/softmagic.c:2116-2121``).
+
+        Args:
+            data: The bytes at the offset being tested.
+            expected: The parsed value this type looks for.
+
+        Returns:
+            The match, or `DataTypeMatch.INVALID` if the buffer is shorter than the value.
+        """
+        if len(data) < expected.value_length:
+            return DataTypeMatch.INVALID
         return expected.matches(data)
 
     STRING_TYPE_FORMAT: Pattern[str] = re.compile(r"^u?string(/(?P<numbytes>\d+))?(?P<opts>/[BbCctTWwf]*)?$")

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1235,14 +1235,16 @@ class StringDataTypeTest(TestCase):
         """`w` was rendered as one optional literal space, so a tab or a run of blanks failed.
 
         libmagic consumes a run of any whitespace, of any length including none, wherever the magic
-        value holds a blank (`file/src/softmagic.c:2116-2120`).
+        value holds a blank (`file/src/softmagic.c:2116-2120`). The cases that consume no blank at
+        all carry a trailing byte, because a value never matches a buffer shorter than the length
+        it declares; `test_a_value_longer_than_the_buffer_does_not_match` covers that rule.
         """
         blanks = StringType.parse("string/w")
         space_in_value = blanks.parse_expected("A\\ B")
-        for data in (b"AB", b"A B", b"A  B", b"A\tB", b"A \t B"):
+        for data in (b"ABx", b"A B", b"A  B", b"A\tB", b"A \t B"):
             self.assertTrue(blanks.match(data, space_in_value), repr(data))
         self.assertFalse(blanks.match(b"AxB", space_in_value))
-        self.assertTrue(blanks.match(b"AB", blanks.parse_expected("A\\tB")))
+        self.assertTrue(blanks.match(b"ABx", blanks.parse_expected("A\\tB")))
 
     def test_compact_whitespace_wins_over_optional_blanks(self):
         """`StringMatch` raised when a definition set both `W` and `w`, as `magic_defs/sgml` does.
@@ -1315,6 +1317,37 @@ class StringDataTypeTest(TestCase):
         definition = "0\tsearch/16/ws\tA\\ B\tfound\n>&0\tstring\tx\t%s\n"
         self.assertEqual({"found ABCD, ASCII text, with no line terminators"},
                          self.messages(definition, b"xxABCD"))
+
+    def test_a_value_longer_than_the_buffer_does_not_match(self):
+        """`A\\ B` matched the two bytes `AB` under `w`, because nothing checked the declared length.
+
+        libmagic bounds-checks the declared length of the value against the bytes left in the
+        buffer before it evaluates a string-family test, in
+        `offset_oob(nbytes, offset, m->vallen)` (`file/src/softmagic.c:1936-1942`), so a
+        three-byte value never matches a two-byte file.
+
+        Only `w` made this reachable, because it is the one flag that lets a value consume fewer
+        bytes than it declares. Under `W` every declared blank still consumes at least one byte
+        (`file/src/softmagic.c:2102-2115`), so the `W` and `Ww` cases here already passed; they
+        are kept to pin that `W` stays unaffected.
+        """
+        for flags in ("", "/w", "/W", "/Ww"):
+            definition = f"0\tstring{flags}\tA\\ B\tmatched\n"
+            with self.subTest(flags=flags):
+                self.assertEqual({"ASCII text, with no line terminators"},
+                                 self.messages(definition, b"AB"))
+                self.assertEqual({"matched"}, self.messages(definition, b"A B"))
+
+    def test_a_two_byte_shebang_is_not_a_script(self):
+        """`magic_defs/varied.script:8` declares the three bytes `#!\\ `, so `#!` alone is not it.
+
+        `w` let the two-byte file match the three-byte value, and the shipped definition reported
+        `a  script` for it. `file` 5.48 reports `ASCII text, with no line terminators`.
+        """
+        self.assertEqual({"ASCII text, with no line terminators"},
+                         {str(match) for match in MagicMatcher.DEFAULT_INSTANCE.match(b"#!")})
+        self.assertEqual({"a /bin/sh script, ASCII text executable, with no line terminators"},
+                         {str(match) for match in MagicMatcher.DEFAULT_INSTANCE.match(b"#!/bin/sh")})
 
     def test_wildcard_string_stops_at_a_line_break(self):
         """A wildcard value ran to the first null byte, so a `%s` leaked the rest of the file.


### PR DESCRIPTION
Closes #3504

## Merge order

This PR is unblocked and independent. It sits after #3548 (which closed #3503) and builds on the
`StringTest.value_length` helper that PR names, so it must land on a `master` that already carries
it; `master` at `1724227` does.

#3530 and #3537 may be in flight alongside this one. Neither touches the string machinery, so this
can land in any order relative to them. Nothing is blocked on this PR, and nothing downstream needs
to rebase onto it.

## Reproducer

The value `A\ B` declares three bytes and the file holds two, so libmagic refuses the test:

```console
$ printf '0\tstring/w\tA\\ B\tmatched\n' > vallen.magic
$ printf 'AB' > vallen.bin
$ TZ=UTC ./file/src/file -b -m vallen.magic vallen.bin
ASCII text, with no line terminators
```

Before, PolyFile matched it:

```
{'matched'}
```

After:

```
{'ASCII text, with no line terminators'}
```

The shipped definitions reach the same defect, which is the case this PR pins as its primary
regression test. `polyfile/magic_defs/varied.script:8` and `:12` declare the three bytes `#!\ `, so
the two-byte file `#!` reported as a script:

| data | `file` 5.48 | before | after |
| --- | --- | --- | --- |
| `#!` | `ASCII text, with no line terminators` | `a  script, ASCII text executable, with no line terminators` | `ASCII text, with no line terminators` |
| `#! ` | `a  script, ASCII text executable, with no line terminators` | same | same |
| `#!/bin/sh` | `a /bin/sh script, ASCII text executable, with no line terminators` | same | same |

## What the fix does

libmagic bounds-checks the declared length of the value against the bytes left in the buffer before
it evaluates a string-family test:

```c
	case FILE_STRING:
	case FILE_PSTRING:
	case FILE_SEARCH:
	case FILE_OCTAL:
		if (offset_oob(nbytes, offset, m->vallen))
			return 0;
		break;
```

(`file/src/softmagic.c:1936-1942`, where `offset_oob(n, o, i)` is `i > n - o`.) PolyFile compiled the
value to a regular expression and matched it against whatever bytes remained, so a shortfall became
a shorter successful match rather than a rejection.

The guard goes at the head of `StringType.match`, rather than in `StringMatch.matches`, so that it
covers all three kinds of string test in one place: `StringMatch`, `StringLengthTest`, and
`NegatedStringTest`. Each already reports its own `m->vallen` through `StringTest.value_length`, the
property #3548 built `StringType.declared_length` on, so no second spelling of the declared length is
introduced. `value_length` rather than `declared_length` is the right input here, because
`declared_length` folds in the `s` flag, which governs where a following relative offset resolves
and not whether the value fits.

`ConstantMatchTest.test` slices `data[absolute_offset:]` before it calls the data type, so
`len(data) < expected.value_length` is exactly `m->vallen > nbytes - offset`.

## `W` is unaffected

The issue asks whether `W` (compact whitespace) reaches the same shortfall. It does not. Under `w`,
`STRING_COMPACT_OPTIONAL_WHITESPACE` consumes a run of blanks *of any length including none*
(`file/src/softmagic.c:2116-2121`), so the match can be shorter than the value. Under `W`,
`STRING_COMPACT_WHITESPACE` requires at least one blank for each declared one and only then consumes
more (`file/src/softmagic.c:2102-2115`), so a match is never shorter than the value. PolyFile builds
the same asymmetry into its patterns: `w` renders a blank as `\s*` and `W` renders it as `\ +`.

Confirmed against the reference binary and against PolyFile before the change, for `A\ B` on `AB`:

| flags | `file` 5.48 | PolyFile before | PolyFile after |
| --- | --- | --- | --- |
| (none) | no match | no match | no match |
| `/w` | no match | **`matched`** | no match |
| `/W` | no match | no match | no match |
| `/Ww` | no match | no match | no match |

Only `w` diverged. The bounds check still applies to the other three in libmagic; it is simply not
observable there.

## What the tests pin

Both tests are in `StringDataTypeTest` in `tests/test_magic.py`, beside the cases #3548 added.

- `test_a_value_longer_than_the_buffer_does_not_match` runs `A\ B` against `AB` and `A B` under each
  of the four flag spellings above. With the guard removed, the `/w` subtest fails with `matched`
  instead of `ASCII text, with no line terminators`; the other three keep passing, which is what
  records that `W` was never affected.
- `test_a_two_byte_shebang_is_not_a_script` runs the shipped definitions over `#!` and `#!/bin/sh`.
  With the guard removed it fails with `a  script, ASCII text executable, with no line terminators`
  for `#!`.

Both failures were confirmed by removing the two-line guard and rerunning.

`test_optional_blanks_accept_any_whitespace`, which #3483 added, asserted the defect: its two
zero-blank cases matched a three-byte value against the two-byte buffer `AB`. They now use `ABx`, so
they still pin that `w` consumes no blank at all while leaving the value room to fit. `file` 5.48
reports `matched` for `ABx` under both `A\ B` and `A\tB`.

## Verification

- Corpus differential over all 88 `file/tests/*.testfile` stems, with the normalization of
  `corpus_result_matches`, sidecar globbing, and `.flags` handling: **88 passing before, 88 passing
  after, zero regressions.** The two JSON reports are byte-identical, so not one stem's message set
  changed.
- `varied.script` drives `cmd1` through `cmd4`, which are the stems most exposed to this change.
  All four still pass with the text they had before: `a /usr/bin/cmd1 script, ASCII text executable`,
  the same for `cmd2`, and `a /usr/bin/cmd3 script executable (binary data)` and the same for `cmd4`.
- `uv run pytest tests --ignore=tests/test_corkami.py`: 287 passed, 1259 subtests passed.
- Blocking lint pass (`--select=E9,F63,F7,F82`): 0 findings.
- Complexity pass over `polyfile/magic.py` and `tests/test_magic.py`: identical to `master`, with
  only line numbers shifted.
- `uvx pip-audit`: no known vulnerabilities.

## Follow-up

`SearchType.match` overrides `StringType.match`, so the guard does not reach a `search`, and a
search needs a different rule anyway: libmagic bounds each candidate start offset
(`file/src/softmagic.c:2357-2361`), not only the start of the test. `search/4/w` for `A\ B` still
reports `found` for both `AB` and `xAB`, where `file` reports neither. That is filed as #3552 with a
reproducer, outside this issue's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
