### PR TITLE
Let a negated string test match a buffer shorter than its value

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -1879,6 +1879,23 @@ class StringTest(ABC):
     def matches(self, data: bytes) -> DataTypeMatch:
         raise NotImplementedError()
 
+    def out_of_bounds_match(self, data: bytes) -> DataTypeMatch:
+        """The result libmagic reports when the buffer is too short to hold this test's value.
+
+        ``mget`` returns 0 without evaluating the test once
+        ``offset_oob(nbytes, offset, m->vallen)`` rejects it, and ``match`` keeps the test alive
+        only under the ``!`` relation: ``flush = m->reln != '!'``
+        (``file/src/softmagic.c:279-282``). This is the same rule
+        `DataType.allows_invalid_offsets` reports for an offset that lands past the buffer.
+
+        Args:
+            data: The bytes at the offset being tested.
+
+        Returns:
+            `DataTypeMatch.INVALID`, because every relation but ``!`` fails the bounds check.
+        """
+        return DataTypeMatch.INVALID
+
     @abstractmethod
     def is_always_text(self) -> bool:
         raise NotImplementedError()
@@ -2001,6 +2018,22 @@ class NegatedStringTest(StringWildcard):
             return super().matches(data)
         else:
             return DataTypeMatch.INVALID
+
+    def out_of_bounds_match(self, data: bytes) -> DataTypeMatch:
+        r"""Matches without reading the value, which is what ``flush = m->reln != '!'`` leaves.
+
+        libmagic never evaluates the wrapped test in this case, so a flag that lets a value
+        consume fewer bytes than it declares cannot rescue it: ``w`` turns each declared blank
+        into an optional one (``file/src/softmagic.c:2116-2121``), yet ``string/w !A\ B`` still
+        matches the two bytes ``AB`` that its three-byte value does not fit in.
+
+        Args:
+            data: The bytes at the offset being tested.
+
+        Returns:
+            The value a negated test reports whenever the test it wraps fails.
+        """
+        return super().matches(data)
 
     def search(self, data: bytes) -> DataTypeMatch:
         result = self.parent.search(data)
@@ -2349,15 +2382,19 @@ class StringType(DataType[StringTest]):
         what ``w`` does: it turns each declared blank into an optional one
         (``file/src/softmagic.c:2116-2121``).
 
+        A failed bounds check rejects the test rather than the file, and a negated test inverts
+        that rejection into a match, so `StringTest.out_of_bounds_match` answers for it.
+
         Args:
             data: The bytes at the offset being tested.
             expected: The parsed value this type looks for.
 
         Returns:
-            The match, or `DataTypeMatch.INVALID` if the buffer is shorter than the value.
+            The match, or what `expected` reports out of bounds if the buffer is shorter than the
+            value.
         """
         if len(data) < expected.value_length:
-            return DataTypeMatch.INVALID
+            return expected.out_of_bounds_match(data)
         return expected.matches(data)
 
     STRING_TYPE_FORMAT: Pattern[str] = re.compile(r"^u?string(/(?P<numbytes>\d+))?(?P<opts>/[BbCctTWwf]*)?$")

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1336,6 +1336,65 @@ class StringDataTypeTest(TestCase):
                                  self.messages(definition, b"AB"))
                 self.assertEqual({"matched"}, self.messages(definition, b"A B"))
 
+    def test_a_negated_value_longer_than_the_buffer_still_matches(self):
+        r"""The bound added for issue #3504 rejected `!ABC` against `ZZ`, which `file` matches.
+
+        A failed bounds check rejects the test rather than the file, and libmagic carries a
+        negated test through it: `mget` returns 0 and `match` sets `flush = m->reln != '!'`
+        (`file/src/softmagic.c:279-282`), so `!` inverts the rejection into a match the same way
+        it inverts a value that is present but different.
+
+        The `w` case pins the order of the two steps. libmagic checks the bound before it
+        evaluates anything, so `string/w !A\ B` matches the two bytes `AB` even though the value
+        it negates does fit them once `w` makes the declared blank optional; evaluating the
+        wrapped test first and negating the outcome would report no match. `file` 5.48 reports
+        `found` for every case here.
+        """
+        for definition, data in (
+            ("0\tstring\t!ABC\tfound\n", b"ZZ"),
+            ("0\tstring\t!ABC\tfound\n", b"Z"),
+            ("0\tstring\t!ABC\tfound\n", b"\x00\x01"),
+            ("0\tstring/w\t!A\\ B\tfound\n", b"AB"),
+        ):
+            with self.subTest(definition=definition, data=data):
+                self.assertEqual({"found"}, self.messages(definition, data))
+
+    def test_only_a_negated_test_survives_the_short_buffer_bound(self):
+        """Every relation but `!` still fails the bound, which is what `flush = m->reln != '!'` says.
+
+        `NegatedStringTest` and `StringLengthTest` both reach the bound in `StringType.match`, and
+        only the first of them is declared with `!`. `>ABC` and `<ABC` are chosen so that the
+        comparison would succeed on the bytes that are there, which is how this tells the bound
+        apart from the comparison. A wildcard reads no value at all, so libmagic gives it a
+        `m->vallen` of 0 (`file/src/apprentice.c:2409`) and the bound never applies to it.
+
+        `file` 5.48 reports `found` only for the wildcard and the negated test below.
+        """
+        text = "ASCII text, with no line terminators"
+        for definition, data, expected in (
+            ("0\tstring\t>ABC\tfound\n", b"ZZ", {text}),
+            ("0\tstring\t<ABC\tfound\n", b"AA", {text}),
+            ("0\tstring\tABC\tfound\n", b"ZZ", {text}),
+            ("0\tstring\tx\tfound\n", b"ZZ", {"found"}),
+            ("0\tstring\t!ABC\tfound\n", b"ZZ", {"found"}),
+        ):
+            with self.subTest(definition=definition, data=data):
+                self.assertEqual(expected, self.messages(definition, data))
+
+    def test_a_negated_search_is_not_bounded_by_the_string_guard(self):
+        """`SearchType.match` overrides `StringType.match`, so its bound lives in `StringMatch.search`.
+
+        A negated search already matched a buffer too short for its value before the `string` bound
+        arrived, and it has to keep doing so: the search-side bound rejects a start offset inside
+        `StringMatch.search` (`file/src/softmagic.c:2357-2361`), which leaves the wrapped test
+        failing and the negation reporting a match. `file` 5.48 reports `found` for both.
+        """
+        definition = "0\tsearch/4\t!ABC\tfound\n"
+        for data in (b"ZZ", b"ZZZZ"):
+            with self.subTest(data=data):
+                self.assertEqual({"found, ASCII text, with no line terminators"},
+                                 self.messages(definition, data))
+
     def test_a_search_value_longer_than_the_bytes_left_does_not_match(self):
         """`search/4/w` reported `A\\ B` as found in `AB` and in `xAB`, which hold no room for it.
 


### PR DESCRIPTION
Closes #3557

## Merge order

This is a regression PolyFile shipped in #3553, so merge it first in this wave. It has no
dependency on the two sibling PRs that also touch the `string` family in `polyfile/magic.py`:

- #3558 (a flagged search tries one start offset too many) owns the start-offset window in
  `StringMatch.search`.
- #3559 (the full word `f` flag anchors both sides) owns the pattern compilation.

Neither overlaps the hunks here, which are `StringTest`, `NegatedStringTest`, and
`StringType.match`. Both should rebase onto this one; expect adjacent-hunk rebases in
`StringTest.parse` rather than semantic conflicts. Nothing else is waiting on this.

## Reproducer

```console
$ printf '0\tstring\t!ABC\tfound\n' > negstring.magic
$ printf 'ZZ' > short.bin
$ TZ=UTC ./file/src/file -b -m negstring.magic short.bin
found
```

Before, on `003a241`:

```python
>>> {str(m) for m in MagicMatcher.parse("negstring.magic").match(b"ZZ")}
{'ASCII text, with no line terminators'}
```

After:

```python
>>> {str(m) for m in MagicMatcher.parse("negstring.magic").match(b"ZZ")}
{'found'}
```

## What the fix does

libmagic bounds-checks a string test's declared length inside `mget`, which returns 0 when
`offset_oob(nbytes, offset, m->vallen)` rejects it (`file/src/softmagic.c:1936-1942`). `match`
then keeps the test alive under one relation only:

```c
case 0:
	flush = m->reln != '!';
	break;
```

(`file/src/softmagic.c:279-282`). A `!` test therefore matches a buffer too short to hold its
value, in the same way it matches a value that is present but different. #3553 added the bound at
the head of `StringType.match` and returned `INVALID` for every relation, which lost that.

`StringType.match` now hands the out-of-bounds case to `StringTest.out_of_bounds_match`, which
returns `INVALID` on the base class and a match on `NegatedStringTest`.

The dispatch has to supply the result, not only the verdict. libmagic runs the bounds check
*before* it evaluates anything, so a negated test that overruns the buffer matches without reading
its value. Skipping the bound and negating the wrapped test's outcome instead gives a different
answer whenever a flag lets a value consume fewer bytes than it declares, which is what `w` does
(`file/src/softmagic.c:2116-2121`): `string/w !A\ B` matches the two bytes `AB`, because the bound
rejects the test before `w` gets to make the declared blank optional. That is why the fix does not
read `StringType.allows_invalid_offsets`, which reports the same libmagic rule for offsets but
answers only whether the test survives.

## The sibling types

#3553 hoisted the bound into `StringType.match`, which every `StringTest` reaches, so all three
are covered here:

| Test | Relation | Buffer shorter than the value |
|------|----------|-------------------------------|
| `NegatedStringTest` | `!` | Matches, and this PR restores that |
| `StringLengthTest` | `>` or `<` | Fails, which `m->reln != '!'` calls for; unchanged |
| `StringWildcard` | `x` | Never reaches the bound: libmagic reads no value for `x`, so `m->vallen` is 0 (`file/src/apprentice.c:2409`) |

`PascalStringType` extends `DataType` rather than `StringType`, so it does not share this code
path even though libmagic groups `FILE_PSTRING` with `FILE_STRING` in the same check.

## The search side is unaffected

`SearchType.match` overrides `StringType.match` and calls `expected.search(data)`, so the bound
this PR changes never reached a search. #3560 put its own bound in `StringMatch.search` for that
reason, and that placement still holds: the search-side bound rejects a start offset, which leaves
the wrapped test failing and the negation reporting a match, which is what `file` does. The guard
in `StringMatch.search` is untouched, and `test_a_negated_search_is_not_bounded_by_the_string_guard`
pins the behavior so a later change cannot quietly extend this regression to searches.

## What the tests pin

#3553 shipped with no negated-test case at all, which is how this reached a release. The new
`test_a_negated_value_longer_than_the_buffer_still_matches` is the case that would have caught it:
with the bound restored to an unconditional `DataTypeMatch.INVALID`, all four of its subtests fail.

Its `string/w !A\ B` against `AB` subtest additionally pins the order of the two steps. With the
bound skipped for negated tests but the wrapped test still evaluated, that one subtest fails on
its own while the other three pass, so it is what separates the correct fix from the obvious one.

Two more tests were added to `StringDataTypeTest`:

- `test_only_a_negated_test_survives_the_short_buffer_bound` covers the sibling types. `>ABC` and
  `<ABC` are chosen so the comparison would succeed on the bytes that are present, which is what
  tells the bound apart from the comparison.
- `test_a_negated_search_is_not_bounded_by_the_string_guard` covers the search side described
  above.

## Verification

- `flake8 ... --select=E9,F63,F7,F82`: 0 findings.
- `flake8 ... --max-complexity=10 --max-line-length=127`: 172 findings, identical line for line to
  `003a241`; none on the lines this PR touches.
- `pytest tests --ignore=tests/test_corkami.py`: 303 passed, 1358 subtests passed.
- `pytest tests/test_corkami.py`: 906 passed, 1 skipped.
- `pip-audit`: no known vulnerabilities found.
- Corpus differential over all 88 `file/tests/*.testfile` stems: 0 failures, and 0 stems whose
  match set differs from `003a241`. Comparing against `7ef823b~1`, the state before #3553, 0 stems
  differ either, so this restores the pre-#3553 answers exactly.
- A second differential truncating each corpus file to 1, 2, 3, 4, 5, 8, 16, 32, 64, 128, 256 and
  512 bytes, 819 inputs in all, reports 0 differences against `003a241`. The 114 negated `string`
  tests in `magic_defs/` are all nested under parent tests that a truncated corpus file does not
  reach, which is consistent with the corpus never having caught this.

## Out of scope, found while checking the sibling types

Two divergences from `file` 5.48 that predate #3553 and are untouched here, now filed as
#3565 and #3566:

- `0 string !>ABC` against a buffer that does hold four bytes. libmagic reads one relational
  operator and takes `>ABC` as a literal four-byte value (`file/src/apprentice.c:2366-2403`), while
  `StringTest.parse` reads `!` and then `>` and builds a `NegatedStringTest` around a
  `StringLengthTest`, which is the `string` analogue of #3498 (#3528 fixed that one for `regex`).
  No shipped definition writes `!>` or `!<` on a string. Filed as #3565.
- `file` reports `empty` for a zero-length file from `file_buffer`, ahead of soft magic, and
  PolyFile has no equivalent short circuit, so a hand-written `0 string !ABC` definition reports a
  match on an empty buffer. This is what PolyFile did before #3553 as well, and no shipped
  definition changes: `MagicMatcher.DEFAULT_INSTANCE.match(b"")` is identical on `003a241` and
  here. Filed as #3566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
