### PR TITLE
Name the UTF-8 byte order mark in the text encoding description

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -4062,6 +4062,9 @@ _UCS_BYTE_ORDER_MARKS: Tuple[Tuple[bytes, str, int], ...] = (
     (b"\xfe\xff", "utf-16be", 2),
 )
 
+UTF8_BYTE_ORDER_MARK: bytes = b"\xef\xbb\xbf"
+"""The mark ``looks_utf8_with_BOM`` reads before it classifies what follows (``src/encoding.c``)."""
+
 
 def _only_contains(data: bytes, allowed: bytes) -> bool:
     return not data.translate(None, delete=allowed)
@@ -4075,6 +4078,26 @@ def _looks_like_utf8(data: bytes) -> bool:
     except UnicodeDecodeError:
         return False
     return True
+
+
+def _utf8_encoding(data: bytes) -> Optional[str]:
+    """Names the UTF-8 family `data` belongs to, as ``file_encoding``'s two UTF-8 tests do.
+
+    ``looks_utf8_with_BOM`` gives up unless more than the three bytes of the mark are present, so a
+    buffer holding nothing but the mark is plain UTF-8 whose one character is U+FEFF.
+
+    Args:
+        data: the bytes to classify.
+
+    Returns:
+        The name of the UTF-8 family, or None if `data` is not UTF-8.
+    """
+    body = data[len(UTF8_BYTE_ORDER_MARK):]
+    if data.startswith(UTF8_BYTE_ORDER_MARK) and body and _looks_like_utf8(body):
+        return "utf-8-sig"
+    elif _looks_like_utf8(data):
+        return "utf-8"
+    return None
 
 
 def _looks_like_ucs(data: bytes) -> Optional[str]:
@@ -4185,8 +4208,9 @@ def detect_text_encoding(data: bytes) -> Optional[str]:
         return None
     elif _only_contains(data, _ASCII_BYTES):
         return "ascii"
-    elif _looks_like_utf8(data):
-        return "utf-8"
+    utf8_encoding = _utf8_encoding(data)
+    if utf8_encoding is not None:
+        return utf8_encoding
     ucs_encoding = _looks_like_ucs(data)
     if ucs_encoding is not None:
         return ucs_encoding
