### PR TITLE
Accept any whitespace byte for a compact-whitespace blank

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -81,6 +81,9 @@ VALUE_TERMINATOR: Pattern[bytes] = re.compile(rb"[\0\r\n]")
 MAX_STRING_BYTES: int = 128
 # what the `f` flag requires after a match: `file/src/softmagic.c:2127-2130`
 FULL_WORD_TERMINATOR: bytes = rb"(?=[\0\s]|\Z)"
+# what a blank of a `W` or `w` value accepts: any byte C `isspace` accepts in the `C` locale, never
+# the value's own whitespace byte (`file/src/softmagic.c:2102-2121`)
+BLANK_CLASS: bytes = rb"[ \t\n\v\f\r]"
 ESCAPES = {
     "n": ord("\n"),
     "r": ord("\r"),
@@ -89,6 +92,49 @@ ESCAPES = {
     "t": ord("\t"),
     "f": ord("\f")
 }
+
+
+def compact_blanks(pattern: bytes, value: bytes) -> bytes:
+    """Renders the blanks of an `re.escape`-ed pattern the way the `W` string flag asks for.
+
+    Runs of an identical byte are collapsed into a counted repetition, and every blank counts as
+    the same byte however the value spelled it, so `A\\t\\ B` asks for two blanks of any kind.
+
+    Args:
+        pattern: The escaped value, which may already carry case-insensitive character classes.
+        value: The unescaped value, for the error message.
+
+    Returns:
+        The pattern with each run of *n* blanks replaced by *n* or more blanks of any kind.
+
+    Raises:
+        ValueError: If `pattern` ends in a backslash that escapes nothing.
+    """
+    runs: List[Tuple[bytes, int]] = []
+    escaped = False
+    for c in (bytes([b]) for b in pattern):
+        if escaped:
+            c = b"\\" + c
+            escaped = False
+        elif c == b"\\":
+            escaped = True
+            continue
+        if c[-1:] in WHITESPACE:
+            c = BLANK_CLASS
+        if runs and runs[-1][0] == c:
+            runs[-1] = (c, runs[-1][1] + 1)
+        else:
+            runs.append((c, 1))
+    if escaped:
+        raise ValueError(f"Error parsing search pattern {value!r}")
+    compacted = bytearray()
+    for c, count in runs:
+        compacted.extend(c)
+        if c == BLANK_CLASS:
+            compacted.extend(b"+" if count == 1 else f"{{{count},}}".encode("utf-8"))
+        elif count > 1:
+            compacted.extend(f"{{{count}}}".encode("utf-8"))
+    return bytes(compacted)
 
 
 def unescape(to_unescape: Union[str, bytes]) -> bytes:
@@ -2138,9 +2184,15 @@ class StringMatch(StringTest):
     def pattern_string(self) -> bytes:
         """Builds the regular expression that implements this test's string flags.
 
-        A definition may set both ``W`` (compact whitespace) and ``w`` (optional blanks);
-        ``polyfile/magic_defs/sgml`` does. libmagic keeps both bits and lets ``W`` win, because
-        ``file_strncmp`` tests it first (``file/src/softmagic.c:2103-2120``).
+        A definition may set both ``W`` (compact whitespace) and ``w`` (optional blanks). libmagic
+        keeps both bits and lets ``W`` win, because ``file_strncmp`` tests it first
+        (``file/src/softmagic.c:2103-2120``).
+
+        Neither flag compares the value's own whitespace byte. Each blank of a ``W`` value asks for
+        one byte that C ``isspace`` accepts, and after the last blank of a run libmagic skips
+        whatever whitespace is left (``file/src/softmagic.c:2102-2115``), so a run of *n* blanks
+        compiles to *n* or more blanks. ``w`` drops the lower bound and compiles to zero or more
+        (``file/src/softmagic.c:2116-2121``). Both take their byte set from `BLANK_CLASS`.
 
         ``f`` (full word) constrains only what follows the match, and it asks for whitespace rather
         than a word boundary: ``file_strncmp`` runs ``if (*b && !isspace(*b)) v = 1;`` once the
@@ -2164,35 +2216,9 @@ class StringMatch(StringTest):
             for ordinal in range(ord('A'), ord('Z') + 1):
                 pattern = pattern.replace(bytes([ordinal]), f"[{chr(ordinal)}{chr(ordinal+delta)}]".encode("utf-8"))
         if self.compact_whitespace:
-            new_pattern_bytes: List[Tuple[bytes, int]] = []
-            escaped = False
-            for c in (bytes([b]) for b in pattern):
-                if escaped:
-                    c = b"\\" + c
-                    escaped = False
-                elif c == b"\\":
-                    escaped = True
-                    continue
-                if new_pattern_bytes and new_pattern_bytes[-1][0] == c:
-                    new_pattern_bytes[-1] = (c, new_pattern_bytes[-1][1] + 1)
-                else:
-                    new_pattern_bytes.append((c, 1))
-            if escaped:
-                raise ValueError(f"Error parsing search pattern {self.string!r}")
-            pattern_bytes = bytearray()
-            for c, count in new_pattern_bytes:
-                pattern_bytes.extend(c)
-                if c in (b'\\ ', b'\\s', b'\\t', b'\\r', b'\\v', b'\\f'):
-                    # this is whitespace
-                    if count == 1:
-                        pattern_bytes.extend(b"+")
-                    else:
-                        pattern_bytes.extend(f"{{{count},}}".encode("utf-8"))
-                elif count > 1:
-                    pattern_bytes.extend(f"{{{count}}}".encode("utf-8"))
-            pattern = bytes(pattern_bytes)
+            pattern = compact_blanks(pattern, self.string)
         elif self.optional_blanks:
-            pattern = BLANK_IN_PATTERN.sub(rb"\\s*", pattern)
+            pattern = BLANK_IN_PATTERN.sub(lambda _: BLANK_CLASS + b"*", pattern)
         if self.full_word_match:
             pattern += FULL_WORD_TERMINATOR
         return pattern

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1300,16 +1300,19 @@ class StringDataTypeTest(TestCase):
         self.assertTrue(blanks.match(b"ABx", blanks.parse_expected("A\\tB")))
 
     def test_compact_whitespace_wins_over_optional_blanks(self):
-        """`StringMatch` raised when a definition set both `W` and `w`, as `magic_defs/sgml` does.
+        """`StringMatch` raised when a definition set both `W` and `w`.
 
         libmagic keeps both bits and lets `W` win, because `file_strncmp` tests it first
-        (`file/src/softmagic.c:2103-2120`).
+        (`file/src/softmagic.c:2103-2120`). The tab case pins that `W` keeps its byte set as well
+        as its lower bound when `w` is also set; `file` 5.48 reports `found` for `A\\tB` and not
+        for `AB`.
         """
         both = StringType.parse("string/Ww")
         self.assertTrue(both.compact_whitespace)
         self.assertTrue(both.optional_blanks)
         expected = both.parse_expected("A\\ B")
         self.assertTrue(both.match(b"A  B", expected))
+        self.assertTrue(both.match(b"A\tB", expected))
         self.assertFalse(both.match(b"AB", expected))
 
     def test_search_b_flag_is_not_optional_blanks(self):
@@ -1651,6 +1654,81 @@ class StringDataTypeTest(TestCase):
         definition = "0\tsearch/4/fb\tABC\tfound\n"
         self.assertEqual({"found"}, self.messages(definition, b"ABC\x00zz"))
         self.assertEqual({"data"}, self.messages(definition, b"ABC\x01zz"))
+
+    def test_compact_whitespace_accepts_any_whitespace_byte(self):
+        r"""A `W` blank repeated the value's own byte, so a tab never matched a declared space.
+
+        libmagic never compares the whitespace byte the value declares. A blank asks for
+        `isspace(*b)` and then skips whatever whitespace is left
+        (`file/src/softmagic.c:2102-2115`). The accepted set is C `isspace` in the `C` locale,
+        which is the same six bytes Python's `\s` matches in a bytes pattern.
+
+        `\xa0` is the guard against widening the class too far. `file(1)` accepts it as a seventh
+        byte on this host, but only because `main` adopts the caller's locale
+        (`file/src/file.c:211`) and macOS classifies `\xa0` as a space in a UTF-8 one; under
+        `LC_ALL=C`, `file` 5.48 reports `found` for the first group here and not for the second.
+        """
+        compact = StringType.parse("string/W")
+        space_in_value = compact.parse_expected("A\\ B")
+        for data in (b"A B", b"A\tB", b"A\nB", b"A\x0bB", b"A\x0cB", b"A\rB", b"A \t\r B"):
+            with self.subTest(data=data):
+                self.assertTrue(compact.match(data, space_in_value))
+        for data in (b"AB", b"ABx", b"AxB", b"A.B", b"A\xa0B"):
+            with self.subTest(data=data):
+                self.assertFalse(compact.match(data, space_in_value))
+
+    def test_compact_whitespace_ignores_the_blank_the_value_declares(self):
+        r"""A value that writes a tab or a newline compiled to that literal byte with no repetition.
+
+        Only the escaped space was recognized as a blank, so `magic_defs/perl:47`'s `\=pod\n`
+        demanded exactly one line feed. libmagic reads the value's blank through `isspace(*a)`
+        alone (`file/src/softmagic.c:2102-2103`), so which blank a definition writes is not
+        observable. `file` 5.48 agrees with every case here.
+        """
+        compact = StringType.parse("string/W")
+        for value in ("A\\tB", "A\\nB", "A\\ B"):
+            expected = compact.parse_expected(value)
+            with self.subTest(value=value):
+                for data in (b"A B", b"A\tB", b"A\nB", b"A  B"):
+                    self.assertTrue(compact.match(data, expected), repr(data))
+                self.assertFalse(compact.match(b"AB", expected))
+
+    def test_compact_whitespace_requires_one_blank_for_each_it_declares(self):
+        """`W` differs from `w` in its lower bound, and the fix for the byte set has to keep it.
+
+        libmagic consumes one whitespace byte per declared blank before it skips the rest of the
+        run (`file/src/softmagic.c:2102-2115`), where `w` consumes a run of any length including
+        none (`file/src/softmagic.c:2116-2121`). `file` 5.48 reports `found` for `A  B` under both
+        flags, for `ABxx` under `w` alone, and for none of `A B`, `A Bx`, `AB` or `ABxx` under `W`.
+        The four-byte cases matter on their own: a value never matches a buffer shorter than the
+        length it declares, so a three-byte buffer fails the bound that
+        `test_a_value_longer_than_the_buffer_does_not_match` covers before the lower bound here is
+        reached.
+        """
+        compact = StringType.parse("string/W")
+        two_blanks = compact.parse_expected("A\\ \\ B")
+        for data in (b"A  B", b"A\t\nB", b"A   B", b"A \t\r B"):
+            with self.subTest(data=data):
+                self.assertTrue(compact.match(data, two_blanks))
+        for data in (b"A B", b"A\tB", b"A Bx", b"AB", b"ABxx"):
+            with self.subTest(data=data):
+                self.assertFalse(compact.match(data, two_blanks))
+        blanks = StringType.parse("string/w")
+        self.assertTrue(blanks.match(b"ABxx", blanks.parse_expected("A\\ \\ B")))
+
+    def test_the_dos_batch_table_reports_a_tab_after_echo(self):
+        r"""`magic_defs/msdos:13` writes `echo\ off`, and a batch file may write the blank as a tab.
+
+        PolyFile reported the file as plain text, because the definition's space matched only a
+        space. `magic_defs/perl:47` is the same defect on a newline. `file` 5.48 reports
+        `DOS batch file, ASCII text, with CRLF line terminators` and
+        `Perl POD document, ASCII text`.
+        """
+        batch = MagicMatcher.DEFAULT_INSTANCE.match(b"@echo\toff\r\ndir\r\n")
+        self.assertEqual({"DOS batch file, ASCII text, with CRLF line terminators"},
+                         {str(match) for match in batch})
+        pod = MagicMatcher.DEFAULT_INSTANCE.match(b"=pod\x0bNAME\n")
+        self.assertEqual({"Perl POD document, ASCII text"}, {str(match) for match in pod})
 
     def test_the_interpreter_line_table_reports_a_posix_shell_script(self):
         """Every `f` definition in `magic_defs/commands` declares a value that starts with `#`.


### PR DESCRIPTION
Closes #3562

## Merge order

This PR is independent and can merge from its current base, `fde96d4`. It touches
`StringMatch.pattern_string` and the helper it now calls, which is the same method PR #3564
changed for the `f` flag; that one is already merged, and nothing else is open against
`polyfile/magic.py`. Two issues this work turned up are filed and left for later, refs #3570 and
refs #3571; whoever takes either rebases onto this.

## Reproducer

Before, on `master` at `fde96d4`:

```console
$ printf '@echo\toff\r\ndir\r\n' > bat_tab.bin
$ TZ=UTC ./file/src/file -b -m ./file/magic/magic.mgc bat_tab.bin
DOS batch file, ASCII text, with CRLF line terminators
$ python -c "from polyfile.magic import MagicMatcher; \
    print(sorted({str(m) for m in MagicMatcher.DEFAULT_INSTANCE.match(open('bat_tab.bin','rb').read())}))"
['ASCII text, with CRLF line terminators']
```

After:

```console
$ python -c "from polyfile.magic import MagicMatcher; \
    print(sorted({str(m) for m in MagicMatcher.DEFAULT_INSTANCE.match(open('bat_tab.bin','rb').read())}))"
['DOS batch file, ASCII text, with CRLF line terminators']
```

The same file written with a space was reported correctly all along, so only the whitespace byte
differed. `magic_defs/perl:47` is the same defect on a newline: `=pod\x0bNAME\n` now reports
`Perl POD document, ASCII text`, which is what `file` reports for it.

## What the fix does

`StringMatch.pattern_string` collapsed runs of an identical byte and appended a repetition operator
to the whitespace ones, which left the byte itself literal:

```python
if c in (b'\\ ', b'\\s', b'\\t', b'\\r', b'\\v', b'\\f'):
```

`re.escape` renders a tab as a backslash followed by the tab byte, not as the two characters `\t`,
so only the first of those six entries ever matched. A value written with a space demanded a space,
and a value written with a tab or a newline compiled to that byte with no repetition at all.

libmagic never compares the whitespace byte the value declares. A blank asks for `isspace(*b)`, and
once the next value byte is not itself a blank the rest of the run is skipped
(`file/src/softmagic.c:2102-2115`):

```c
else if ((flags & STRING_COMPACT_WHITESPACE) && isspace(*a)) {
	a++;
	if (isspace(*b)) {
		b++;
		if (!isspace(*a))
			while (b < eb && isspace(*b))
				b++;
	}
	else {
		v = 1;
		break;
	}
}
```

Three things follow from that source, each confirmed against `file` 5.48 before the pattern was
written:

- The lower bound stays. Every declared blank consumes one byte before the skip runs, so a run of
  *n* blanks compiles to *n* or more, which is what separates `W` from `w`. `file` reports `found`
  for `A  B` under `0 string/W A\ \ B` and not for `A B`, `A Bx` or `ABxx`.
- Only the character class was wrong. Which blank the value writes is not observable, because
  `isspace(*a)` is all that reads it: `0 string/W A\tB` and `0 string/W A\ B` accept the same
  inputs.
- The accepted set is C `isspace`. Enumerating all 256 separator bytes against `file` under
  `LC_ALL=C` gives exactly `\t`, `\n`, `\v`, `\f`, `\r` and the space, which is the same six bytes
  Python's `\s` matches in a bytes pattern, as PR #3564 found for `f`. That agreement was checked
  rather than assumed, and the same enumeration shows it is not the whole story: under the ambient
  `en_US.UTF-8` locale `file` accepts `\xa0` as a seventh byte, for `f` as well as for `W`, because
  `main` calls `setlocale(LC_CTYPE, "")` (`file/src/file.c:211`) and macOS classifies that byte as
  a space in a UTF-8 locale. That is a property of the host, not of the format, so the class here
  is the `C` locale set and a test pins `\xa0` out of it.

`BLANK_CLASS` names that set, and both `W` and `w` render from it, which keeps the two flags from
drifting apart. `w` compiled to `\s*` before and to the same six bytes now, so it is unchanged. The
run collapsing moves out of `pattern_string` into `compact_blanks`; that keeps the method from
growing, and drops the `C901` finding `master` already reports for it.

## Blast radius

32 definitions carry `W`, 29 of them with a blank in the value: 13 in `magic_defs/sgml`, 8 in
`magic_defs/perl`, 4 in `magic_defs/clojure`, 3 in `magic_defs/msdos` and 1 in `magic_defs/inform`.
(The issue's per-file breakdown is of all 32; `animation:101`, `animation:180` and `msdos:16`
declare `qt`, `jp2` and `rem`, which hold no blank.) Every one of the 29 missed any file that
writes a tab, a newline or a form feed where the value writes a space, and the eight `perl` POD
definitions additionally demanded exactly one line feed where the value writes one.

To measure what that means on real input, 3,769 files were collected from `/usr`, `/opt/homebrew`,
`/Library`, `/Applications` and `/System/Library` whose first 8 KiB write one of those blanks as
something other than a space. **6 of the 29 definitions begin to match:**

| definition | value | files it newly matches |
| --- | --- | --- |
| `sgml:99` | `<script ` | 235 |
| `perl:50` | `\n=head1 ` | 52 |
| `perl:52` | `\n=head2 ` | 14 |
| `sgml:87` | `<title ` | 3 |
| `perl:48` | `\n=pod\n` | 2 |
| `perl:47` | `=pod\n` | 1 |

Only 4 files change what PolyFile reports, because the other definitions produce a description a
sibling definition already reported for the same file. Each of the 4 gains a description `file -k`
also reports for it, and none loses one:

| file | gains |
| --- | --- |
| `/usr/share/httpd/icons/apache_pb.svg` | `HTML document, ASCII text` |
| `/Applications/Meld.app/…/org.gnome.Meld.svg` | `HTML document, ASCII text, with very long lines (915)` |
| `/Applications/Meld.app/…/preferences-system-parental-controls-symbolic.svg` | `HTML document, ASCII text, with very long lines (1234)` |
| `/System/Library/Perl/5.34/Filter/Simple.pm` | `Perl POD document, ASCII text` |

## What the tests pin

Five tests in `StringDataTypeTest`, all with `file` 5.48 as the oracle:

- `test_compact_whitespace_accepts_any_whitespace_byte` fails on each of the five non-space blanks
  if the class comes back to a literal space, and on `\xa0` if the class is widened past the `C`
  locale.
- `test_compact_whitespace_ignores_the_blank_the_value_declares` covers the other direction, where
  a value written with a tab or a newline had no repetition at all.
- `test_compact_whitespace_requires_one_blank_for_each_it_declares` is the guard against the
  opposite error, relaxing `W` into `w`. Its negative cases carry a fourth byte on purpose: a
  three-byte buffer fails the declared-length bound from #3504 before the lower bound here is
  reached, which would make the assertion vacuous.
- `test_compact_whitespace_wins_over_optional_blanks` gains a tab case, so `/Ww` pins the byte set
  as well as the precedence it already pinned.
- `test_the_dos_batch_table_reports_a_tab_after_echo` is the headline case, plus the `perl` POD
  definition that declares its blank as a newline.

Reverting the fix fails all five (13 failures and subfailures). Two mutations were run as well:
widening `BLANK_CLASS` to include `\xa0` fails the first test, and relaxing the lower bound to
zero-or-more fails the first, third and fifth.

## Verification

- `flake8 … --select=E9,F63,F7,F82`: 0.
- `flake8 … --max-complexity=10 --max-line-length=127`: 171 findings, against 172 on `master` for
  the same files. No new finding, and the `C901` for `StringMatch.pattern_string` is gone.
- `pytest tests --ignore=tests/test_corkami.py`: 319 passed, 1426 subtests passed.
- `pytest tests/test_corkami.py`: 906 passed, 1 skipped, unchanged from `master`.
- Corpus differential over all 88 stems, normalized the way `corpus_result_matches` does, with
  `<stem>*.magic` sidecars and `<stem>.flags`: **0 stems change and 0 regress**, 0 failing before
  and after. No corpus stem exercises `W`, which is why the real-file differential above is the
  evidence that the new matches are right.
- A 95-case differential against `file` 5.48 covering `W`, `Ww`, `w` and `search/N/W`, over all six
  blanks, multi-blank values, values that end in a blank, and non-blank separators including `\0`,
  `\x01` and `\xa0`: **0 mismatches.**
- `pip-audit`: clean.

## Noted, not fixed

Two divergences next to this one, both of which `master` shows identically before and after this
change, so neither is introduced here. Filed as refs #3570 and refs #3571:

- A `w` or `W` value that ends with a blank backtracks under `f`, giving a byte back so the
  full-word terminator can match. libmagic runs the skip once and does not revisit it. Latent: none
  of the 60 `f` definitions ends its value with a blank.
- The blank skip is unbounded here, where libmagic stops at `MAXstring`
  (`file/src/softmagic.c:2070` and `2303-2304`), so a whitespace run longer than that buffer
  matches in PolyFile and not in `file`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
