### PR TITLE
Stop a flagged search one start offset earlier

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -1895,6 +1895,7 @@ class StringTest(ABC):
               case_insensitive_upper: bool = False,
               optional_blanks: bool = False,
               full_word_match: bool = False,
+              has_string_flags: bool = False,
               num_bytes: Optional[int] = None) -> "StringTest":
         if specification.strip() == "x":
             return StringWildcard(trim=trim, compact_whitespace=compact_whitespace, num_bytes=num_bytes)
@@ -1922,6 +1923,7 @@ class StringTest(ABC):
                 case_insensitive_upper=case_insensitive_upper,
                 optional_blanks=optional_blanks,
                 full_word_match=full_word_match,
+                has_string_flags=has_string_flags,
                 num_bytes=num_bytes
             )
         if negate:
@@ -2075,6 +2077,7 @@ class StringMatch(StringTest):
                  case_insensitive_upper: bool = False,
                  optional_blanks: bool = False,
                  full_word_match: bool = False,
+                 has_string_flags: bool = False,
                  num_bytes: Optional[int] = None
     ):
         super().__init__(trim=trim, compact_whitespace=compact_whitespace, num_bytes=num_bytes)
@@ -2084,6 +2087,7 @@ class StringMatch(StringTest):
         self.case_insensitive_upper: bool = case_insensitive_upper
         self.optional_blanks: bool = optional_blanks
         self.full_word_match: bool = full_word_match
+        self.has_string_flags: bool = has_string_flags
         self._is_always_text: Optional[bool] = None
         self._pattern: Optional[re.Pattern] = None
         _ = self.pattern
@@ -2186,17 +2190,43 @@ class StringMatch(StringTest):
             return self.post_process(bytes(m.group(0)))
         return DataTypeMatch.INVALID
 
+    def last_start_offset(self, buffer_length: int) -> int:
+        """The greatest offset into the buffer at which libmagic still tries this value.
+
+        ``magiccheck`` implements a search twice, and the two implementations differ by one
+        offset. The loop runs ``idx`` over ``[0, m->str_range)``, so the last offset it tries is
+        ``str_range - 1`` (``file/src/softmagic.c:2355-2368``). The ``memmem`` fast path ahead of
+        it runs only when ``m->str_flags == 0`` and searches a window of ``m->str_range + slen``
+        bytes (``file/src/softmagic.c:2334-2353``), where a value of ``slen`` bytes can still start
+        at ``str_range``. Every modifier letter a search accepts sets a ``str_flags`` bit
+        (``file/src/apprentice.c:1952-1978``), so a single flag of any kind costs the search its
+        last start offset.
+
+        Args:
+            buffer_length: The number of bytes at the offset being tested.
+
+        Returns:
+            The last candidate start offset, which is the end of the buffer for a search that
+            declared no range.
+        """
+        if self.num_bytes is None:
+            return buffer_length
+        elif self.has_string_flags:
+            return self.num_bytes - 1
+        return self.num_bytes
+
     def search(self, data: bytes) -> DataTypeMatch:
         """Finds the first start offset at which this value matches.
 
         libmagic bounds every candidate start offset of a search, not only the start of the test:
         it abandons the remaining offsets as soon as the declared length of the value no longer
         fits in what is left of the buffer (``file/src/softmagic.c:2357-2361``). The leftmost match
-        is the one libmagic takes, so a leftmost match that starts past that bound rules out every
-        later offset too.
+        is the one libmagic takes, so a leftmost match that starts past either bound rules out
+        every later offset too.
 
-        The bound is observable only when a flag lets a value consume fewer bytes than it declares,
-        which is what ``w`` does (``file/src/softmagic.c:2116-2121``).
+        Both bounds are on where a match starts rather than on where it ends, because ``W`` and
+        ``w`` both let a value consume more bytes than it declares, by matching a run of blanks of
+        any length against one declared blank (``file/src/softmagic.c:2102-2121``).
 
         Args:
             data: The bytes at the offset being tested.
@@ -2204,14 +2234,9 @@ class StringMatch(StringTest):
         Returns:
             The match, or `DataTypeMatch.INVALID` if no start offset that fits the value matches.
         """
