### PR TITLE
Map every archive in a file of concatenated ZIP archives

### DIFF
--- a/polyfile/zipmatcher.py
+++ b/polyfile/zipmatcher.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+from itertools import chain
 from pathlib import Path
 from typing import Iterator, Optional
 from zipfile import BadZipFile, ZipFile as PythonZip
@@ -11,6 +12,10 @@ from .structmatcher import PolyFileStruct
 from .structs import ByteField, Constant, Endianness, StructError, UInt16, UInt32
 
 log = StatusLogger("polyfile")
+
+LOCAL_FILE_HEADER_SIGNATURE = b"\x50\x4b\x03\x04"
+CENTRAL_DIRECTORY_SIGNATURE = b"\x50\x4b\x01\x02"
+EOCD_SIGNATURE = b"\x50\x4b\x05\x06"
 
 with ExactNamedTempfile(b"""# The default libmagic tests for detecting ZIPs assumes they start at byte offset zero
 0 search \\x50\\x4b\\x05\\x06 ZIP end of central directory record
@@ -58,7 +63,7 @@ MagicMatcher.DEFAULT_INSTANCE.add(RelaxedJarMatcher())
 class LocalFileHeader(PolyFileStruct):
     endianness = Endianness.LITTLE
 
-    magic: Constant[b"\x50\x4b\x03\x04"]
+    magic: Constant[LOCAL_FILE_HEADER_SIGNATURE]
     version_needed_to_extract: UInt16
     general_purpose_bit_flag: UInt16
     compression_method: UInt16
@@ -77,7 +82,7 @@ class LocalFileHeader(PolyFileStruct):
 class CentralDirectory(PolyFileStruct):
     endianness = Endianness.LITTLE
 
-    magic: Constant[b"\x50\x4b\x01\x02"]
+    magic: Constant[CENTRAL_DIRECTORY_SIGNATURE]
     version_made_by: UInt16
     version_needed_to_extract: UInt16
     general_bit_flag: UInt16
@@ -121,7 +126,7 @@ class CentralDirectory(PolyFileStruct):
 class EndOfCentralDirectory(PolyFileStruct):
     endianness = Endianness.LITTLE
 
-    magic: Constant[b"\x50\x4b\x05\x06"]
+    magic: Constant[EOCD_SIGNATURE]
     disk_number: UInt16
     start_disk: UInt16
     num_records: UInt16
@@ -169,26 +174,157 @@ class EndOfCentralDirectory(PolyFileStruct):
                 yield cd
                 cdo += cd.num_bytes
 
+    def terminates_archive(self, file_stream: FileStream, archive_end: int) -> bool:
+        """Checks whether this record ends an archive that ends at `archive_end`.
+
+        The four signature bytes also occur inside archive comments and inside the data of
+        stored members, so a record found by searching for them is only believable if it is
+        the last thing in its archive, which is where the record belongs, and if the central
+        directory it points to is really where it says it is.
+
+        Args:
+            file_stream: The stream containing the whole file, not only the archive.
+            archive_end: The byte offset at which the archive has to end.
+
+        Returns:
+            True if the record is consistent with the rest of the file.
+        """
+        archive_offset = (
+            self.start_offset - self.central_directory_bytes - self.central_directory_offset
+        )
+        record_end = self.start_offset + self.num_bytes
+        if record_end != archive_end or archive_offset < 0:
+            return False
+        elif self.total_records == 0:
+            return self.central_directory_bytes == 0
+        try:
+            with file_stream.save_pos() as f:
+                f.seek(archive_offset + self.central_directory_offset)
+                return f.read(len(CENTRAL_DIRECTORY_SIGNATURE)) == CENTRAL_DIRECTORY_SIGNATURE
+        except IndexError:
+            # FileStream.seek rejects a position past the end of the stream
+            return False
+
     @staticmethod
-    def load(file_stream: FileStream) -> Optional["EndOfCentralDirectory"]:
+    def read_at(file_stream: FileStream, offset: int) -> Optional["EndOfCentralDirectory"]:
+        """Reads a record at a byte offset.
+
+        Args:
+            file_stream: The stream containing the whole file, not only the archive.
+            offset: The byte offset of the record within the stream.
+
+        Returns:
+            The record, or None if the bytes at that offset are not a complete record.
+        """
+        try:
+            with file_stream.save_pos() as f:
+                f.seek(offset)
+                return EndOfCentralDirectory.read(f)
+        except (IndexError, StructError, ValueError):
+            return None
+
+    @staticmethod
+    def read_before(
+            file_stream: FileStream, data: bytes, base: int, search_end: int
+    ) -> Optional["EndOfCentralDirectory"]:
+        """Reads the last record that starts before a byte offset.
+
+        Args:
+            file_stream: The stream containing the whole file, not only the archive.
+            data: The contents of the stream from byte offset `base` onward.
+            base: The byte offset within the stream at which `data` starts.
+            search_end: The index within `data` before which the record must start.
+
+        Returns:
+            The last record before `search_end`, or None if there is none.
+        """
+        while search_end > 0:
+            candidate = data.rfind(EOCD_SIGNATURE, 0, search_end)
+            if candidate < 0:
+                return None
+            eocd = EndOfCentralDirectory.read_at(file_stream, base + candidate)
+            if eocd is not None:
+                return eocd
+            search_end = candidate + len(EOCD_SIGNATURE) - 1
+        return None
+
+    @staticmethod
+    def load_all(file_stream: FileStream) -> Iterator["EndOfCentralDirectory"]:
+        """Finds the end of central directory record of every archive in the file.
+
+        ZIP archives can be concatenated, and each archive keeps its own end of central
+        directory record, so the last record in a file describes only the last archive. The
+        search runs backwards from the end of the file and resumes ahead of the start of
+        each archive it reports, which is what keeps an archive stored inside another from
+        being reported as a sibling of it.
+
+        A record is only reported if it validates, because reporting an archive on the
+        strength of four signature bytes would invent one. When nothing in the file
+        validates, as in a ZIP64 archive or in one volume of a split archive, whose records
+        hold offsets these fields cannot express, the last record that reads is reported on
+        its own, which is the archive the search found before it looked for more than one.
+
+        Args:
+            file_stream: The stream containing the whole file.
+
+        Yields:
+            One record per archive, from the last archive in the file to the first.
+        """
         offset_before = file_stream.tell()
         try:
             data = file_stream.read()
         finally:
             file_stream.seek(offset_before)
-        # first, find the end of central directory record
-        eocd = data.rfind(b"\x50\x4b\x05\x06")
-        if eocd < 0:
+        archive_end = offset_before + len(data)
+        search_end = len(data)
+        found = False
+        while search_end > 0:
+            eocd = EndOfCentralDirectory.read_before(file_stream, data, offset_before, search_end)
+            if eocd is None:
+                break
+            elif not eocd.terminates_archive(file_stream, archive_end):
+                search_end = eocd.start_offset - offset_before + len(EOCD_SIGNATURE) - 1
+                continue
+            found = True
+            yield eocd
+            archive_end = eocd.archive_offset
+            search_end = archive_end - offset_before
+        if not found:
+            yield from EndOfCentralDirectory.load_unvalidated(file_stream, data, offset_before)
+
+    @staticmethod
+    def load_unvalidated(
+            file_stream: FileStream, data: bytes, base: int
+    ) -> Iterator["EndOfCentralDirectory"]:
+        """Reports the last record in a file in which no record validates.
+
+        Args:
+            file_stream: The stream containing the whole file.
+            data: The contents of the stream from byte offset `base` onward.
+            base: The byte offset within the stream at which `data` starts.
+
+        Yields:
+            The last record that reads, if the file holds one.
+        """
+        eocd = EndOfCentralDirectory.read_before(file_stream, data, base, len(data))
+        if eocd is None:
             log.warning(f"Could not find central directory record for {file_stream.name}")
-            return None
-        del data
-        try:
-            with file_stream.save_pos() as f:
-                f.seek(eocd)
-                return EndOfCentralDirectory.read(f)
-        except ValueError as e:
-            log.error(str(e))
-            return None
+        else:
+            yield eocd
+
+    @staticmethod
+    def load(file_stream: FileStream) -> Optional["EndOfCentralDirectory"]:
+        """Reads the end of central directory record of the last archive in the file.
+
+        Args:
+            file_stream: The stream containing the whole file.
+
+        Returns:
+            The record of the last archive, or None if the file holds no archive.
+        """
+        for eocd in EndOfCentralDirectory.load_all(file_stream):
+            return eocd
+        return None
 
 
 def open_archive(
@@ -239,12 +375,19 @@ def member_data(
         return None
 
 
-@register_parser("application/zip")
-@register_parser("application/java-archive")
-def parse_zip(file_stream, parent):
-    eocd = EndOfCentralDirectory.load(file_stream)
-    if eocd is None:
-        raise InvalidMatch()
+def parse_archive(
+        file_stream: FileStream, eocd: EndOfCentralDirectory, parent: Match
+) -> Iterator[Match]:
+    """Yields the matches for the one archive that ends at `eocd`.
+
+    Args:
+        file_stream: The stream containing the whole file, not only the archive.
+        eocd: The end of central directory record of the archive to parse.
+        parent: The match that contains the archive.
+
+    Yields:
+        A match for each record of the archive, and for the files its members contain.
+    """
     cds = list(eocd.central_directories(file_stream))
     fhs = list(cd.local_file_header(file_stream) for cd in cds)
     zf = open_archive(file_stream, eocd, fhs[0].start_offset) if fhs else None
@@ -261,3 +404,29 @@ def parse_zip(file_stream, parent):
     for cd in cds:
         yield from cd.match(matcher=parent.matcher, parent=parent)
     yield from eocd.match(matcher=parent.matcher, parent=parent)
+
+
+@register_parser("application/zip")
+@register_parser("application/java-archive")
+def parse_zip(file_stream, parent):
+    """Yields the matches for every archive in the file, the first archive first.
+
+    This returns an iterator instead of being a generator itself, so that an archive nested
+    inside another costs no more stack to parse than it did when a file held one archive.
+
+    Args:
+        file_stream: The stream containing the whole file.
+        parent: The match for the file.
+
+    Returns:
+        An iterator over the matches for every archive in the file.
+
+    Raises:
+        InvalidMatch: If the file holds no archive.
+    """
+    archives = list(EndOfCentralDirectory.load_all(file_stream))
+    if not archives:
+        raise InvalidMatch()
+    return chain.from_iterable(
+        parse_archive(file_stream, eocd, parent) for eocd in reversed(archives)
+    )

--- a/polyfile/zipmatcher.py
+++ b/polyfile/zipmatcher.py
@@ -1,12 +1,12 @@
 from io import BytesIO
 from pathlib import Path
 from typing import Iterator, Optional
-from zipfile import ZipFile as PythonZip
+from zipfile import BadZipFile, ZipFile as PythonZip
 
 from .fileutils import ExactNamedTempfile, FileStream, Tempfile
 from .logger import StatusLogger
 from .magic import AbsoluteOffset, FailedTest, MagicMatcher, MagicTest, MatchedTest, TestResult, TestType
-from .polyfile import InvalidMatch, register_parser
+from .polyfile import InvalidMatch, Match, register_parser
 from .structmatcher import PolyFileStruct
 from .structs import ByteField, Constant, Endianness, StructError, UInt16, UInt32
 
@@ -191,6 +191,54 @@ class EndOfCentralDirectory(PolyFileStruct):
             return None
 
 
+def open_archive(
+        file_stream: FileStream, eocd: EndOfCentralDirectory, start: int
+) -> Optional[PythonZip]:
+    """Opens an archive with Python's zipfile module, so that its members can be decompressed.
+
+    Args:
+        file_stream: The stream containing the whole file, not only the archive.
+        eocd: The end of central directory record of the archive.
+        start: The byte offset of the first local file header of the archive.
+
+    Returns:
+        The open archive, or None if zipfile refuses to read it.
+    """
+    with file_stream.save_pos():
+        file_stream.seek(start)
+        zip_data = file_stream.read(eocd.start_offset + eocd.num_bytes - start)
+    with Tempfile(zip_data) as tmp:
+        try:
+            return PythonZip(tmp)
+        except BadZipFile as e:
+            log.warning(f"Could not read the members of the archive at byte offset {start}: {e!s}")
+            return None
+
+
+def member_data(
+        zf: Optional[PythonZip], fh: LocalFileHeader, match: Match, parent: Match
+) -> Optional[bytes]:
+    """Decompresses the member of an archive whose compressed data a match covers.
+
+    Args:
+        zf: The archive as zipfile reads it, or None if zipfile refused to read it.
+        fh: The local file header of the member.
+        match: A match for one of the fields of `fh`.
+        parent: The match that contains the archive.
+
+    Returns:
+        The decompressed contents of the member, or None if `match` covers another field or
+        the member cannot be decompressed.
+    """
+    if zf is None or match.name != "compressed_data" or match.parent.parent != parent:
+        return None
+    try:
+        return zf.read(fh.file_name.decode("utf-8"))
+    except Exception:
+        log.warning(f"Error decompressing file {fh.file_name!r} at byte offset {match.offset}")
+        return None
+
+
 @register_parser("application/zip")
 @register_parser("application/java-archive")
 def parse_zip(file_stream, parent):
@@ -199,26 +247,17 @@ def parse_zip(file_stream, parent):
         raise InvalidMatch()
     cds = list(eocd.central_directories(file_stream))
     fhs = list(cd.local_file_header(file_stream) for cd in cds)
-    zf: Optional[PythonZip] = None
+    zf = open_archive(file_stream, eocd, fhs[0].start_offset) if fhs else None
     for fh in fhs:
-        if zf is None:
-            with file_stream.save_pos():
-                file_stream.seek(fh.start_offset)
-                zip_data = file_stream.read(eocd.start_offset + eocd.num_bytes - fh.start_offset)
-                with Tempfile(zip_data) as tmp:
-                    zf = PythonZip(tmp)
         for match in fh.match(matcher=parent.matcher, parent=parent):
-            is_data = False
-            if match.name == "compressed_data" and match.parent.parent == parent:
-                try:
-                    match.decoded = zf.read(fh.file_name.decode("utf-8"))
-                    is_data = True
-                except Exception as e:
-                    log.warning(f"Error decompressing file {fh.file_name!r} at byte offset {match.offset}")
+            decoded = member_data(zf, fh, match, parent)
+            if decoded is None:
+                yield match
+                continue
+            match.decoded = decoded
             yield match
-            if is_data:
-                with Tempfile(match.decoded) as tmp:
-                    yield from parent.matcher.match(tmp, parent=match)
+            with Tempfile(decoded) as tmp:
+                yield from parent.matcher.match(tmp, parent=match)
     for cd in cds:
         yield from cd.match(matcher=parent.matcher, parent=parent)
     yield from eocd.match(matcher=parent.matcher, parent=parent)

--- a/tests/test_zipmatcher.py
+++ b/tests/test_zipmatcher.py
@@ -2,15 +2,16 @@ from contextlib import contextmanager
 from io import BytesIO
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Dict, Iterator, List, Optional, Set
+from typing import Dict, Iterator, List, Optional, Set, Tuple
 from unittest import TestCase
+import struct
 import zipfile
 
 from polyfile.fileutils import FileStream
 from polyfile.magic import MagicMatcher, MatchContext
 from polyfile.polyfile import Match, Matcher
 from polyfile.structs import Constant
-from polyfile.zipmatcher import EndOfCentralDirectory, parse_zip
+from polyfile.zipmatcher import EOCD_SIGNATURE, EndOfCentralDirectory, parse_zip
 
 MEMBERS: Dict[str, bytes] = {
     "first.txt": b"the first member of the archive\n",
@@ -18,6 +19,9 @@ MEMBERS: Dict[str, bytes] = {
 }
 
 MANIFEST: Dict[str, bytes] = {"META-INF/MANIFEST.MF": b"Manifest-Version: 1.0\n\n"}
+
+# The size of an end of central directory record that carries no comment:
+EOCD_SIZE = 22
 
 # A minimal but valid PNG, so the prepended data is a real file type rather than filler:
 PNG = (
@@ -28,12 +32,19 @@ PNG = (
 )
 
 
-def build_zip(prefix: bytes = b"", members: Optional[Dict[str, bytes]] = None) -> bytes:
+def build_zip(
+        prefix: bytes = b"",
+        members: Optional[Dict[str, bytes]] = None,
+        comment: bytes = b"",
+        compression: int = zipfile.ZIP_DEFLATED,
+) -> bytes:
     """Builds a ZIP archive, optionally appended to unrelated leading data.
 
     Args:
         prefix: Bytes to place before the archive, as in a polyglot file.
         members: The archive members to write, defaulting to :data:`MEMBERS`.
+        comment: The archive comment, which the end of central directory record carries.
+        compression: The compression method to store the members with.
 
     Returns:
         The contents of the resulting file.
@@ -41,9 +52,10 @@ def build_zip(prefix: bytes = b"", members: Optional[Dict[str, bytes]] = None) -
     if members is None:
         members = MEMBERS
     buffer = BytesIO()
-    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+    with zipfile.ZipFile(buffer, "w", compression) as archive:
         for name, content in members.items():
             archive.writestr(name, content)
+        archive.comment = comment
     return prefix + buffer.getvalue()
 
 
@@ -75,6 +87,25 @@ class TestZipMatcher(TestCase):
 
     def parsed_names(self, data: bytes) -> List[str]:
         return [match.name for match in self.parsed_matches(data)]
+
+    def archive_offsets(self, data: bytes) -> List[int]:
+        """Returns the byte offset at which each archive in the file starts, first one first."""
+        with temporary_file(data) as path, FileStream(str(path)) as stream:
+            return [eocd.archive_offset for eocd in EndOfCentralDirectory.load_all(stream)][::-1]
+
+    def records(self, data: bytes) -> List[Tuple[str, int]]:
+        """Returns the name and byte offset of every ZIP record that `parse_zip` maps."""
+        parent = Match("application/zip", None, 0, length=len(data), matcher=Matcher(parse=False))
+        with temporary_file(data) as path, FileStream(str(path)) as stream:
+            return [
+                (match.name, match.offset)
+                for match in parse_zip(stream, parent)
+                if match.parent is parent
+            ]
+
+    def record_offsets(self, data: bytes, name: str) -> List[int]:
+        """Returns the byte offset of every mapped ZIP record of one kind."""
+        return [offset for record_name, offset in self.records(data) if record_name == name]
 
     def matched_mime_types(self, data: bytes) -> Set[str]:
         with temporary_file(data) as path, FileStream(str(path)) as stream:
@@ -135,6 +166,103 @@ class TestZipMatcher(TestCase):
         """The nested match on the magic ran parse_zip on four bytes, which logged a warning."""
         with self.assertNoLogs("polyfile", "WARNING"):
             self.parsed_matches(build_zip(), parse=True)
+
+    def test_concatenated_archives(self):
+        """Regression test for #3466.
+
+        `EndOfCentralDirectory.load` searched with `rfind`, so only the last archive of a
+        file holding concatenated archives was walked. Every byte of the archives before it
+        went unmapped, even though the match claimed to span the whole file.
+        """
+        first, second = build_zip(), build_zip(members=MANIFEST)
+        self.assertEqual([0, len(first)], self.archive_offsets(first + second))
+        self.assertEqual(
+            [len(first) - EOCD_SIZE, len(first) + len(second) - EOCD_SIZE],
+            self.record_offsets(first + second, "EndOfCentralDirectory"),
+        )
+        headers = self.record_offsets(first + second, "LocalFileHeader")
+        self.assertEqual(len(MEMBERS) + len(MANIFEST), len(headers))
+        self.assertEqual(0, headers[0])
+
+    def test_three_concatenated_archives(self):
+        parts = [build_zip(), build_zip(members=MANIFEST), build_zip(members=MEMBERS)]
+        data = b"".join(parts)
+        self.assertEqual(
+            [0, len(parts[0]), len(parts[0]) + len(parts[1])], self.archive_offsets(data)
+        )
+        self.assertEqual(3, len(self.record_offsets(data, "EndOfCentralDirectory")))
+
+    def test_single_archive_is_one_archive(self):
+        self.assertEqual([0], self.archive_offsets(build_zip()))
+        self.assertEqual([len(PNG)], self.archive_offsets(build_zip(PNG)))
+
+    def test_nested_archive_is_not_a_sibling(self):
+        """An archive stored inside another is a member of it, not a second archive.
+
+        The signature of the stored archive's end of central directory record is in the
+        bytes of the containing archive, so a search that took every occurrence at face
+        value would report the two as siblings that overlap.
+        """
+        inner = build_zip(members=MANIFEST)
+        outer = build_zip(members={"inner.zip": inner}, compression=zipfile.ZIP_STORED)
+        self.assertEqual([0], self.archive_offsets(outer))
+        self.assertEqual(1, len(self.record_offsets(outer, "EndOfCentralDirectory")))
+        self.assertEqual([0], self.record_offsets(outer, "LocalFileHeader"))
+
+    def test_signature_in_archive_comment(self):
+        """A comment holding the signature bytes does not end an archive.
+
+        Before the fix the search stopped at the occurrence in the comment and read a record
+        out of the comment text, which failed and left the archive unmapped.
+        """
+        data = build_zip(comment=b"a comment holding \x50\x4b\x05\x06 in the middle of it")
+        self.assertEqual([0], self.archive_offsets(data))
+        self.assertEqual(len(MEMBERS), len(self.record_offsets(data, "LocalFileHeader")))
+
+    def test_comment_that_reads_as_a_record(self):
+        """A comment can hold bytes that read as a whole record, and still not be one.
+
+        22 zero bytes are a valid record for an empty archive, so a comment holding them is
+        only told apart from a second archive by where the record they read as would have to
+        end.
+        """
+        data = build_zip(comment=EOCD_SIGNATURE + bytes(18) + b" and the rest of the comment")
+        self.assertEqual([0], self.archive_offsets(data))
+        self.assertEqual(len(MEMBERS), len(self.record_offsets(data, "LocalFileHeader")))
+
+    def test_comment_that_ends_in_a_record(self):
+        """A comment whose last bytes read as a record is told apart by its central directory.
+
+        The forged record ends where a real one would, so the only thing left that separates
+        it from a second archive is that nothing points back at a central directory.
+        """
+        forged = EOCD_SIGNATURE + struct.pack("<HHHHIIH", 0, 0, 1, 1, 46, 0, 0)
+        data = build_zip(comment=b"a comment that ends in " + forged)
+        self.assertEqual([0], self.archive_offsets(data))
+        self.assertEqual(len(MEMBERS), len(self.record_offsets(data, "LocalFileHeader")))
+
+    def test_trailing_signature_is_not_an_archive(self):
+        """Bytes after an archive that start with the signature do not hide the archive.
+
+        Before the fix the search took the trailing occurrence, read a record that was not
+        there, and mapped nothing at all.
+        """
+        data = build_zip() + EOCD_SIGNATURE + b"\xde\xad\xbe\xef" * 4
+        self.assertEqual([0], self.archive_offsets(data))
+        self.assertEqual(len(MEMBERS), len(self.record_offsets(data, "LocalFileHeader")))
+
+    def test_archive_that_zipfile_refuses_is_still_mapped(self):
+        """The structure of an archive is reported even when its members cannot be read.
+
+        Python's zipfile locates the end of central directory record with the same backwards
+        search, so a comment holding the signature makes it refuse the file. Its refusal used
+        to abort the parse and leave every record of the archive unmapped.
+        """
+        data = build_zip(comment=b"a comment holding \x50\x4b\x05\x06 in the middle of it")
+        self.assertEqual(
+            len(MEMBERS) * 2 + 1,
+            len([name for name, _ in self.records(data)]),
+        )
 
     def test_jar_with_prepended_data(self):
         """RelaxedJarMatcher reads local file headers, so it needs the archive offset too."""


### PR DESCRIPTION
Closes #3466
Closes #3530

## Merge order

Nothing blocks this one, and nothing waits on it except the meta-issue it finishes.
It builds on the stream half of #3530, which landed as PR #3556: `parse_zip` only sees a
correctly positioned stream because of that change. #3552 and the pending `FileStream`
length PR are in flight alongside this, and neither touches `polyfile/zipmatcher.py`, so
they merge in either order.

## The defect

`EndOfCentralDirectory.load` located the end of central directory record with
`data.rfind(b"\x50\x4b\x05\x06")`. `rfind` returns the last occurrence, so `parse_zip`
walked the central directory of the last archive in the file and of no other.

```python
import zipfile, io
def mk(name, body):
    b = io.BytesIO(); zipfile.ZipFile(b, "w").writestr(name, body); return b.getvalue()
a, c = mk("a.txt", b"hello\n"), mk("b.txt", b"world\n")
open("two.zip", "wb").write(a + c)   # first archive 0-113, second starts at 114
```

Before, on `master` at 71e3fe9. The match spans the whole file, and the first thing mapped
inside it is at byte 114. Bytes 0 to 113 — a complete, valid archive — are described by
nothing:

```
application/zip @0 +228
  LocalFileHeader @114 +41
  CentralDirectory @155 +51
  EndOfCentralDirectory @206 +22
```

After:

```
application/zip @0 +228
  LocalFileHeader @0 +41
  CentralDirectory @41 +51
  EndOfCentralDirectory @92 +22
  LocalFileHeader @114 +41
  CentralDirectory @155 +51
  EndOfCentralDirectory @206 +22
```

Three concatenated archives map as three, at 0, 114, and 228.

## What the fix does

`EndOfCentralDirectory.load_all` searches backwards over every occurrence of the signature
instead of stopping at the last one, and resumes ahead of the start of each archive it
reports. Where it resumes is what tells concatenation apart from nesting: the records of an
archive stored inside another lie within the bytes of the archive that holds it, so they are
behind the point the search has already reached and are never examined. An archive stored in
another is still reported, through the recursion that decompresses each member, exactly as
it was before.

Four signature bytes are not an archive. A ZIP comment can hold them, so can the data of a
stored member, and 22 zero bytes read as a valid record for an empty archive.
`EndOfCentralDirectory.terminates_archive` therefore checks a candidate the way
`archive_offset` already reasons about the record it is given:

- The record has to end exactly where its archive ends — at the end of the file for the last
  archive, and at the start of the next archive for an earlier one. A record is the last
  thing in its archive, so this is where it belongs. Python's `zipfile` makes the same check
  in `_EndRecData`, comparing the comment length against the bytes that follow the record.
- The offset arithmetic has to be representable: `start_offset - central_directory_bytes -
  central_directory_offset` cannot be negative.
- The central directory it points to has to start with `PK\x01\x02`. An empty archive has no
  central directory, so its record is carried by the first two checks alone.

Reporting an archive on weaker evidence than that would invent one, in bytes that are already
accounted for. There is one deliberate exception, for the record that is alone in its file:
when nothing in the file validates, the last record that reads is reported on its own. That is
what a ZIP64 archive and one volume of a split archive need, since both hold offsets that the
32-bit fields of this record cannot express — `pocs-master/zip/zip64.zip` stores
`central_directory_offset = 0xFFFFFFFF`, and `pocs-master/zip/volume.zip.002` points at a
central directory in a different file. Both keep the record they were given before this
change. Without that fallback they lose it, which the corpus differential caught.

Two smaller changes come with it:

- Handing the archive to Python's `zipfile` to decompress the members is now a step that can
  fail on its own. It used to let `BadZipFile` out, which threw away the whole parse
  including the records the archive really has. `zipfile` locates the record with the same
  backwards search this code used to, so a comment holding the signature bytes makes it
  refuse a file whose structure is otherwise readable.
- `parse_zip` returns an iterator rather than being a generator. That keeps the stack cost of
  parsing unchanged, which matters for `pocs-master/zip/gynvael/THI_2018_files.zip`: it is a
  recursive archive whose depth is bounded by the interpreter's recursion limit, so one extra
  frame per level shortened its output by 1,650 matches. With the iterator, it is untouched.

## What the tests pin

`tests/test_zipmatcher.py` grows from 8 tests to 17. Each new test was checked by breaking
the part of the search it covers and confirming it fails:

| Test | Fails when |
| --- | --- |
| `test_concatenated_archives`, `test_three_concatenated_archives` | the search stops at the last record, as `rfind` did |
| `test_comment_that_reads_as_a_record` | the record is not required to end where its archive ends |
| `test_comment_that_ends_in_a_record` | the central directory the record points to is not checked |
| `test_trailing_signature_is_not_an_archive` | the fallback for a file in which nothing validates is removed |
| `test_archive_that_zipfile_refuses_is_still_mapped`, `test_signature_in_archive_comment` | `zipfile`'s refusal is allowed out of the parser again |
| `test_nested_archive_is_not_a_sibling` | both the resume point and the validation are removed |

`test_single_archive_is_one_archive` pins the common case. The two tests PR #3534 added,
`test_no_matches_inside_constant_fields` and `test_no_parser_warning_for_constant_fields`,
still pass.

## Verification

**Output differential**, in the manner of PR #3549 and PR #3545: every match's name, offset,
and length over 351 files — the 57 files in the Corkami corpus that contain a ZIP signature,
200 more Corkami files sampled at random, the 88 `file/tests/*.testfile` fixtures, and 6
constructed archives. Both runs used the same interpreter and the same virtualenv, with only
`polyfile/zipmatcher.py` swapped.

```
files changed: 4 of 351
total: 52765 -> 53015 (+250/-0)
```

**No match was lost, on any file.** All 250 gains are on the constructed files: the two- and
three-archive concatenations, and two files that mapped nothing at all before — one archive
whose comment contains the signature bytes, and one with a trailing signature that is not a
record. Every Corkami file, the recursive archive included, is byte-for-byte identical.

Worth saying plainly: the Corkami corpus contains no concatenated archives. One file of the
943 holds more than one occurrence of the signature (`pocs-master/pdf/1016garbage.pdf`, which
is random bytes), and it still reports one archive. The corpus shows that nothing regressed,
not that the new case is common there.

**libmagic corpus differential**: all 88 stems pass before and after, and no stem's reported
matches changed. This change is in the parser rather than in matching, so that is a
regression guard, not evidence the fix works; the reproducer above is the evidence.

**Lint, tests, audit**

```
flake8 --select=E9,F63,F7,F82 ... : 0
flake8 polyfile/zipmatcher.py --max-complexity=8 --max-line-length=100: clean
pytest tests --ignore=tests/test_corkami.py: 304 passed, 1268 subtests passed
uvx pip-audit: No known vulnerabilities found
```

The complexity pass over the whole package reports one finding fewer than `master` does; the
one that goes away is the unused exception variable in the code this moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
