### PR TITLE
Seek to the requested start when FileStream wraps a stream

### DIFF
--- a/polyfile/fileutils.py
+++ b/polyfile/fileutils.py
@@ -171,6 +171,9 @@ class FileStream(IO):
     def name(self):
         return self._name
 
+    def __str__(self):
+        return str(self._name)
+
     @property
     def root(self):
         if self._root is None:

--- a/polyfile/fileutils.py
+++ b/polyfile/fileutils.py
@@ -151,6 +151,9 @@ class FileStream(IO):
         self.close_on_exit = close_on_exit
         self._entries = 0
         self._root = None
+        # a stream that is handed in keeps whatever position it was left at, and every caller
+        # that passes `start` means to read the region beginning there
+        self.seek(0)
 
     def __len__(self):
         return self._length

--- a/polyfile/polyfile.py
+++ b/polyfile/polyfile.py
@@ -285,7 +285,7 @@ class Matcher:
                     if mimetype in matched_mimetypes:
                         continue
                     matched_mimetypes.add(mimetype)
-                    yield from self.handle_mimetype(mimetype, result, context.data, file_stream, parent)
+                    yield from self.handle_mimetype(mimetype, result, context.data, f, parent)
 
 
 class Analyzer:

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+from typing import Iterable, Iterator, List, Tuple
+from unittest import TestCase
+
+from polyfile.fileutils import FileStream
+from polyfile.magic import Match as MagicMatch
+from polyfile.polyfile import Match, Matcher
+
+from .test_zipmatcher import build_zip, temporary_file
+
+Structure = List[Tuple[int, str, int, int]]
+
+
+def structure(matches: Iterable[Match]) -> Structure:
+    """Flattens a match tree into a value that two matcher runs can be compared on.
+
+    Args:
+        matches: The matches one :meth:`polyfile.polyfile.Matcher.match` call produced.
+
+    Returns:
+        The depth, name, absolute offset, and length of every match, in the order the matcher
+        produced them.
+    """
+    flattened: Structure = []
+    for match in matches:
+        depth = 0
+        parent = match.parent
+        while parent is not None:
+            depth += 1
+            parent = parent.parent
+        flattened.append((depth, match.name, match.offset, match.length))
+    return flattened
+
+
+def mime_types(matches: Iterator[MagicMatch]) -> List[str]:
+    """Returns every MIME type a :meth:`polyfile.polyfile.Matcher.identify` call reported."""
+    return sorted(mimetype for match in matches for mimetype in match.mimetypes)
+
+
+class TestMatcherInputForms(TestCase):
+    """Regression tests for #3463.
+
+    `Matcher.match` accepts a path, a `Path`, an open binary stream, or a `FileStream`, and
+    `MatchContext.load` reads whichever it is to EOF before any parser runs. Only the first two
+    survived that: a path is reopened, while an already-open stream was handed to the parsers
+    still sitting at EOF, so every parser read `b""` and mapped nothing.
+    """
+
+    def assertArchiveMapped(self, mapped: Structure):
+        """Asserts that a match tree covers the records of a ZIP, not only its file type."""
+        names = [name for _, name, _, _ in mapped]
+        self.assertIn("application/zip", names)
+        self.assertIn("LocalFileHeader", names)
+        self.assertIn("CentralDirectory", names)
+        self.assertIn("EndOfCentralDirectory", names)
+
+    def matched(self, source) -> Structure:
+        return structure(Matcher(parse=True).match(source))
+
+    def test_every_input_form_produces_the_same_structure(self):
+        with temporary_file(build_zip()) as path:
+            from_path = self.matched(str(path))
+            self.assertArchiveMapped(from_path)
+            self.assertEqual(from_path, self.matched(Path(path)))
+            with open(path, "rb") as stream:
+                self.assertEqual(from_path, self.matched(stream))
+            with FileStream(str(path)) as stream:
+                self.assertEqual(from_path, self.matched(stream))
+
+
+class TestMatcherStreamReuse(TestCase):
+    """Regression tests for #3463 on the other entry points that read a caller's stream.
+
+    `Matcher.identify` never re-wraps its stream, so it did not lose structure the way `match`
+    did, but it left the caller's handle at EOF. A second call on the same handle saw an empty
+    file and reported `application/octet-stream`.
+    """
+
+    def test_identify_is_repeatable_on_one_handle(self):
+        with temporary_file(build_zip()) as path, open(path, "rb") as stream:
+            matcher = Matcher(parse=False)
+            first = mime_types(matcher.identify(stream))
+            self.assertIn("application/zip", first)
+            self.assertEqual(first, mime_types(matcher.identify(stream)))
+
+    def test_match_is_repeatable_on_one_handle(self):
+        with temporary_file(build_zip()) as path, open(path, "rb") as stream:
+            matcher = Matcher(parse=True)
+            first = structure(matcher.match(stream))
+            self.assertEqual(first, structure(matcher.match(stream)))

