### PR TITLE
Report an empty file the way libmagic does

### DIFF
--- a/polyfile/html.py
+++ b/polyfile/html.py
@@ -86,6 +86,9 @@ def generate(file_path, sbud):
     matches = assign_ids(sbud)
 
     input_bytes = sbud['length']
+    # the hex viewer's column header is indented by the width of its address gutter, and an empty
+    # file has no address to print
+    address_digits = math.ceil(math.log(input_bytes, 16)) if input_bytes > 0 else 0
     regions = undescribed_regions(matches, input_bytes)
     undescribed_bytes = sum(size for _, size in regions)
     with open(file_path, 'rb') as input_file:
@@ -171,7 +174,7 @@ def generate(file_path, sbud):
             matches=matches,
             input_file=input_file,
             input_bytes=input_bytes,
-            math=math,
+            address_digits=address_digits,
             read_unicode=ReadUnicode(),
             mime_type=mime_type,
             decoded_matches=decoded_matches,

--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -4574,6 +4574,47 @@ class OctetStreamTest(MagicTest):
         return self.test(data, absolute_offset, parent_match)
 
 
+class EmptyFileTest(MagicTest):
+    """Matches a zero-length buffer, which libmagic never runs a test against.
+
+    `file_buffer` short-circuits an empty buffer to the default description ahead of the text
+    encoding classifier and of every builtin and soft magic test (`file/src/funcs.c:360-362`
+    reaching `file/src/funcs.c:506-512`). The MIME type comes from `file_fsmagic`, which reads the
+    size out of `stat` and reports `inode/x-empty` without opening the file
+    (`file/src/fsmagic.c:406-411`). The `charset=binary` `file -i` prints alongside it is a MIME
+    encoding rather than a MIME type, and PolyFile reports no encodings, so this test carries only
+    the type.
+    """
+
+    AUTO_REGISTER_TEST = False
+
+    def __init__(
+            self,
+            offset: Offset = AbsoluteOffset(0),
+            mime: Union[str, TernaryExecutableMessage] = "inode/x-empty",
+            extensions: Iterable[str] = (),
+            message: Union[str, Message] = "empty",
+            parent: Optional["MagicTest"] = None,
+            comments: Iterable[Comment] = ()
+    ):
+        super().__init__(offset, mime, extensions, message, parent, comments)
+
+    def subtest_type(self) -> TestType:
+        return TestType.BINARY
+
+    def calculate_absolute_offset(self, data: bytes, parent_match: Optional[TestResult] = None) -> int:
+        # an empty buffer has no valid offset, and libmagic reports it without reading one
+        return self.offset.to_absolute(data, parent_match, allow_invalid=True)
+
+    def test(self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]) -> TestResult:
+        return MatchedTest(self, offset=absolute_offset, length=0, parent=parent_match, value=data)
+
+    def test_flip_endianness(
+            self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]
+    ) -> TestResult:
+        return self.test(data, absolute_offset, parent_match)
+
+
 TEST_PATTERN: Pattern[str] = re.compile(
     r"^(?P<level>[>]*)(?P<offset>[^\s!][^\s]*)\s+(?P<data_type>[^\s]+)\s+(?P<remainder>.+)$"
 )
@@ -4690,8 +4731,13 @@ class Match:
                 result = next(self._result_iter)
                 self._results.append(result)
                 if isinstance(result, IndirectResult):
-                    for match in self.matcher.match(self.context[result.offset:]):
-                        self._results.extend(match)
+                    indirect = self.context[result.offset:]
+                    # an indirect test re-enters soft magic over the sub-buffer rather than
+                    # classifying it (`file/src/softmagic.c:1949-1977`), so an offset at the end of
+                    # the file dispatches nothing instead of reporting the empty file
+                    if indirect.data:
+                        for match in self.matcher.match(indirect):
+                            self._results.extend(match)
             except StopIteration:
                 self._result_iter = None
         return self._results[index]
@@ -5049,6 +5095,11 @@ class MagicMatcher:
             to_match = MatchContext(to_match)
         elif not isinstance(to_match, MatchContext):
             to_match = MatchContext.load(to_match)
