### PR TITLE
Bound each start offset a search test tries

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -2187,6 +2187,23 @@ class StringMatch(StringTest):
         return DataTypeMatch.INVALID
 
     def search(self, data: bytes) -> DataTypeMatch:
+        """Finds the first start offset at which this value matches.
+
+        libmagic bounds every candidate start offset of a search, not only the start of the test:
+        it abandons the remaining offsets as soon as the declared length of the value no longer
+        fits in what is left of the buffer (``file/src/softmagic.c:2357-2361``). The leftmost match
+        is the one libmagic takes, so a leftmost match that starts past that bound rules out every
+        later offset too.
+
+        The bound is observable only when a flag lets a value consume fewer bytes than it declares,
+        which is what ``w`` does (``file/src/softmagic.c:2116-2121``).
+
+        Args:
+            data: The bytes at the offset being tested.
+
+        Returns:
+            The match, or `DataTypeMatch.INVALID` if no start offset that fits the value matches.
+        """
         if self.num_bytes is None:
             end_pos = len(data)
         else:
@@ -2194,9 +2211,9 @@ class StringMatch(StringTest):
             # many bytes plus the length of the string it is looking for
             end_pos = min(len(data), self.num_bytes + len(self.string))
         m = self.pattern.search(data, 0, end_pos)
-        if m:
-            return self.post_process(bytes(m.group(0)), initial_offset=m.start())
-        return DataTypeMatch.INVALID
+        if m is None or m.start() + self.value_length > len(data):
+            return DataTypeMatch.INVALID
+        return self.post_process(bytes(m.group(0)), initial_offset=m.start())
 
     def __str__(self):
         return repr(self.string)

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1336,6 +1336,49 @@ class StringDataTypeTest(TestCase):
                                  self.messages(definition, b"AB"))
                 self.assertEqual({"matched"}, self.messages(definition, b"A B"))
 