--- a/tests/unit/test_fileutils.py
+++ b/tests/unit/test_fileutils.py
@@ -1,0 +1,36 @@
+from io import BytesIO
+from unittest import TestCase
+
+from polyfile.fileutils import FileStream
+
+DATA = b"0123456789"
+
+
+class TestFileStreamStart(TestCase):
+    """Regression tests for the stream positioning half of #3463.
+
+    `FileStream` wraps a stream it is handed rather than reopening it, so it inherits whatever
+    position that stream is already at. Callers pass `start` to slice a region out of a larger
+    file and then read from the beginning of the slice, which only works if construction moves
+    the stream to `start`.
+    """
+
+    def stream_at_end(self) -> BytesIO:
+        stream = BytesIO(DATA)
+        setattr(stream, "name", "bytes")
+        stream.seek(0, 2)
+        return stream
+
+    def test_read_from_start_of_slice(self):
+        with FileStream(self.stream_at_end(), start=4) as f:
+            self.assertEqual(b"456789", f.read())
+
+    def test_read_whole_stream_that_is_at_its_end(self):
+        with FileStream(self.stream_at_end()) as f:
+            self.assertEqual(DATA, f.read())
+
+    def test_nested_slice_reads_from_its_start(self):
+        with FileStream(self.stream_at_end()) as outer:
+            outer.read()
+            with FileStream(outer, start=2, length=4) as inner:
+                self.assertEqual(b"2345", inner.read())


### PR DESCRIPTION
Closes #3463

Refs #3530, refs #3466. This PR fixes #3463. It deliberately leaves #3466 open: that issue's diagnosis
does not hold up against the code, and implementing it as written regresses output on 81 of the
1,023 files I measured. The evidence is in "Why #3466 is not in this PR" below, along with the
question I need answered before #3530 can be closed.

## Merge order

Wave 2, alongside #3507, #3503, and #3542, all three of which have already merged. None of them
touches `polyfile/polyfile.py` or `polyfile/fileutils.py`, so there is no conflict and no ordering
constraint. This branch is cut at 16cb294; merging it into master at ed571ba is clean and the full
suite passes on the merge result (295 passed, 1268 subtests).

#3531 branches from master after this merges.

## Reproducer

From #3463, against a one-entry ZIP:

```python
from polyfile.polyfile import Matcher

path = "embedded.zip"

print(len(list(Matcher(parse=True).match(path))))
with open(path, "rb") as f:
    print(len(list(Matcher(parse=True).match(f))))
```

Before, on master at 16cb294:

```
51      # given a path: local file header, central directory, EOCD, all fields
1       # given an open stream: "ZIP end of central directory record", nothing inside
```

After:

```
51
51
```

All four input forms `Matcher.match` accepts — `str`, `Path`, an open binary stream, and a
`FileStream` — now produce identical trees, not merely equal counts.

The issue reports 54 where this run reports 51. The difference is #3470, which merged in wave 1
and stopped `structmatcher` from re-matching `Constant` fields, so the ZIP's three record
signatures no longer report a nested match each.

## What the fix does

`MatchContext.load` (`polyfile/magic.py:872-880`) opens a fresh handle for a `str` or a `Path`,
but calls `read()` on an `IO` that is already open, which leaves the caller's handle at EOF. Every
`FileStream` built over that handle afterwards then started at EOF.

`FileStream.__init__` reopens a path but wraps an already-open stream in place, and it never moved
that stream to `start`. `Matcher.handle_mimetype` builds `FileStream(file_stream, start=offset,
length=length)` for each parser it dispatches to, so the parser received a stream whose first
`read()` returned `b""`. `EndOfCentralDirectory.load` (`polyfile/zipmatcher.py:172-191`) reads from
the current position, found no `PK\x05\x06`, and raised `InvalidMatch`; `parse_zip` mapped nothing.
Passing a path masked all of it, because `handle_mimetype` reopened the path instead of reusing the
exhausted handle.

The fix is one line: `FileStream.__init__` now seeks to `start`. A fresh `open()` already satisfies
that invariant, so this only changes the wrap-in-place case, which is the broken one.

The second commit hands `handle_mimetype` the `FileStream` that `Matcher.match` already opened
instead of the caller's original input. That is not what fixed the bug — with the seek in place the
original input works too — but it reuses one handle rather than reopening the file once per parser,
and it keeps the parser's view bounded by what the matcher measured. `FileStream` gains a `__str__`
returning its name so the warning `handle_mimetype` logs for a failing parser still names the file
instead of printing an object address.

Note the ordering: forwarding the wrapper **without** the seek is a regression, not a fix. With
that change alone the path form drops from 51 matches to 1, because `FileStream(f, ...)` inherits
`f`'s position at EOF, so paths break the same way streams already did.

## `Matcher.identify` and `Analyzer.mime_types`