+        if not to_match.data:
+            # `file_buffer` reports an empty buffer before it classifies the encoding and before it
+            # runs a single test (`file/src/funcs.c:360-362`)
+            yield Match(matcher=self, context=to_match, results=EmptyFileTest().match(to_match))
+            return
         text_encoding = TextEncodingDescription.detect(to_match.data)
         yielded = False
         matched_on_the_files_bytes: Set[MagicTest] = set()

--- a/polyfile/templates/template.html
+++ b/polyfile/templates/template.html
@@ -81,7 +81,7 @@
             <center id="loading" style="cursor: wait;">
                 <br />Loading…<br />
             </center>
-            <span class="byterow">{% for i in range(math.ceil(math.log(input_bytes)/math.log(16))) %}&nbsp;{% endfor %}</span>{% for col in range(16) %}<span class="byte" style="color:gray">{{ '%x' % col }}</span>{% endfor %}
+            <span class="byterow">{% for i in range(address_digits) %}&nbsp;{% endfor %}</span>{% for col in range(16) %}<span class="byte" style="color:gray">{{ '%x' % col }}</span>{% endfor %}
             <br />
             {#
     {% for row in range(input_bytes // 16 + 1) %}

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -780,6 +780,61 @@ class MagicTest(TestCase):
         test = UnimplementedTest(offset=polyfile.magic.AbsoluteOffset(0), message="unimplemented")
         self.assertEqual([], list(test.match(b"any data at all")))
 
+    def test_an_empty_file_reports_empty(self):
+        """Tests that a zero-length buffer reports what `file` reports for one.
+
+        This is a regression test for trailofbits/polyfile#3566. Every level 0 test resolves an
+        absolute offset first, and offset 0 is out of bounds in a zero-length buffer, so the
+        `OctetStreamTest` fallback failed along with everything else and PolyFile printed nothing
+        at all. libmagic never reaches a test: `file_buffer` short-circuits `nb == 0` to the
+        description `empty` (`file/src/funcs.c:360-362`), and `file_fsmagic` reports
+        `inode/x-empty` off the size in `stat` (`file/src/fsmagic.c:406-411`).
+        """
+        matches = list(MagicMatcher.DEFAULT_INSTANCE.match(b""))
+        self.assertEqual(["empty"], [str(match) for match in matches])
+        self.assertEqual([{"inode/x-empty"}], [set(match.mimetypes) for match in matches])
+
+    def test_an_empty_file_runs_no_tests(self):
+        """Tests that the empty short-circuit sits above soft magic and the text classifier.
+
+        `file_buffer` jumps straight to its default description, past `file_encoding` and past
+        every builtin and soft magic test (`file/src/funcs.c:360-362`). Reporting `empty` from
+        the output layer instead would leave a hand-written negated test such as
+        `0 string !ABC found` matching a buffer libmagic never hands it.
+        """
+        with TemporaryDirectory() as tmp_dir:
+            definition = Path(tmp_dir) / "negated"
+            definition.write_text("0\tstring\t!ABC\tnegated matched\n")
+            matcher = MagicMatcher.parse(definition)
+        self.assertEqual({"negated matched"}, {str(match) for match in matcher.match(b"XYZ")})
+        self.assertEqual({"empty"}, {str(match) for match in matcher.match(b"")})
+
+    def test_an_empty_file_reports_empty_under_only_match_mime(self):
+        """Tests that `--format mime` reports the empty file's MIME type.
+
+        `MatchContext.only_match_mime` drops any test that cannot produce a MIME type, which is
+        the context `Analyzer.mime_types` and `Matcher.match` build, so the SBUD, JSON, HTML and
+        MIME outputs all read this path.
+        """
+        matches = list(MagicMatcher.DEFAULT_INSTANCE.match(MatchContext(b"", only_match_mime=True)))
+        self.assertEqual([{"inode/x-empty"}], [set(match.mimetypes) for match in matches])
+
+    def test_an_indirect_offset_at_the_end_of_the_file_reports_nothing(self):
+        """Tests that the empty short-circuit stays out of the indirect dispatch path.
+
+        An indirect test re-enters soft magic over the bytes after its offset
+        (`file/src/softmagic.c:1949-1977`) rather than classifying them, so an offset that lands
+        on the last byte plus one finds nothing. Reaching `MagicMatcher.match` there would append
+        the empty file's description to the parent match, and `file` reports `marker` for all
+        three buffers below.
+        """
+        with TemporaryDirectory() as tmp_dir:
+            definition = Path(tmp_dir) / "indirect_at_eof"
+            definition.write_text("2\tstring\tCD\tmarker\n>&0\tindirect\tx\n")
+            matcher = MagicMatcher.parse(definition)
+        self.assertEqual({"marker"}, {str(match) for match in matcher.match(b"ABCD")})
+        self.assertEqual({"marker"}, {str(match) for match in matcher.match(b"ABCDEF")})
+
     def test_corpus_comparison_is_exact_outside_two_allowances(self):
         """Tests that the corpus comparison is exact apart from its two documented allowances.
 

--- a/tests/unit/test_html.py
+++ b/tests/unit/test_html.py
@@ -104,6 +104,17 @@ class GeneratedHtmlTests(TestCase):
         self.assertIn('Every one of the 16 bytes is described by a match.', self.legend(html))
         self.assertNotIn('class="swatch undescribed"', html)
 
+    def test_an_empty_file_renders(self):
+        """The address gutter used to take the logarithm of the file's length.
+
+        This is a regression test for trailofbits/polyfile#3566. `math.log(0)` raises
+        `ValueError: expected a positive input`, so `--format html` aborted with a traceback on a
+        zero-length file rather than writing a viewer.
+        """
+        html = self.render(b'', [{**match(0, 0), 'type': 'inode/x-empty', 'name': 'inode/x-empty'}])
+        self.assertEqual([], self.emitted_regions(html))
+        self.assertIn('inode/x-empty', html)
+
     def test_the_style_the_viewer_applies_is_defined(self):
         html = self.render(bytes(16), [match(0, 16)])
         self.assertIn(".toggleClass('undescribed'", html)


### PR DESCRIPTION
Closes #3566

## Merge order

This branch sits on top of `54696a1`, which already carries #3563 (`fix/3557-negated-string-bound`)
and #3564 (`fix/3559-full-word-flag`). The one other PR open in this wave is #3567
(`fix/3558-search-start-offset-count`), which owns the start-offset window in `StringMatch.search`.
The two do not overlap: this change touches the top of `MagicMatcher.match`, the indirect dispatch
in `Match.__getitem__`, and the HTML template, and none of the string machinery. Either can merge
first; whichever lands second rebases cleanly.

Nothing downstream has to rebase onto this.

## The defect

The MIME type in the issue body is wrong. The reference binary at libmagic 5.48 reports
`inode/x-empty`, not `application/x-empty`, for a zero-length file given by path:

```console
$ : > empty.bin
$ TZ=UTC ./file/src/file -b    -m file/magic/magic.mgc empty.bin
empty
$ TZ=UTC ./file/src/file -b -i -m file/magic/magic.mgc empty.bin
inode/x-empty; charset=binary
```

`application/x-empty` is the buffer path, which `file` takes only for stdin or under `-s`.
PolyFile classifies a file, so `inode/x-empty` is the type to match.

### Before

| Output format | Behavior |
| --- | --- |
| default (`file`) | one blank line |
| `--format mime` | nothing |
| `--format explain` | nothing |
| `--format json`, `--format sbud` | valid JSON with `"struc": []` |
| `--format html` | **crash**: `ValueError: expected a positive input` out of `math.log(0)` |

### After

| Output format | Behavior |
| --- | --- |
| default (`file`) | `empty` |
| `--format mime` | `inode/x-empty` |
| `--format explain` | `inode/x-empty`, then the test that produced it |
| `--format json`, `--format sbud` | one `struc` entry: `{"offset": 0, "size": 0, "type": "inode/x-empty", "value": "empty", "subEls": []}` |
| `--format html` | a viewer, 124,662 bytes |

`--format file` is still rejected by argparse, which is #3497 and not touched here.

## What the fix does

**The short circuit.** Every level 0 test resolves an absolute offset before it runs, and
`AbsoluteOffset.to_absolute` raises `InvalidOffsetError` when the offset is not less than the
buffer's length. In a zero-length buffer that rejects offset 0, so every test failed, the
`OctetStreamTest` fallback at the end of `MagicMatcher.match` failed with them, and the matcher
yielded a `Match` holding no results.

libmagic never reaches a test. `file_buffer` short-circuits `nb == 0` to the description `empty`
(`file/src/funcs.c:360-362`, reaching the `simple:` label at `file/src/funcs.c:506-512`), ahead of
`file_encoding` and of every builtin and soft magic test. The MIME type comes from a different
place again: `file_fsmagic` reads the size out of `stat` and prints `inode/x-empty` without opening
the file (`file/src/fsmagic.c:406-411`).

This mirrors that position rather than special-casing the output. `MagicMatcher.match` yields an
`EmptyFileTest` and returns before it detects the text encoding, so an empty buffer reaches neither
the text classifier nor `OctetStreamTest` nor a single definition. Placing it here is what keeps a
hand-written negated test such as `0 string !ABC found` from reporting a match on an empty buffer,
which is the behavior the issue calls out and which #3557 deliberately left alone.

**The indirect guard.** `Match.__getitem__` dispatches an indirect test by re-entering
`MagicMatcher.match` over `self.context[result.offset:]`. A relative indirect adds its parent's
offset after the bounds check, so that slice can be empty, and the short circuit alone made
`2 string CD marker` / `>&0 indirect x` report `marker empty` for `ABCD` where `file` reports
`marker`. libmagic's `FILE_INDIRECT` runs `match()` over the sub-buffer rather than classifying it
(`file/src/softmagic.c:1949-1977`), so an empty sub-buffer dispatches nothing. The recursion now
skips an empty slice.

**The HTML crash.** The viewer's column header is indented by the width of its address gutter,
which `template.html` computed as `math.ceil(math.log(input_bytes)/math.log(16))`. `math.log(0)`
raises, so `--format html` aborted with a traceback. `generate` now computes the width, where the
file's length is already special-cased for the coverage percentage, and hands the template a count.
Nothing reached this before, because the analysis reported no match for an empty file at all. The
rendered HTML for a non-empty file is byte-identical to master's.

## On `charset=binary`

`file -i` prints `inode/x-empty; charset=binary`, but `charset` is a MIME *encoding*
(`MAGIC_MIME_ENCODING`), not a MIME type, and `handle_mime` prints the two separately
(`file/src/fsmagic.c`). PolyFile emits no encodings anywhere, and `file --mime-type` alone prints
`inode/x-empty`, which is what `--format mime` now matches. The clause is out of scope; this change
does not invent one.

## Tests

`tests/test_magic.py`:

* `test_an_empty_file_reports_empty` — the matcher reports exactly `empty` / `inode/x-empty` for
  `b""`. Fails without the short circuit: the matcher yields a `Match` with no results.
* `test_an_empty_file_runs_no_tests` — `0 string !ABC negated matched` reports `negated matched`
  for `XYZ` and only `empty` for `b""`. Fails without the short circuit, which is what pins the
  short circuit's *position* rather than the string it produces.
* `test_an_empty_file_reports_empty_under_only_match_mime` — the same verdict under
  `only_match_mime`, the context every MIME, SBUD, JSON, and HTML path builds.
* `test_an_indirect_offset_at_the_end_of_the_file_reports_nothing` — an indirect offset that lands
  at the end of the file reports `marker`, not `marker empty`. Fails without the guard, which is
  the regression the short circuit would otherwise introduce for non-empty files.

`tests/unit/test_html.py`:

* `test_an_empty_file_renders` — `generate` produces a viewer for a zero-length file. Fails
  without the template fix with the original `ValueError: expected a positive input`.

Each of the five was confirmed to fail with its fix reverted and to pass with it restored.

`tests/test_corkami.py`'s `KNOWN_BAD_FILES` has no zero-length entry to remove, and
`CorkamiCorpus.files` skips `info.file_size <= 0` by design; the corpus holds 944 entries, none of
them zero-length. `file/tests/` has no zero-length `.testfile` among its 88 stems either, so
neither corpus gains a case from this.

## Verification

* Corpus differential, 88 stems, normalized as `corpus_result_matches` does, with `<stem>*.magic`
  sidecars and `<stem>.flags` honored: 88 pass before, 88 pass after, and every reported
  description is byte-identical. **Zero regressions.**
* `uv run pytest tests/test_corkami.py`: 906 passed, 1 skipped.
* `uv run pytest tests --ignore=tests/test_corkami.py`: 312 passed, 1375 subtests passed.
* Blocking lint (`--select=E9,F63,F7,F82`): 0.
* Complexity pass over the touched files: no new findings; `polyfile/magic.py` and
  `polyfile/html.py` report exactly what they report on master.
* `uvx pip-audit`: no known vulnerabilities found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
