### PR TITLE
Count a FileStream's length from its start in both branches

### DIFF
--- a/polyfile/fileutils.py
+++ b/polyfile/fileutils.py
@@ -110,6 +110,19 @@ class FileStream(IO):
             mode: str = "rb",
             close_on_exit: Optional[bool] = None
     ):
+        """Presents a region of a file or stream as a stream in its own right.
+
+        Args:
+            path_or_stream: The bytes to read. A path is opened, `bytes` are wrapped in a
+                `BytesIO`, and an already-open stream is wrapped in place.
+            start: The offset within `path_or_stream` at which this stream begins.
+            length: How many bytes this stream holds, counted from `start` rather than from the
+                beginning of `path_or_stream`, and clamped to the bytes that remain after
+                `start`. Defaults to all of them.
+            mode: The mode to open `path_or_stream` with, when it is a path.
+            close_on_exit: Whether leaving this stream's context closes the underlying stream,
+                defaulting to True for a path this opened and False for a stream it was handed.
+        """
         if isinstance(path_or_stream, Path):
             path_or_stream = str(path_or_stream)
         if isinstance(path_or_stream, str):
@@ -126,24 +139,21 @@ class FileStream(IO):
                 raise ValueError('FileStream can only wrap streams that are readable')
             self._stream = path_or_stream
         if isinstance(path_or_stream, FileStream):
-            if length is None:
-                self._length = len(path_or_stream) - start
-            else:
-                self._length = min(length, len(path_or_stream))
+            stream_length = len(path_or_stream)
+        elif isinstance(path_or_stream, BytesIO):
+            orig_pos = path_or_stream.tell()
+            path_or_stream.seek(0, SEEK_END)
+            try:
+                stream_length = path_or_stream.tell()
+            finally:
+                path_or_stream.seek(orig_pos)
         else:
-            if isinstance(path_or_stream, BytesIO):
-                orig_pos = path_or_stream.tell()
-                path_or_stream.seek(0, SEEK_END)
-                try:
-                    filesize = path_or_stream.tell()
-                finally:
-                    path_or_stream.seek(orig_pos)
-            else:
-                filesize = os.path.getsize(self._stream.name)
-            if length is None:
-                self._length = filesize - start
-            else:
-                self._length = min(filesize, length) - start
+            stream_length = os.path.getsize(self._stream.name)
+        remaining = max(stream_length - start, 0)
+        if length is None:
+            self._length = remaining
+        else:
+            self._length = min(length, remaining)
         if close_on_exit is None:
             close_on_exit = False
         self._name = self._stream.name

--- a/tests/unit/test_fileutils.py
+++ b/tests/unit/test_fileutils.py
@@ -34,3 +34,47 @@ class TestFileStreamStart(TestCase):
             outer.read()
             with FileStream(outer, start=2, length=4) as inner:
                 self.assertEqual(b"2345", inner.read())
+
+
+class TestFileStreamLength(TestCase):
+    """Regression tests for the two readings of `length` in `FileStream.__init__`.
+
+    The branch for a nested `FileStream` read `length` as a count of bytes from `start`, while
+    the branch for a raw stream or a path read it as an offset from the beginning of the
+    underlying stream and then subtracted `start` from it. The two therefore disagreed about
+    every slice taken at a non-zero `start`, and the second could return a negative length,
+    which made `__len__` raise `ValueError: __len__() should return >= 0` on the first read.
+    """
+
+    def raw(self, start: int = 0, length=None) -> FileStream:
+        stream = BytesIO(DATA)
+        setattr(stream, "name", "bytes")
+        return FileStream(stream, start=start, length=length)
+
+    def nested(self, start: int = 0, length=None) -> FileStream:
+        outer = BytesIO(DATA)
+        setattr(outer, "name", "bytes")
+        return FileStream(FileStream(outer), start=start, length=length)
+
+    def test_length_counts_bytes_from_start(self):
+        for start, length, expected in ((4, 3, b"456"), (0, 3, b"012"), (8, 5, b"89"),
+                                        (4, None, b"456789")):
+            with self.subTest(start=start, length=length):
+                self.assertEqual(expected, self.raw(start, length).read())
+                self.assertEqual(expected, self.nested(start, length).read())
+
+    def test_both_branches_agree(self):
+        for start in range(len(DATA) + 1):
+            for length in (None, 0, 1, 4, len(DATA), len(DATA) * 2):
+                with self.subTest(start=start, length=length):
+                    raw = self.raw(start, length)
+                    nested = self.nested(start, length)
+                    self.assertEqual(len(raw), len(nested))
+                    self.assertEqual(raw.read(), nested.read())
+
+    def test_length_is_never_negative(self):
+        for start, length in ((4, 3), (len(DATA) + 5, None), (len(DATA) + 5, 2)):
+            with self.subTest(start=start, length=length):
+                stream = self.raw(start, length)
+                self.assertLessEqual(0, len(stream))
+                self.assertEqual(len(stream), len(stream.read()))