-        if self.num_bytes is None:
-            end_pos = len(data)
-        else:
-            # libmagic tries `num_bytes` successive start offsets, so the window it reads is that
-            # many bytes plus the length of the string it is looking for
-            end_pos = min(len(data), self.num_bytes + len(self.string))
-        m = self.pattern.search(data, 0, end_pos)
-        if m is None or m.start() + self.value_length > len(data):
+        m = self.pattern.search(data)
+        if (m is None or m.start() > self.last_start_offset(len(data))
+                or m.start() + self.value_length > len(data)):
             return DataTypeMatch.INVALID
         return self.post_process(bytes(m.group(0)), initial_offset=m.start())
 
@@ -2328,6 +2353,20 @@ class StringType(DataType[StringTest]):
     def allows_invalid_offsets(self, expected: StringTest) -> bool:
         return isinstance(expected, NegatedStringTest)
 
+    @property
+    def has_string_flags(self) -> bool:
+        """Whether this declaration sets any bit of libmagic's ``str_flags``.
+
+        `FLAGS` names every modifier letter this type accepts, and each one sets a bit of the word
+        (``file/src/apprentice.c:1952-1978``). The word being zero is what lets a search take the
+        ``memmem`` fast path, whose window reaches one start offset further than the loop
+        (``file/src/softmagic.c:2334``).
+
+        Returns:
+            True if the declaration carried at least one modifier letter.
+        """
+        return any(getattr(self, attribute) for _, attribute in self.FLAGS)
+
     def parse_expected(self, specification: str) -> StringTest:
         return StringTest.parse(
             specification,
@@ -2337,6 +2376,7 @@ class StringType(DataType[StringTest]):
             compact_whitespace=self.compact_whitespace,
             optional_blanks=self.optional_blanks,
             full_word_match=self.full_word_match,
+            has_string_flags=self.has_string_flags,
             num_bytes=self.num_bytes
         )
 

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1379,6 +1379,83 @@ class StringDataTypeTest(TestCase):
         self.assertEqual({"ASCII text, with no line terminators"},
                          self.messages(definition, b"xAB"))
 
+    def test_a_flag_costs_a_search_its_last_start_offset(self):
+        """`search/4/c` found `ABC` at offset 4, where `file` tries offsets 0 through 3.
+
+        `magiccheck` implements a search twice, and the two disagree by one offset. The loop runs
+        `idx` over `[0, m->str_range)`, so its last start offset is `str_range - 1`
+        (`file/src/softmagic.c:2355-2368`). The `memmem` fast path ahead of it runs only when
+        `m->str_flags == 0`, and it searches a window of `m->str_range + slen` bytes
+        (`file/src/softmagic.c:2334-2353`), in which a value of `slen` bytes still fits when it
+        starts at `str_range`. PolyFile computed the `memmem` window for every search.
+
+        Every modifier letter a search accepts sets a bit of `str_flags`
+        (`file/src/apprentice.c:1952-1978`), `s`, `t` and `T` included, none of which changes how
+        a value is compared. So the flag that narrows the window need not be one that has anything
+        to do with matching.
+
+        The flagless row is the control, and the only one that reaches offset 4: `file` 5.48
+        reports `found` for `search/4` at offsets 3 and 4, for every flagged spelling at offset 3
+        alone, and for none of them at offset 5.
+        """
+        buffers = {3: b"xxxABC", 4: b"xxxxABC", 5: b"xxxxxABC"}
+        for flags, last_offset in (("", 4), ("/c", 3), ("/C", 3), ("/w", 3), ("/W", 3),
+                                   ("/T", 3), ("/s", 3), ("/t", 3), ("/Ww", 3)):
+            definition = f"0\tsearch/4{flags}\tABC\tfound\n"
+            for offset, data in buffers.items():
+                with self.subTest(flags=flags, offset=offset):
+                    found = "found, " if offset <= last_offset else ""
+                    self.assertEqual({f"{found}ASCII text, with no line terminators"},
+                                     self.messages(definition, data))
+
+    def test_a_search_bounds_where_a_match_starts_and_not_where_it_ends(self):
+        """`search/4/W` lost `A\\ B` in `xxxA   B`, and `search/4/w` found it in `xxxxABzz`.
+
+        The window was a bound on where a match ends, `num_bytes + len(value)`, which is the
+        `memmem` window. Subtracting one from it does not express the loop's bound either, because
+        `W` and `w` both match a run of blanks of any length against one declared blank
+        (`file/src/softmagic.c:2102-2121`). A match that starts at a candidate offset may then end
+        anywhere, and a match that ends inside the window may start past the last candidate
+        offset. libmagic bounds `idx`, which is where the match starts
+        (`file/src/softmagic.c:2355-2368`).
+
+        `file` 5.48 reports `found` for `xxxA   B` and `xxxABzz`, and not for `xxxxA   B` or
+        `xxxxABzz`.
+        """
+        stretched = "0\tsearch/4/W\tA\\ B\tfound\n"
+        self.assertEqual({"found, ASCII text, with no line terminators"},
+                         self.messages(stretched, b"xxxA   B"))
+        self.assertEqual({"ASCII text, with no line terminators"},
+                         self.messages(stretched, b"xxxxA   B"))
+        shortened = "0\tsearch/4/w\tA\\ B\tfound\n"
+        self.assertEqual({"found, ASCII text, with no line terminators"},
+                         self.messages(shortened, b"xxxABzz"))
+        self.assertEqual({"ASCII text, with no line terminators"},
+                         self.messages(shortened, b"xxxxABzz"))
+
+    def test_the_s_flag_narrows_the_window_without_changing_what_is_reported(self):
+        """`s` costs a search its last start offset, and still resolves `&` from the match.
+
+        `REGEX_OFFSET_START` governs only where a following relative offset resolves from
+        (`file/src/softmagic.c:966-968`), so it changes neither the value nor the length the value
+        declares, and `SearchType.declared_length` is not what bounds the window. `s` reaches the
+        window only by setting a `str_flags` bit, which is what takes the search off the `memmem`
+        path (`file/src/softmagic.c:2334`).
+
+        `file` 5.48 reports `found ABCD` for `xxxABCD` under `search/4/s`, nothing for `xxxxABCD`,
+        and `found D` for both under the flagless `search/4`, which keeps the extra offset and
+        counts the three bytes of the value.
+        """
+        definition = "0\tsearch/4/s\tABC\tfound\n>&0\tstring\tx\t%s\n"
+        self.assertEqual({"found ABCD, ASCII text, with no line terminators"},
+                         self.messages(definition, b"xxxABCD"))
+        self.assertEqual({"ASCII text, with no line terminators"},
+                         self.messages(definition, b"xxxxABCD"))
+        flagless = "0\tsearch/4\tABC\tfound\n>&0\tstring\tx\t%s\n"
+        for data in (b"xxxABCD", b"xxxxABCD"):
+            self.assertEqual({"found D, ASCII text, with no line terminators"},
+                             self.messages(flagless, data), repr(data))
+
     def test_a_two_byte_shebang_is_not_a_script(self):
         """`magic_defs/varied.script:8` declares the three bytes `#!\\ `, so `#!` alone is not it.
 


### PR DESCRIPTION
Closes #3558

## Merge order

This is one of three PRs open against `polyfile/magic.py` in the same wave, and the three touch
different methods:

- #3563 (issue #3557) owns the bounds guard at the head of `StringType.match` and
  `allows_invalid_offsets`.
- #3564 (issue #3559) owns the `f` flag in `StringMatch.pattern_string`.
- This PR owns the start-offset window in `StringMatch.search`.

Any order works. I merged each of the other two branches into this one locally: both merge without
conflict, and the fast suite passes on each combination (307 passed with #3564, 306 passed with
#3563). Nothing downstream has to rebase onto this one.

One note for #3564. The boundary table below deliberately omits the `f` spelling, because on
`master` an `f` search cannot match at all, which is what #3559 reports. Nothing extra is needed
once #3564 lands: `full_word_match` is already in `StringType.FLAGS`, so an `f` search is a flagged
search here and gets the narrower window like every other one.

## Reproducer

`ABC` sits at offset 3, 4, or 5, and `search/4` declares four start offsets. Using `file` 5.48 from
the `file` submodule:

```console
$ for d in search/4 search/4/c search/4/C search/4/w search/4/W search/4/T search/4/s \
      search/4/t search/4/Ww; do
    printf '0\t%s\tABC\tfound\n' "$d" > reps.magic
    row=""
    for s in xxxABC xxxxABC xxxxxABC; do
      printf '%s' "$s" > in.bin
      r=$(TZ=UTC ./file/src/file -b -m reps.magic in.bin)
      case "$r" in found*) v=found;; *) v="-";; esac
      row="$row  off$((${#s}-3))=$(printf '%-5s' "$v")"
    done
    printf '%-12s %s\n' "$d" "$row"
  done
search/4       off3=found  off4=found  off5=-
search/4/c     off3=found  off4=-      off5=-
search/4/C     off3=found  off4=-      off5=-
search/4/w     off3=found  off4=-      off5=-
search/4/W     off3=found  off4=-      off5=-
search/4/T     off3=found  off4=-      off5=-
search/4/s     off3=found  off4=-      off5=-
search/4/t     off3=found  off4=-      off5=-
search/4/Ww    off3=found  off4=-      off5=-
```

Before, on `master` at `003a241`, where every flagged spelling still reaches offset 4:

```
search/4     off3=found  off4=found  off5=-
search/4/c   off3=found  off4=found  off5=-
search/4/C   off3=found  off4=found  off5=-
search/4/w   off3=found  off4=found  off5=-
search/4/W   off3=found  off4=found  off5=-
search/4/T   off3=found  off4=found  off5=-
search/4/s   off3=found  off4=found  off5=-
search/4/t   off3=found  off4=found  off5=-
search/4/Ww  off3=found  off4=found  off5=-
```

After:

```
search/4     off3=found  off4=found  off5=-
search/4/c   off3=found  off4=-      off5=-
search/4/C   off3=found  off4=-      off5=-
search/4/w   off3=found  off4=-      off5=-
search/4/W   off3=found  off4=-      off5=-
search/4/T   off3=found  off4=-      off5=-
search/4/s   off3=found  off4=-      off5=-
search/4/t   off3=found  off4=-      off5=-
search/4/Ww  off3=found  off4=-      off5=-
```

The flagless `search/4` row is the control. It answers the same way before and after, and the same
way as `file` does.

## Where the candidate range comes from

`magiccheck` implements `FILE_SEARCH` twice. The loop runs `idx` from 0 while `idx < m->str_range`,
so the last start offset it tries is `str_range - 1` (`file/src/softmagic.c:2355-2368`):

```c
		for (idx = 0; m->str_range == 0 || idx < m->str_range; idx++) {
			if (slen + idx > ms->search.s_len) {
				v = 1;
				break;
			}

			v = file_strncmp(m->value.s, ms->search.s + idx, slen,
			    ms->search.s_len - idx, m->str_flags);
			if (v == 0) {	/* found match */
```

The `memmem` fast path sits ahead of it and runs only when the flag word is still zero. It searches
a window of `m->str_range + slen` bytes, in which a value of `slen` bytes still fits when it starts
at `str_range` (`file/src/softmagic.c:2334-2353`):

```c
		if (slen > 0 && m->str_flags == 0) {
			const char *found;
			idx = m->str_range + slen;
			if (m->str_range == 0 || ms->search.s_len < idx)
				idx = ms->search.s_len;
			found = CAST(const char *, memmem(ms->search.s, idx,
			    m->value.s, slen));
```

So the flagless path reaches offset `str_range` and the flagged path stops at `str_range - 1`. Which
flags count is not a judgment call: the string modifier loop sets a bit for every letter it accepts,
`s`, `t`, `b`, `T` and `f` among them (`file/src/apprentice.c:1952-1978`), none of which changes how
a value is compared. A single letter of any kind therefore costs a search its last start offset,
which is why the table above has `/s`, `/t` and `/T` rows.

`STRING_DEFAULT_RANGE` does not enter this. `str_range == 0` escapes both bounds, and that is what
a bare `search` leaves it at: `string_modifier_check`, which would default it to 100
(`file/src/apprentice.c:1769-1776`), is reached only through the flag loop, which in turn runs only
for a declaration that carries a `/` (`file/src/apprentice.c:2350-2354`). `file` 5.48 finds `ABC`
150 bytes into a file under a bare `search`, which is what PolyFile's `num_bytes is None` path
already does. This PR leaves that path alone.

## What the fix does

`StringMatch.search` computed the `memmem` window for every search:

```python
end_pos = min(len(data), self.num_bytes + len(self.string))
```

Two things are wrong with that, and neither is fixed by subtracting one.

**Which offsets are candidates.** `StringType` now reports whether the declaration carried any
modifier letter, reading the `FLAGS` table it already keeps, and passes that down to the value it
parses, beside `num_bytes`. `StringMatch.last_start_offset` returns `num_bytes - 1` for a flagged
search and `num_bytes` for a flagless one. Reading `FLAGS` is what picks up `s`, `t` and `b`, which
`StringMatch` has no other reason to know about.

**Where the bound goes.** It has to be on where a match starts, not on where it ends. `W` and `w`
both match a run of blanks of any length against one declared blank
(`file/src/softmagic.c:2102-2121`), so a match that starts at a candidate offset may end anywhere,
and a match that ends inside the old window may start past the last candidate offset. The old shape
was therefore wrong in both directions, and `search/4/w` is the case that shows it cannot be
repaired by moving the end bound: `A\ B` in `xxxxABzz` starts at offset 4 and ends at offset 6,
inside `num_bytes - 1 + len(value)`.

```console
$ printf '0\tsearch/4/W\tA\\ B\tfound\n' > win.magic
$ for s in 'xxxA   B' 'xxxxA   B'; do printf '%s' "$s" > in.bin; \
    printf '%-12s -> %s\n' "[$s]" "$(TZ=UTC ./file/src/file -b -m win.magic in.bin)"; done
[xxxA   B]   -> found, ASCII text, with no line terminators
[xxxxA   B]  -> ASCII text, with no line terminators
```

`master` reports neither as found. So this PR turns six false negatives into matches as well as
removing the sixteen false positives #3558 reports; over the 93-case grid I ran against `file` 5.48,
`master` diverges on 22 and this branch on none.

### How this interacts with #3560

#3560 put a per-candidate bound in this same method, and the two compose rather than overlap.
#3560's is libmagic's `if (slen + idx > ms->search.s_len)`, the rule that the value must still fit
in what is left of the buffer; this PR's is `idx < m->str_range`, the rule that limits how many
offsets are tried at all. They are the two conditions of the same loop, and both are now read off
`m.start()` for the reason #3560 gave: the leftmost match is the one libmagic takes, so a leftmost
match that fails either bound rules out every later offset too.

Both read `StringTest.value_length`, libmagic's `m->vallen`, and neither reads the
`SearchType.declared_length` that #3548 added. `s` zeroes `declared_length`, because
`REGEX_OFFSET_START` governs only where a following relative offset resolves from
(`file/src/softmagic.c:966-968`). It has nothing to do with the window, and it reaches this method
only by setting a `str_flags` bit. A third test pins that, and pins that the relative offset #3548
fixed still resolves the same way.

### The negated case

`NegatedStringTest.search` delegates to the test it wraps and inverts the result, so a narrower
window makes a negated search match more buffers. That is what `file` does: `search/4/w !ABC`
reports a match on `xxxxABC`, where `search/4 !ABC` does not. PolyFile now answers all twelve
combinations of `{search/4, search/4/w, search/4/c}` against
`{xxxABC, xxxxABC, xxxxxABC, zzzz}` the way `file` 5.48 does. This is the boundary #3563 is working
near, and it needs nothing from that PR.

## What the tests pin

Three tests in `StringDataTypeTest`, beside the ones #3548, #3553 and #3560 added.

`test_a_flag_costs_a_search_its_last_start_offset` is the reproducer: offsets 3, 4 and 5 under nine
flag spellings. With the fix reverted it fails on eight subtests, one per flagged spelling at offset
4. The flagless row is in the same loop on purpose, as a guard against a fix that narrows both
paths: I checked that an unconditional `num_bytes - 1` fails the `(flags='', offset=4)` subtest.

`test_a_search_bounds_where_a_match_starts_and_not_where_it_ends` pins the two cases the end-bound
shape answered wrongly, one under `W` and one under `w`. It fails on `master`.

`test_the_s_flag_narrows_the_window_without_changing_what_is_reported` pins that `s` narrows the
window and still reports `found ABCD` for `xxxABCD`, where the flagless `search/4` reports `found D`
for both `xxxABCD` and `xxxxABCD`. It fails on `master`.

## Verification

- Lint, both passes from `CLAUDE.md` and `.github/workflows/tests.yml:48`: clean. `flake8` reports
  the same 16 findings on `polyfile/magic.py` and `tests/test_magic.py` before and after this
  change, differing only in line numbers, so it adds none.
- `uv run pytest tests --ignore=tests/test_corkami.py`: 303 passed, 1374 subtests passed, up from
  300 and 1347 on `master`. No failures.
- `uv run pytest tests/test_corkami.py`: 906 passed, 1 skipped, unchanged.
- `uvx pip-audit`: no known vulnerabilities.
- Corpus differential over all 88 `file/tests/*.testfile` stems, with the `corpus_result_matches`
  normalization, `<stem>*.magic` sidecars, and `join_matches` for the `k` flag: **zero
  regressions**. 88 of 88 stems pass before and after, and the full set of reported matches is
  byte-identical for every stem, `gedcom` and `searchbug` included.
- Throughput is unchanged. The window no longer bounds the regex scan, so I measured it: 40 corpus
  files through `MagicMatcher.DEFAULT_INSTANCE`, 0.67 s before and 0.67 s after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