@@ -4199,6 +4223,7 @@ def detect_text_encoding(data: bytes) -> Optional[str]:
 LIBMAGIC_ENCODING_NAMES: Dict[str, str] = {
     "ascii": "ASCII",
     "utf-8": "Unicode text, UTF-8",
+    "utf-8-sig": "Unicode text, UTF-8 (with BOM)",
     "utf-16le": "Unicode text, UTF-16, little-endian",
     "utf-16be": "Unicode text, UTF-16, big-endian",
     "utf-32le": "Unicode text, UTF-32, little-endian",
@@ -4235,7 +4260,9 @@ def _decode_text(data: bytes, encoding: str) -> str:
     count as a long line. Each eight bit encoding it names copies a byte's value straight into that
     buffer, which is what decoding as Latin-1 does. For an EBCDIC buffer it fills the buffer with
     the translation `EBCDIC_TO_ASCII` produces, the one whose character classes it counted, so the
-    line terminators and escape sequences it reports are the translated ones.
+    line terminators and escape sequences it reports are the translated ones. A byte order mark
+    never reaches that buffer: ``looks_utf8_with_BOM`` classifies the bytes after the mark, which is
+    what Python's ``utf-8-sig`` codec decodes, and the UCS tests start their loops past it.
 
     Args:
         data: the bytes to decode.

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -680,16 +680,14 @@ class MagicTest(TestCase):
         RFC 8259 section 8.1 permits either reading. Before the fix the JSON match suppressed the
         text description, so the answer `file` gives was lost.
 
-        PolyFile's UTF-8 description omits libmagic's ``(with BOM)`` clause, which is the separate
-        gap in `detect_text_encoding` tracked in trailofbits/polyfile#3537. The UTF-32 cases carry
-        no trailing clauses because their description comes from a soft magic definition in
-        `polyfile/magic_defs/` rather than from the text encoding machinery, which is also where
-        `file` gets it.
+        The UTF-32 cases carry no trailing clauses because their description comes from a soft
+        magic definition in `polyfile/magic_defs/` rather than from the text encoding machinery,
+        which is also where `file` gets it.
         """
         document = '{"a": 1}'
         cases = (
             ("utf-8-sig", b"\xef\xbb\xbf" + document.encode("utf-8"),
-             "Unicode text, UTF-8 text, with no line terminators"),
+             "Unicode text, UTF-8 (with BOM) text, with no line terminators"),
             ("utf-16-le", f"\ufeff{document}".encode("utf-16-le"),
              "Unicode text, UTF-16, little-endian text, with no line terminators"),
             ("utf-16-be", f"\ufeff{document}".encode("utf-16-be"),
@@ -713,7 +711,7 @@ class MagicTest(TestCase):
         NDJSON match alongside each description.
         """
         self.assertEqual(
-            {"New Line Delimited JSON text data", "Unicode text, UTF-8 text"},
+            {"New Line Delimited JSON text data", "Unicode text, UTF-8 (with BOM) text"},
             self.messages(MagicMatcher.DEFAULT_INSTANCE, b"\xef\xbb\xbf{}\n{}\n")
         )
         self.assertEqual(
@@ -1959,10 +1957,49 @@ class TextEncodingDescriptionTest(TestCase):
                 (b"\xff\xfe" + "hi\n".encode("utf-16-le"),
                  "Unicode text, UTF-16, little-endian text"),
                 (b"\xfe\xff" + "hi\n".encode("utf-16-be"), "Unicode text, UTF-16, big-endian text"),
+                (b"\xef\xbb\xbfhello\n", "Unicode text, UTF-8 (with BOM) text"),
                 (b"caf\xe9\n", "ISO-8859 text"),
                 (b"text\x80\x9f\n", "Non-ISO extended-ASCII text")):
             with self.subTest(data=data):
                 self.assertEqual(expected, self.describe(data))
+
+    def test_a_utf8_byte_order_mark_is_named(self):
+        """Tests the ``(with BOM)`` clause and the two inputs that do not earn it.
+
+        `file_encoding` tries `looks_utf8_with_BOM` ahead of `file_looks_utf8` and names what it
+        finds `Unicode text, UTF-8 (with BOM)` (`file/src/encoding.c:117-123`). PolyFile had no
+        case for the mark, so every marked file came out as `Unicode text, UTF-8 text`
+        (trailofbits/polyfile#3537).
+
+        `looks_utf8_with_BOM` gives up unless there are more than three bytes, so a buffer holding
+        nothing but the mark is plain UTF-8 whose one character is U+FEFF, and a mark at any offset
+        but zero is not a mark at all.
+        """
+        for data, expected in (
+                (b"\xef\xbb\xbfa", "Unicode text, UTF-8 (with BOM) text, with no line terminators"),
+                (b"\xef\xbb\xbfa\r\nb\r\n",
+                 "Unicode text, UTF-8 (with BOM) text, with CRLF line terminators"),
+                ("﻿café\n".encode(), "Unicode text, UTF-8 (with BOM) text"),
+                (b"\xef\xbb\xbfa\x1bb\n",
+                 "Unicode text, UTF-8 (with BOM) text, with escape sequences"),
+                (b"\xef\xbb\xbf", "Unicode text, UTF-8 text, with no line terminators"),
+                ("a﻿b\n".encode(), "Unicode text, UTF-8 text")):
+            with self.subTest(data=data):
+                self.assertEqual(expected, self.describe(data))
+
+    def test_the_byte_order_mark_is_not_measured_as_a_character(self):
+        """Tests that the mark counts towards neither the longest line nor the encoding name.
+
+        `looks_utf8_with_BOM` classifies the bytes after the mark, so the mark never reaches the
+        buffer `file_ascmagic_with_encoding` measures and a 300-character line stays short. Keeping
+        the mark as U+FEFF makes it the 301st character and produces
+        `with very long lines (301)`, which `file` prints for neither buffer below.
+        """
+        for length, expected in ((300, "Unicode text, UTF-8 (with BOM) text"),
+                                 (301, "Unicode text, UTF-8 (with BOM) text, "
+                                       "with very long lines (301)")):
+            with self.subTest(length=length):
+                self.assertEqual(expected, self.describe(b"\xef\xbb\xbf" + b"a" * length + b"\n"))
 
     def test_line_terminators_are_named(self):
         """Tests the line-terminator clause, including the LF-only case that has none.


### PR DESCRIPTION
Closes #3537

## Merge order

This PR is independent and unblocked, and nothing is blocked on it. #3530 and #3504 may be in
flight alongside it; neither touches `detect_text_encoding` or `LIBMAGIC_ENCODING_NAMES`, so the
three can merge in any order. It sits on top of #3550 (#3507), which restructured
`detect_text_encoding`, and is already rebased onto that merge.

## The reproducer

Before:

```console
$ printf '\xef\xbb\xbfhello world\n' > bomtext.txt
$ TZ=UTC ./file/src/file -b -m file/magic/magic.mgc bomtext.txt
Unicode text, UTF-8 (with BOM) text
$ polyfile bomtext.txt
Unicode text, UTF-8 text
```

After:

```console
$ polyfile bomtext.txt
Unicode text, UTF-8 (with BOM) text
```

It is not confined to the description's first clause. Every trailing clause is measured over the
bytes after the mark, so a marked file and an unmarked one with the same text now agree:

| input | `file -b` | PolyFile before | PolyFile after |
| --- | --- | --- | --- |
| `\xef\xbb\xbfhello` | `Unicode text, UTF-8 (with BOM) text, with no line terminators` | `Unicode text, UTF-8 text, …` | matches `file` |
| `\xef\xbb\xbfa\x1bb\n` | `Unicode text, UTF-8 (with BOM) text, with escape sequences` | `Unicode text, UTF-8 text, …` | matches `file` |
| `\xef\xbb\xbf` + 300 `a` + `\n` | `Unicode text, UTF-8 (with BOM) text` | `Unicode text, UTF-8 text, with very long lines (301)` | matches `file` |

## What the fix does

`file_encoding` tries `looks_utf8_with_BOM` before `file_looks_utf8` and reports the code string
`Unicode text, UTF-8 (with BOM)` (`file/src/encoding.c:117-123`). `detect_text_encoding` went
straight to the plain UTF-8 test and `LIBMAGIC_ENCODING_NAMES` had no entry for a marked buffer,
so the clause could never appear.

The two UTF-8 tests now live in `_utf8_encoding`, alongside the existing `_eight_bit_encoding` and
`_ebcdic_encoding` helpers, and `detect_text_encoding` dispatches to it in libmagic's order. The
marked encoding is named `utf-8-sig`, Python's own name for it, which matters beyond spelling:
`looks_utf8_with_BOM` classifies `buf + 3` and fills libmagic's buffer from there
(`file/src/encoding.c:437-444`), so the mark counts towards neither the line shape nor the escape
sequences, and `_decode_text`'s incremental decoder for `utf-8-sig` drops the mark the same way.

`looks_utf8_with_BOM` requires `nbytes > 3`, so a buffer holding nothing but the mark stays plain
UTF-8 whose single character is U+FEFF. `file` prints `Unicode text, UTF-8 text, with no line
terminators` for that buffer, and so does PolyFile.

### What is deliberately not in this PR

libmagic also hands the mark-stripped buffer to its text soft magic, so `file` reports
`SVG Scalable Vector Graphics image, Unicode text, UTF-8 (with BOM) text` for a marked XML document
where PolyFile reports only the text description. That is `MatchContext.text_test_context`, which
#3551 owns; the finding is recorded
[there](https://github.com/trailofbits/polyfile/issues/3551#issuecomment-5639604670) rather than
fixed here.

### The UCS encodings do not have the same gap

Issue #3537 asks whether UTF-16 and UTF-32 need the same treatment. They do not. In libmagic 5.48,
`looks_ucs16` and `looks_ucs32` return 0 unless a mark is present, and `file_encoding` has exactly
one code string per endianness with no `(with BOM)` variant — the only `(with BOM)` string in
`encoding.c` is the UTF-8 one at line 119. `LIBMAGIC_ENCODING_NAMES` already spells all four
correctly, `UCSTextBufferTest` already pins the mark being kept out of their buffers, and a
mark-less UTF-16 buffer is `data` to `file` and `None` to `detect_text_encoding`. Nothing to change.

### CSV

#3537 also carried a question from #3500 about whether CSV has the byte-order-mark divergence that
JSON had. It does not: `csv_parse` walks raw bytes, so a marked UTF-8 CSV is CSV to `file` and to
PolyFile alike. Checking it did surface two unrelated `file_is_csv` divergences, filed as #3554 and
left out of this PR: `file` prints `CSV <encoding> text` where PolyFile prints
`CSV text (excel dialect)`, and `CSVTest` decodes as UTF-8 first, so it misses the Latin-1, UTF-16
and UTF-32 CSV that `file` accepts. Neither is a regression, and #3554 is unmilestoned because it
blocks nothing in v0.6.0.

## What the tests pin

Three tests in `tests/test_magic.py`, all against strings taken from `file -b` built from the
submodule:

* `TextEncodingDescriptionTest.test_a_utf8_byte_order_mark_is_named` covers the clause on four
  marked buffers and the two inputs that do not earn it: a buffer that is only the mark, and a mark
  at a non-zero offset.
* `TextEncodingDescriptionTest.test_the_byte_order_mark_is_not_measured_as_a_character` pins the
  mark out of the measured buffer, at the 300/301-character boundary where keeping it as U+FEFF
  produces `with very long lines (301)` for a buffer `file` calls short.
* `TextEncodingDescriptionTest.test_encoding_names_match_libmagics_spelling` gains the marked
  spelling beside the other five.

Both #3500 tests that asserted the old string were updated to the one `file` prints, and the
paragraph in `test_bom_prefixed_json_also_reports_unicode_text` that pointed at this issue is gone.

Verifying the tests catch the failure:

* Disabling the new branch in `_utf8_encoding` fails both new tests, the spelling test, and both
  #3500 tests: 9 failures.
* Keeping the branch but decoding with `utf-8` instead of `utf-8-sig` fails only
  `test_the_byte_order_mark_is_not_measured_as_a_character`, at both lengths, which is the failure
  that test exists for.

## Verification

* `flake8 --select=E9,F63,F7,F82` over `polyfile polymerge tests build_backend.py
  compile_kaitai_parsers.py`: 0 findings.
* `flake8 --max-complexity=10 --max-line-length=127` over `polyfile/magic.py` and
  `tests/test_magic.py`: no new findings; `detect_text_encoding` and `_utf8_encoding` are both
  below the complexity limit and no added line exceeds 100 characters.
* `pytest tests --ignore=tests/test_corkami.py`: 287 passed, 1264 subtests passed.
* `pytest tests/test_corkami.py`: 906 passed, 1 skipped.
* Corpus differential over all 88 `file/tests/*.testfile` stems, with `corpus_result_matches`
  normalization, `<stem>*.magic` sidecars and `<stem>.flags` honored: **0 regressions**. The full
  set of reported matches is byte-identical before and after, which is expected — no corpus stem
  carries a UTF-8 byte order mark.
* `pip-audit`: no known vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