### PR DESCRIPTION
Refs #3463, refs #3530. There is no issue for this one: the defect turned up while I was working
on #3463, and the maintainer chose to correct it here directly rather than file it. No `Closes`
line, by design.

`FileStream.__init__` read its `length` argument two different ways depending on what it was
wrapping, and one of the two could produce a negative length.

```python
132:                self._length = min(length, len(path_or_stream))     # nested FileStream
146:                self._length = min(filesize, length) - start        # raw stream or path
```

For a nested `FileStream`, `length` was a count of bytes from `start`, clamped against the whole
inner stream rather than against the part that follows `start`. For a raw stream or a path, it was
an offset from the beginning of the underlying stream, from which `start` was then subtracted. The
two disagree about every slice taken at a non-zero `start`:

```python
>>> from io import BytesIO
>>> from polyfile.fileutils import FileStream
>>> stream = BytesIO(b"0123456789")
>>> stream.name = "bytes"
>>> FileStream(stream, start=4, length=3).read()
Traceback (most recent call last):
  ...
ValueError: __len__() should return >= 0
```

`min(10, 3) - 4` is `-1`, so `__len__` returns a negative number and the first `read()` raises.
The nested branch returns `b"456"` for the same arguments.

## Why this was not in #3556

#3556 addressed #3463 by making the same constructor seek to `start`, and this turned up while I
was measuring that change. It is unreachable today: `Matcher.handle_mimetype` is the only caller outside
`FileStream.__getitem__`, and it always passes `offset=0`, where the two readings coincide. #3556
merged before this could ride along with it, so it is its own pull request. The maintainer chose to
fix it now rather than file it, because leaving a known trap in a constructor the previous PR had
just touched is worse than a second small diff.

## The semantics chosen, and the callers checked

**`length` counts bytes from `start`, clamped to the bytes that remain after `start`.** The
docstring now says so, in those terms, because the ambiguity rather than the arithmetic was the
real defect.

Both call sites that pass `length` already assume that reading, so this is what they were written
against:

| caller | what it passes | what it means |
| --- | --- | --- |
| `polyfile/polyfile.py:251`, `Matcher.handle_mimetype` | `length=len(data) - offset` with `start=offset` | bytes from `offset` to the end of the buffer |
| `polyfile/fileutils.py:307`, `FileStream.__getitem__` | `length=index.stop - index.start` with `start=index.start` | the width of the slice |

The remaining call sites pass no `length` and so are unaffected either way:
`polyfile/pdf.py:1396` passes `start=pdf_header_offset` alone, and `polyfile/zipmatcher.py:42`,
`polyfile/polyfile.py:272`, `polyfile/polyfile.py:277`, and `polyfile/fileutils.py:19` pass
neither. Both `length is None` arms already measured from `start`, so the fix makes the explicit
arms agree with the default rather than changing what the default meant.

The three size computations now feed one length expression instead of being repeated per branch:

```python
remaining = max(stream_length - start, 0)
if length is None:
    self._length = remaining
else:
    self._length = min(length, remaining)
```

The `max` keeps a `start` past the end of the stream from producing a negative length; such a
stream is simply empty.

## What the tests pin

Three tests in `tests/unit/test_fileutils.py`, beside the three #3556 added:

- `test_length_counts_bytes_from_start` asserts the chosen semantics directly, over four
  `(start, length)` pairs, for the raw-stream branch and the nested-`FileStream` branch.
- `test_both_branches_agree` compares the two branches over every `start` from 0 to the length of
  the stream, crossed with six `length` values including `None` and one past the end, asserting
  both the length and the bytes read.
- `test_length_is_never_negative` covers the `ValueError` above and a `start` past the end.

All three fail before the change, with 55 failing subtests between them. The three #3463 tests keep
passing, since neither fix depends on the other.

## Verification

```
uv run flake8 polyfile polymerge tests build_backend.py compile_kaitai_parsers.py \
    --exclude polyfile/kaitai/parsers --count --select=E9,F63,F7,F82 --show-source --statistics
0

uv run flake8 polyfile polymerge build_backend.py compile_kaitai_parsers.py \
    --max-complexity=10 --max-line-length=127 --exclude=polyfile/kaitai/parsers
172 warnings, identical count to master

uv run pytest tests --ignore=tests/test_corkami.py
298 passed, 1341 subtests passed
```

`uvx pip-audit`: no known vulnerabilities.

Structure differential: the full `(depth, name, offset, length)` match tree for 1,023 files (the 88
libmagic corpus test files plus 934 Corkami polyglots) is byte-identical before and after, which is
the expected result for a defect no caller reaches.

One note on that complexity pass: `FileStream.__init__` is a long-standing `C901`, and it is
counted in the 172. Folding the three size computations together lowers it from 13 to 12. Getting
it under the project's limit of 10 means changing how the constructor opens and wraps its input,
which is more than this fix should carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