+    def test_a_search_value_longer_than_the_bytes_left_does_not_match(self):
+        """`search/4/w` reported `A\\ B` as found in `AB` and in `xAB`, which hold no room for it.
+
+        `SearchType.match` overrides `StringType.match`, so the guard
+        `test_a_value_longer_than_the_buffer_does_not_match` pins never reached a search. libmagic
+        bounds each candidate start offset of the search loop instead, breaking out of it as soon
+        as the value no longer fits: `if (slen + idx > ms->search.s_len)`
+        (`file/src/softmagic.c:2357-2361`).
+
+        The `s` flag does not enter the bound. It governs only where a following relative offset
+        resolves from (`file/src/softmagic.c:966-968`), which is why the check reads
+        `StringTest.value_length` rather than `SearchType.declared_length`, the one the flag zeroes.
+        As on the `string` side, `W` makes every declared blank consume at least one byte
+        (`file/src/softmagic.c:2102-2115`), so the `W` cases already passed and are kept to pin
+        that they stay that way. `file` 5.48 reports each of these four cases the same way under
+        every flag spelling below.
+        """
+        for flags in ("", "/w", "/ws", "/s", "/W", "/Ww"):
+            definition = f"0\tsearch/4{flags}\tA\\ B\tfound\n"
+            with self.subTest(flags=flags):
+                for data in (b"AB", b"xAB"):
+                    self.assertEqual({"ASCII text, with no line terminators"},
+                                     self.messages(definition, data), repr(data))
+                for data in (b"A B", b"xA B"):
+                    self.assertEqual({"found, ASCII text, with no line terminators"},
+                                     self.messages(definition, data), repr(data))
+
+    def test_a_search_bounds_each_start_offset_and_not_the_whole_test(self):
+        """A search still matches where its value fits, even when a later start offset would not.
+
+        libmagic rejects the candidate start offset rather than the test, so the offsets before the
+        one that overruns are still tried (`file/src/softmagic.c:2357-2361`). `A B` and `xAB` are
+        both three bytes long and both run against the same three-byte value, so any guard applied
+        once per test answers them identically: rejecting up front loses `A B`, and letting the
+        test through keeps the false positive on `xAB`. `file` 5.48 reports `found` for `A B` and
+        not for `xAB`.
+        """
+        definition = "0\tsearch/4/w\tA\\ B\tfound\n"
+        self.assertEqual({"found, ASCII text, with no line terminators"},
+                         self.messages(definition, b"A B"))
+        self.assertEqual({"ASCII text, with no line terminators"},
+                         self.messages(definition, b"xAB"))
+
     def test_a_two_byte_shebang_is_not_a_script(self):
         """`magic_defs/varied.script:8` declares the three bytes `#!\\ `, so `#!` alone is not it.
 


### PR DESCRIPTION
Closes #3552

## Merge order

This is the last of the string and offset work in milestone v0.6.0. It builds on two merged PRs and
conflicts with neither, because both are already on `master`:

- #3553 (issue #3504) added the string-side bound in `StringType.match`.
- #3548 (issue #3503) added `StringType.declared_length`, which `SearchType` overrides.

#3530 may be in flight alongside this one. It touches `polyfile/polyfile.py` and not the string
machinery, so the two do not conflict and either order works. Nothing is blocked on this PR, and
nothing downstream has to rebase onto it.

## Reproducer

The magic definition and reference output, using `file` 5.48 from the `file` submodule:

```console
$ printf '0\tsearch/4/w\tA\\ B\tfound\n' > searchlen.magic
$ for s in AB xAB 'A B' 'xA B'; do printf '%s' "$s" > in.bin; \
    printf '%-8s -> %s\n' "[$s]" "$(TZ=UTC ./file/src/file -b -m searchlen.magic in.bin)"; done
[AB]     -> ASCII text, with no line terminators
[xAB]    -> ASCII text, with no line terminators
[A B]    -> found, ASCII text, with no line terminators
[xA B]   -> found, ASCII text, with no line terminators
```

Before, on `master` at `ed571ba`:

```
b'AB'    -> found
b'xAB'   -> found
b'A B'   -> found
b'xA B'  -> found
```

After:

```
b'AB'    -> NOT found
b'xAB'   -> NOT found
b'A B'   -> found
b'xA B'  -> found
```

## What the fix does

`SearchType.match` overrides `StringType.match`, so the bound #3553 added at the head of the latter
never reached a search. Adding the same guard to `SearchType.match` would be the wrong granularity:
libmagic bounds each candidate start offset of a search, not the test as a whole. The loop in
`magiccheck` walks the buffer and abandons the remaining offsets only once the declared length stops
fitting in what is left (`file/src/softmagic.c:2357-2361`):

```c
for (idx = 0; m->str_range == 0 || idx < m->str_range; idx++) {
	if (slen + idx > ms->search.s_len) {
		v = 1;
		break;
	}
	...
}
```

with `slen = MIN(m->vallen, sizeof(m->value.s))` and `ms->search.s_len = nbytes - offset`, the whole
remaining buffer (`file/src/softmagic.c:1392-1393`). That bound subsumes the `offset_oob` rule in
`mget` that #3553 implements for `string`, because `idx == 0` already fails it when the buffer is
shorter than the value.

So the check goes in `StringMatch.search`, which is where a search chooses its start offset. The
leftmost match is the one libmagic takes, so a leftmost match that starts past the bound rules out
every later offset too, and the test can be rejected outright at that point:

```python
if m is None or m.start() + self.value_length > len(data):
    return DataTypeMatch.INVALID
```

Placing it here also keeps the negated case right. When `mget`'s bounds check fails, `match` sets
`flush = m->reln != '!'` (`file/src/softmagic.c:279-282`), so a `!` test still matches a buffer too
short to hold its value. `NegatedStringTest.search` delegates to the test it wraps and inverts the
result, so `search !ABC` keeps reporting a match on a two-byte file, as `file` does.

### Which length the bound reads

It reads `StringTest.value_length`, libmagic's `m->vallen`, and not the `declared_length` that #3548
added. The two differ under the `s` flag, which `SearchType.declared_length` zeroes. That flag is
`REGEX_OFFSET_START`, and all it governs is where a following relative (`&`) offset resolves from
(`file/src/softmagic.c:966-968`); it has nothing to do with whether the value fits in the buffer.
`magiccheck` reads `m->vallen` directly and never consults `m->str_flags` for this bound. Using
`declared_length` would switch the bound off entirely for any `search/…s…` definition. The reference
binary confirms it: `search/4/ws` answers all four cases above exactly as `search/4/w` does.

### The `w` and `W` flags

`w` is the only flag that makes the bound observable, because it is the only one that lets a value
consume fewer bytes than it declares: `STRING_COMPACT_OPTIONAL_WHITESPACE` skips a run of blanks of
any length, including none (`file/src/softmagic.c:2116-2121`). Under `W`
(`STRING_COMPACT_WHITESPACE`) each declared blank still consumes at least one byte
(`file/src/softmagic.c:2102-2115`), and `W` wins when a definition sets both, so the same conclusion
#3553 reached for `string` holds here: `W` and `Ww` were already correct. The `c`, `C`, and `f`
flags are all one-to-one on length. The new test runs `""`, `/w`, `/ws`, `/s`, `/W`, and `/Ww` so
that the unaffected spellings stay pinned.

## What the tests pin

Two tests in `StringDataTypeTest`, beside the ones #3548 and #3553 added.

`test_a_search_value_longer_than_the_bytes_left_does_not_match` is the reproducer across all six
flag spellings. It fails with the fix reverted, on the `/w` and `/ws` subtests.

`test_a_search_bounds_each_start_offset_and_not_the_whole_test` is the granularity case. `A B` and
`xAB` are both three bytes and both run against the same three-byte value, so no guard applied once
per test can separate them: `file` reports `found` for `A B` and not for `xAB`. I checked the test
against three implementations that are wrong in different ways:

| Implementation | Result |
| --- | --- |
| No bound (`master`) | both tests fail |
| Whole-test guard at the head of `SearchType.match` | both tests fail; `xAB` stays a false positive |
| Whole-test guard requiring the last candidate offset to fit | both tests fail; `A B` is lost |
| Per-candidate-offset bound (this PR) | both pass |

## Verification

- Lint, both passes from `CLAUDE.md` and `.github/workflows/tests.yml:48`: clean. `flake8` reports
  the same findings on `polyfile/magic.py` and `tests/test_magic.py` before and after this change,
  so it adds none.
- `uv run pytest tests --ignore=tests/test_corkami.py`: 291 passed, 1274 subtests passed, up from
  289 and 1268 on `master`. No failures.
- `uv run pytest tests/test_corkami.py`: 906 passed, 1 skipped, unchanged.
- `uvx pip-audit`: no known vulnerabilities.
- Corpus differential over all 88 `file/tests/*.testfile` stems, with the `corpus_result_matches`
  normalization, `<stem>*.magic` sidecars, and `join_matches` for the `k` flag: **zero
  regressions**. 88 of 88 stems pass before and after, and the full set of reported matches is
  byte-identical for every stem, including `gedcom` (`search` with a relative offset, the canary for
  #3503) and `searchbug`.

## Noticed while working on this, filed separately

Three divergences from `file` 5.48 that this PR does not touch, each with a reproducer in its issue:

- #3557: a negated `string` test no longer matches a buffer shorter than its value. This is a
  regression from #3553, so it is in milestone v0.6.0. It is also why the bound here goes in
  `StringMatch.search` rather than in `SearchType.match`; putting it in the latter would extend the
  same regression to `search`.
- #3558: a `search/N` carrying any string flag accepts start offset `N`, where libmagic's last
  candidate is `N - 1`. With no flag set libmagic takes its `memmem` path, whose window matches what
  PolyFile already computes, which is why this only shows up with a flag.
- #3559: the `f` (full word) flag compiles to a leading `\b` as well as a trailing one. All 60
  definitions in `magic_defs/commands` that carry it declare a value starting with `#`, so none of
  them can fire; `file` reports `POSIX shell script` for `#! /bin/sh` and PolyFile does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