Both are effectively path-only today, so neither lost structure. `identify` had the same latent
defect in a milder form: it left the caller's handle at EOF, so a second call on one handle saw an
empty file and reported `application/octet-stream` instead of `application/zip`. The `FileStream`
fix closes that too, and `test_identify_is_repeatable_on_one_handle` pins it.

`Analyzer` reads `self.path` directly in `mime_types` and `sbud` and is typed `Union[str, Path]`,
so there is nothing to close off there. It would need broader work to accept a stream at all, which
is out of scope here.

## What the tests pin

`tests/unit/test_fileutils.py` pins the mechanism: a `FileStream` over a stream left at EOF reads
from `start`, both for the whole stream and for a nested slice.

`tests/test_matcher.py` pins the behavior:

- `test_every_input_form_produces_the_same_structure` asserts the four input forms yield identical
  `(depth, name, offset, length)` trees, and first asserts that the path form actually maps the
  archive's records, so the equality cannot pass vacuously if every form were to return one match.
- `test_identify_is_repeatable_on_one_handle` and `test_match_is_repeatable_on_one_handle` pin the
  stream-position half.

All six fail with the `FileStream` seek reverted, with the exact symptom described above.

## Why #3466 is not in this PR

#3466 asks to key the dedupe in `Matcher.match` on `(mimetype, offset)` and forward
`result.offset`, on the grounds that `result.offset` "carries the true byte offset of the match."
It does not. `TestResult.offset` is where one test read its bytes, not where a file of that type
begins. For a plain one-entry ZIP the three results that report `application/zip` carry offsets 72,
0, and 127:

| test | `result.offset` | what is at that offset |
| --- | --- | --- |
| `zip:10 >0 string PK\001\002` | 72 | the central directory signature |
| `archive:2398 >>0 string !#!` | 0 | the start of the file |
| `RelaxedZipMatcher:2 0 search PK\005\006` | 127 | the end of central directory signature |

All three describe the same archive, which starts at 0. Keying on `(mimetype, result.offset)` and
forwarding that offset turns one ZIP into three top-level `application/zip` matches at offsets 72,
0, and 127, each with a `FileStream` slice that begins in the middle of the archive.

Measured over 1,023 files (the 88 libmagic corpus test files plus 934 Corkami polyglots), the
change as specified adds **122 spurious top-level matches across 81 files**. A plain ZIP becomes
three or four `application/zip` matches; `html.htm` becomes four `text/html` matches.

The premise behind the dedupe claim also does not hold. `MagicMatcher.match`
(`polyfile/magic.py:4860-4901`) runs each level 0 test once over the whole buffer and never re-runs
it at another offset, so two results sharing a MIME type are always two tests describing the same
file, never two embedded files. I built the file #3466 describes — two ZIPs concatenated — and the
magic matcher reports nothing at all at the second archive's offset, with or without the dedupe
change. #3532 is the issue that would make repeated embedded types findable, and it lists this
exact deduplication problem as one of its unsolved prerequisites.

There is a real defect behind #3466's symptom, but it is not in `Matcher.match`. For that
two-archive file, `EndOfCentralDirectory.load` does `data.rfind(b"PK\x05\x06")`, so `parse_zip`
maps only the last archive in the file and the first one (bytes 0-148) goes unmapped. Fixing that
means teaching `zipmatcher` to walk every end of central directory record, which is materially
larger than #3466 describes and lands in the file #3470 owns.

**Question for the maintainer:** should #3466 be closed as not reproducible with this analysis,
retargeted at the `zipmatcher` defect above, or folded into #3532? #3530 bundles #3463 and #3466,
so I have left both open rather than closing #3530 on an assumption. Say the word and I will add
the `Closes` lines.

## Verification

```
uv run flake8 polyfile polymerge tests build_backend.py compile_kaitai_parsers.py \
    --exclude polyfile/kaitai/parsers --count --select=E9,F63,F7,F82 --show-source --statistics
0

uv run flake8 polyfile polymerge build_backend.py compile_kaitai_parsers.py \
    --max-complexity=10 --max-line-length=127 --exclude=polyfile/kaitai/parsers
172 warnings, all pre-existing and all in polymerge; identical count on master

uv run pytest tests --ignore=tests/test_corkami.py
284 passed, 1244 subtests passed

uv run pytest tests/test_zipmatcher.py tests/test_pdf.py
20 passed
```

`test_no_matches_inside_constant_fields` and `test_no_parser_warning_for_constant_fields`, the two
tests #3534 added for #3470, both still pass.

`uvx pip-audit`: no known vulnerabilities.

Corpus differential: 88 of 88 libmagic corpus stems pass, zero regressions. This change does not
touch libmagic matching, so that is a guard rather than proof.

Structure differential: the full `(depth, name, offset, length)` tree for all 1,023 files above is
byte-identical before and after when the input is a path. Given a stream, 383 of those 1,023 files
produce a different tree from the path form on master; after this change, 0 do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC

