### PR TITLE
Anchor the full word (f) flag on the trailing side only

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -79,6 +79,8 @@ BLANK_IN_PATTERN: Pattern[bytes] = re.compile(rb"\\?[ \t\n\v\f\r]")
 VALUE_TERMINATOR: Pattern[bytes] = re.compile(rb"[\0\r\n]")
 # `MAXstring`, the size of the buffer libmagic copies a string value into: `file/src/file.h:179`
 MAX_STRING_BYTES: int = 128
+# what the `f` flag requires after a match: `file/src/softmagic.c:2127-2130`
+FULL_WORD_TERMINATOR: bytes = rb"(?=[\0\s]|\Z)"
 ESCAPES = {
     "n": ord("\n"),
     "r": ord("\r"),
@@ -2103,6 +2105,13 @@ class StringMatch(StringTest):
         ``polyfile/magic_defs/sgml`` does. libmagic keeps both bits and lets ``W`` win, because
         ``file_strncmp`` tests it first (``file/src/softmagic.c:2103-2120``).
 
+        ``f`` (full word) constrains only what follows the match, and it asks for whitespace rather
+        than a word boundary: ``file_strncmp`` runs ``if (*b && !isspace(*b)) v = 1;`` once the
+        comparison has succeeded (``file/src/softmagic.c:2127-2130``). Nothing constrains what
+        precedes the match, the byte after it has to be a C ``isspace`` byte or a null byte, and
+        the end of the buffer qualifies because ``file_or_fd`` null-terminates it
+        (``file/src/magic.c:534``).
+
         Returns:
             The pattern to compile, with the flags folded into it.
         """
@@ -2148,7 +2157,7 @@ class StringMatch(StringTest):
         elif self.optional_blanks:
             pattern = BLANK_IN_PATTERN.sub(rb"\\s*", pattern)
         if self.full_word_match:
-            pattern = rb"\b" + pattern + rb"\b"
+            pattern += FULL_WORD_TERMINATOR
         return pattern
 
     def pattern_flags(self) -> int:

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1422,6 +1422,57 @@ class StringDataTypeTest(TestCase):
         untrimmed = verbatim.match(b"\x06  hi  ", verbatim.parse_expected("x"))
         self.assertEqual("  hi  ", untrimmed.value)
 
+    def test_full_word_leaves_what_precedes_the_match_unconstrained(self):
+        """The `f` flag compiled to a word boundary on both sides, so `xxxABC` did not match.
+
+        libmagic applies `STRING_FULL_WORD` once, after the comparison has succeeded, and looks
+        only at the byte that follows the match (`file/src/softmagic.c:2127-2130`). `file` 5.48
+        reports `found` for every case here.
+        """
+        definition = "0\tsearch/4/f\tABC\tfound\n"
+        for data in (b"ABC", b"xABC", b"xxABC", b"xxxABC", b"xABC yy"):
+            with self.subTest(data=data):
+                self.assertEqual({"found, ASCII text, with no line terminators"},
+                                 self.messages(definition, data))
+
+    def test_full_word_requires_whitespace_or_the_end_of_the_buffer(self):
+        """A word boundary let `ABC.` through, which is the opposite error to the one above.
+
+        libmagic asks for `*b == '\\0' || isspace(*b)` (`file/src/softmagic.c:2127-2130`), so
+        punctuation fails even though it ends a word. The end of the buffer qualifies because
+        `file_or_fd` null-terminates it (`file/src/magic.c:534`). `file` 5.48 reports `found` for
+        the first group and not for the second.
+        """
+        definition = "0\tsearch/4/f\tABC\tfound\n"
+        for data in (b"ABC", b"ABC ", b"ABC\t", b"ABC\n", b"ABC\x0b", b"ABC\x0c", b"ABC\r"):
+            with self.subTest(data=data):
+                self.assertIn("found", " ".join(self.messages(definition, data)))
+        for data in (b"ABCD", b"ABC.", b"ABC-", b"ABC/", b"ABC_"):
+            with self.subTest(data=data):
+                self.assertNotIn("found", " ".join(self.messages(definition, data)))
+
+    def test_full_word_accepts_a_null_byte_and_rejects_another_control_byte(self):
+        """`\\0` is the byte that stands for the end of the buffer, and no other control byte is.
+
+        The cases need the `b` flag because a null byte makes the buffer binary, and a text test
+        never runs against one. `file` 5.48 reports `found` for the null byte and not for `\\x01`.
+        """
+        definition = "0\tsearch/4/fb\tABC\tfound\n"
+        self.assertEqual({"found"}, self.messages(definition, b"ABC\x00zz"))
+        self.assertEqual({"data"}, self.messages(definition, b"ABC\x01zz"))
+
+    def test_the_interpreter_line_table_reports_a_posix_shell_script(self):
+        """Every `f` definition in `magic_defs/commands` declares a value that starts with `#`.
+
+        A leading `\\b` at offset 0 needs a word character there, so all sixty of them were dead
+        and PolyFile reported only `a /bin/sh script` from `magic_defs/varied.script`. `file` 5.48
+        reports `POSIX shell script text executable` and `a /bin/sh script, ASCII text
+        executable`.
+        """
+        self.assertEqual({"POSIX shell script, ASCII text executable",
+                          "a /bin/sh script, ASCII text executable"},
+                         {str(match) for match in MagicMatcher.DEFAULT_INSTANCE.match(b"#! /bin/sh\n")})
+
 
 class SearchTextClassificationTest(TestCase):
     r"""Regression tests for the pass classification defect reported in issue #3511.


### PR DESCRIPTION
Closes #3559

## Merge order

This PR is independent of the two other `polyfile/magic.py` changes in the same wave and can merge
in any position relative to them. It touches only `StringMatch.pattern_string`; refs #3557 owns the
bounds guard in `StringType.match` and refs #3558 owns the start-offset window in
`StringMatch.search`. Whichever of the three merges second and third rebases onto `master`; the
hunks do not overlap.

One interaction is worth calling out for whoever takes refs #3558. The trailing assertion this PR
adds reads the byte after the match, and `StringMatch.search` passes an `endpos` to `re.search`, so
at the very last start offset the assertion sees the end of the window rather than the end of the
buffer. That last start offset is the one refs #3558 reports as one too many, so fixing it removes
the only case where the two meet.

## Reproducer

Before, on `master` at `003a241`:

```console
$ printf '#! /bin/sh\n' > sh.txt
$ TZ=UTC ./file/src/file -b -m ./file/magic/magic.mgc sh.txt
POSIX shell script, ASCII text executable
$ python -c "from polyfile.magic import MagicMatcher; \
    print(sorted({str(m) for m in MagicMatcher.DEFAULT_INSTANCE.match(open('sh.txt','rb').read())}))"
['a /bin/sh script, ASCII text executable']
```

After:

```console
$ python -c "from polyfile.magic import MagicMatcher; \
    print(sorted({str(m) for m in MagicMatcher.DEFAULT_INSTANCE.match(open('sh.txt','rb').read())}))"
['POSIX shell script, ASCII text executable', 'a /bin/sh script, ASCII text executable']
```

That is now exactly the set `file` reports with `-k`:

```console
$ TZ=UTC ./file/src/file -b -k -m ./file/magic/magic.mgc sh.txt
POSIX shell script text executable\012- a /bin/sh script, ASCII text executable
```

The issue's other case, `#! /usr/bin/tclsh`, gains `Tcl/Tk script` and likewise ends up matching
`file -k` exactly.

## What the fix does

`StringMatch.pattern_string` wrapped an `f` (full word) value in `\b` on both sides. libmagic
applies `STRING_FULL_WORD` once, after the comparison has already succeeded, and looks only at the
byte that follows the match (`file/src/softmagic.c:2127-2130`):

```c
if (len == 0 && v == 0 && (flags & STRING_FULL_WORD)) {
	if (*b && !isspace(*b))
		v = 1;
}
```

So the flag compiles to a trailing assertion and nothing else:

```python
FULL_WORD_TERMINATOR: bytes = rb"(?=[\0\s]|\Z)"
```

Three things follow from that source, each confirmed against `file` 5.48 before the pattern was
written:

- Nothing constrains what precedes the match. `file` reports `found` for `xxxABC` under
  `0 search/4/f ABC found`; PolyFile reported nothing, because `\b` needs a word character before
  the `A`.
- The trailing byte has to be whitespace, not merely a word boundary. `file` does not report
  `ABC.`, `ABC-` or `ABC/`; PolyFile reported all three, because `\b` accepts punctuation. The
  accepted set is C `isspace` in the `C` locale, which is the same six bytes Python's `\s` matches
  in a bytes pattern.
- A null byte qualifies, and no other control byte does. `file` reports `found` for `ABC\x00zz`
  under `0 search/4/fb ABC found` and not for `ABC\x01zz`. The end of the buffer reaches the same
  branch, because `file_or_fd` null-terminates what it read (`file/src/magic.c:534`), which is why
  the pattern carries `\Z` alongside the character class.

## Blast radius

60 definitions carry `f`, all of them in `polyfile/magic_defs/commands`: 47 `string/wft`, 6
`string/wfb` and 7 `search/1/wft`. Every one declares a value that starts with `#`, so a leading
`\b` at offset 0 needed a word character that is never there. **0 of the 60 could fire before this
change and all 60 fire after it.** That is the whole of the file's interpreter-line table.

To measure what that means on real input, 274 files carrying a shebang were collected from
`/usr/bin`, `/bin`, `/usr/sbin`, `/opt/homebrew/bin` and `/usr/libexec`, and PolyFile's match set
was compared before and after. 88 of them change. Every changed file gains a description that
`file -k` also reports for it, and none loses one:

| new description | files |
| --- | --- |
| POSIX shell script | 72 |
| Bourne-Again shell script | 13 |
| Paul Falstad's zsh script | 2 |
| Korn shell script | 1 |

## What the tests pin

Four tests in `StringDataTypeTest`, all with `file` 5.48 as the oracle:

- `test_full_word_leaves_what_precedes_the_match_unconstrained` fails on `xABC`, `xxABC`, `xxxABC`
  and `xABC yy` if the leading `\b` comes back.
- `test_full_word_requires_whitespace_or_the_end_of_the_buffer` fails on `ABC.`, `ABC-` and `ABC/`
  if the trailing assertion is relaxed to a word boundary, and on the whitespace and
  end-of-buffer cases if it is dropped. This is the guard against the opposite error: deleting the
  leading `\b` alone would let `f` match mid-word.
- `test_full_word_accepts_a_null_byte_and_rejects_another_control_byte` separates the null byte
  from `\x01`.
- `test_the_interpreter_line_table_reports_a_posix_shell_script` is the headline case.

Reverting the one-line fix fails all four (9 failures and subfailures); restoring it passes them.

## Verification

- `flake8 … --select=E9,F63,F7,F82`: 0.
- `flake8 … --max-complexity=10 --max-line-length=127`: no finding that `master` does not already
  report for the same files.
- `pytest tests --ignore=tests/test_corkami.py`: 304 passed, 1364 subtests passed.
- `pytest tests/test_corkami.py`: 906 passed, 1 skipped, unchanged from `master`.
- Corpus differential over all 88 stems, normalized the way `corpus_result_matches` does, with
  `<stem>*.magic` sidecars and `<stem>.flags`: **0 stems change and 0 regress.** No corpus stem
  exercises `f` in either direction, which is why the real-file differential above is the evidence
  that the new matches are right.
- `pip-audit`: clean.

## Noted, not fixed

The `W` (compact whitespace) flag has the same shape of defect on a different axis: it renders each
blank of the value as a repetition of that same literal byte, where libmagic asks `isspace(*b)` and
accepts any whitespace. `@echo\toff` is a `DOS batch file` to `file` and plain text to PolyFile.
Filed as #3562; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
