### PR TITLE
Fix the --format choices and the documentation they advertise

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@ PolyFile is a file analysis utility that identifies and maps the semantic and sy
 **Key capabilities:**
 - Pure-Python libmagic implementation (896 MIME types, from libmagic 5.48)
 - Recursive embedded file detection (like binwalk)
-- Parsers for PDF, ZIP, JPEG, iNES, and 183 compiled Kaitai Struct formats (44 mapped to MIME types)
+- Parsers for PDF, ZIP, JPEG, iNES, and 183 compiled Kaitai Struct formats (45 of the specifications
+  are dispatched, covering 67 MIME types)
 - Interactive HTML hex viewer with structure mapping
 - Drop-in replacement for Unix `file` command
 
@@ -19,16 +20,23 @@ Part of the [ALAN Parsers Project](https://github.com/trailofbits/polyfile#the-a
 
 **Matchers** classify file types. Two types:
 - libmagic DSL matchers (defined in `polyfile/magic_defs/`)
-- Python matchers (classes extending `Matcher`)
+- Python matchers (classes extending `MagicTest`, such as `zipmatcher.RelaxedJarMatcher`)
 
-**Parsers** create AST representations of file structure. Registered via decorator:
+**Parsers** create AST representations of file structure. A parser written as a function is
+registered with the `register_parser` decorator:
 ```python
 from polyfile import register_parser
 
-@register_parser("application/pdf")
-def parse_pdf(file_stream, match):
-    # Return parsed structure
+@register_parser("application/zip")
+def parse_zip(file_stream, parent):
     ...
+```
+
+`register_parser` wraps whatever it receives in a function wrapper, so it takes a function, not a
+class. Register a `Parser` subclass by adding an instance to `PARSERS`, which is what
+`polyfile/__init__.py` does for PDF, through `_LazyPDFParser`, to defer the `pdfminer` import:
+```python
+PARSERS["application/pdf"].add(_LazyPDFParser())
 ```
 
 ### Key Modules
@@ -183,34 +191,46 @@ tests/
 
 ### Adding a Custom Matcher (Python)
 ```python
-from polyfile import Matcher, Match
+from typing import Optional
 
-class MyMatcher(Matcher):
-    def match(self, data: bytes) -> Match | None:
-        if data.startswith(b'MAGIC'):
-            return Match(
-                mime_type="application/x-myformat",
-                name="My Format",
-                offset=0,
-                length=len(data)
-            )
-        return None
+from polyfile.magic import AbsoluteOffset, FailedTest, MagicMatcher, MagicTest, MatchedTest, TestResult, TestType
+
+
+class MyMatcher(MagicTest):
+    def __init__(self):
+        super().__init__(
+            offset=AbsoluteOffset(0),
+            mime="application/x-myformat",
+            extensions=("myformat",),
+            message="My Format"
+        )
+
+    def subtest_type(self) -> TestType:
+        return TestType.BINARY
+
+    def test(self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]) -> TestResult:
+        if data.startswith(b"MAGIC"):
+            return MatchedTest(self, value=data, offset=0, length=len(data))
+        return FailedTest(self, offset=0, message="the file does not start with MAGIC")
+
+
+MagicMatcher.DEFAULT_INSTANCE.add(MyMatcher())
 ```
 
 ### Adding a Custom Parser
 ```python
-from polyfile import register_parser, Parser, Submatch
+from polyfile import register_parser, Submatch
+
 
 @register_parser("application/x-myformat")
-class MyParser(Parser):
-    def parse(self, file_stream, match) -> Iterator[Submatch]:
-        # Yield Submatch objects representing structure
-        yield Submatch(
-            name="header",
-            start=0,
-            length=8,
-            value=file_stream.read(8)
-        )
+def parse_myformat(file_stream, parent):
+    yield Submatch(
+        name="header",
+        match_obj=file_stream.read(8),
+        relative_offset=0,
+        length=8,
+        parent=parent
+    )
 ```
 
 ### Updating the libmagic Definitions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,10 @@ PolyFile is a file analysis utility that identifies and maps the semantic and sy
 
 **Key capabilities:**
 - Pure-Python libmagic implementation (896 MIME types, from libmagic 5.48)
-- Recursive embedded file detection (like binwalk)
+- Recursive embedded file detection: ZIP members, PDF streams, non-`Constant` `bytes` fields
+  re-matched by `structmatcher.py`, and matchers that `search` for their magic at any offset, such
+  as the relaxed ZIP matcher in `zipmatcher.py`. There is no binwalk-style scan of every offset;
+  #3532 tracks that.
 - Parsers for PDF, ZIP, JPEG, iNES, and 183 compiled Kaitai Struct formats (45 of the specifications
   are dispatched, covering 67 MIME types)
 - Interactive HTML hex viewer with structure mapping

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You can run PolyFile with the debugger enabled using the `-db` option.
 PolyFile has a cleanroom, [pure Python implementation of the libmagic file classifier](#libmagic-implementation), and supports all 896 MIME types that it can identify.
 
 It currently has support for parsing and semantically mapping the following formats:
-* PDF, using an instrumented version of [Didier Stevens' public domain, permissive, forensic parser](https://blog.didierstevens.com/programs/pdf-tools/)
+* PDF, using [pdfminer.six](https://github.com/pdfminer/pdfminer.six) to decode objects and streams
 * ZIP, including recursive identification of all ZIP contents
 * JPEG/JFIF, using its [Kaitai Struct grammar](https://formats.kaitai.io/jpeg/index.html)
 * [iNES](https://wiki.nesdev.com/w/index.php/INES)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Slack Status](https://slack.empirehacking.nyc/badge.svg)](https://slack.empirehacking.nyc)
 
 A utility to identify and map the semantic and syntactic structure of files,
-including polyglots, chimeras, and schizophrenic files. It has [a pure-Python implementation of libmagic](#file-support) and can act as a drop-in replacement for the [`file` command](https://github.com/file/file). However, unlike `file`, PolyFile can recursively identify embedded files, like [binwalk](https://github.com/ReFirmLabs/binwalk).
+including polyglots, chimeras, and schizophrenic files. It has [a pure-Python implementation of libmagic](#file-support) and can act as a drop-in replacement for the [`file` command](https://github.com/file/file). However, unlike `file`, PolyFile recurses into the files it identifies: the ZIP parser matches every decompressed member, the PDF parser matches every decoded stream, and every non-constant byte field of a parsed structure is matched again on its own. A few matchers also search for their magic anywhere in the input, so a ZIP archive that does not start at byte offset zero is still found. PolyFile does not scan every offset the way [binwalk](https://github.com/ReFirmLabs/binwalk) does; [issue #3532](https://github.com/trailofbits/polyfile/issues/3532) tracks that.
 
 PolyFile can be used in conjunction with its sister tool
 [PolyTracker](https://github.com/trailofbits/polytracker) for

--- a/polyfile/__main__.py
+++ b/polyfile/__main__.py
@@ -173,7 +173,7 @@ then it will implicitly be printed to STDOUT.
     group.add_argument('--list', '-l', action='store_true',
                        help='list the supported filetypes for the `--filetype` argument and exit')
     group.add_argument('--html', '-t', action="append",
-                       help=dedent("""path to write an interactive HTML file for exploring the PDF;
+                       help=dedent("""path to write an interactive HTML file for exploring the input;
 equivalent to `--format html --output HTML`"""))
     group.add_argument("--explain", action="store_true", help="equivalent to `--format explain")
     # parser.add_argument('--try-all-offsets', '-a', action='store_true',

--- a/polyfile/__main__.py
+++ b/polyfile/__main__.py
@@ -57,7 +57,7 @@ class KeyboardInterruptHandler:
 
 
 class FormatOutput:
-    valid_formats = ("mime", "html", "json", "sbud", "explain")
+    valid_formats = ("file", "mime", "html", "json", "sbud", "explain")
     default_format = "file"
 
     def __init__(self, output_format: Optional[str] = None, output_path: Optional[str] = None):
@@ -120,7 +120,7 @@ def main(argv=None):
                         help='the file to analyze; pass \'-\' or omit to read from STDIN')
 
     parser.add_argument('--format', '-r', type=FormatOutput, action="append", choices=[
-        FormatOutput(f) for f in FormatOutput.valid_formats + ("json",)
+        FormatOutput(f) for f in FormatOutput.valid_formats
     ], help=dedent("""PolyFile's output format
 
 Output formats are:
@@ -136,7 +136,7 @@ sbud ...... equivalent to 'json'
 
 Multiple formats can be output at once:
 
-    polyfile INPUT_FILE -f mime -f json
+    polyfile INPUT_FILE -r mime -r json
 
 Their output will be concatenated to STDOUT in the order that
 they occur in the arguments.

--- a/polyfile/__main__.py
+++ b/polyfile/__main__.py
@@ -176,9 +176,6 @@ then it will implicitly be printed to STDOUT.
                        help=dedent("""path to write an interactive HTML file for exploring the input;
 equivalent to `--format html --output HTML`"""))
     group.add_argument("--explain", action="store_true", help="equivalent to `--format explain")
-    # parser.add_argument('--try-all-offsets', '-a', action='store_true',
-    #                     help='Search for a file match at every possible offset; this can be very slow for larger '
-    #                     'files')
     group.add_argument('--only-match-mime', '-I', action='store_true',
                        help=dedent(""""just print out the matching MIME types for the file, one on each line;
 equivalent to `--format mime`"""))

--- a/polyfile/polyfile.py
+++ b/polyfile/polyfile.py
@@ -209,12 +209,11 @@ def register_parser(*filetypes: str) -> Callable[[Union[Parser, ParserFunction]]
 
 
 class Matcher:
-    def __init__(self, try_all_offsets: bool = False, parse: bool = True, matcher: Optional[MagicMatcher] = None):
+    def __init__(self, parse: bool = True, matcher: Optional[MagicMatcher] = None):
         if matcher is None:
             self.magic_matcher: MagicMatcher = MagicMatcher.DEFAULT_INSTANCE
         else:
             self.magic_matcher = matcher
-        self.try_all_offsets: bool = try_all_offsets
         self.parse: bool = parse
 
     def handle_mimetype(
@@ -289,10 +288,9 @@ class Matcher:
 
 
 class Analyzer:
-    def __init__(self, path: Union[str, Path], try_all_offsets: bool = False, parse: bool = True,
+    def __init__(self, path: Union[str, Path], parse: bool = True,
                  magic_matcher: Optional[MagicMatcher] = None):
         self.path: Union[str, Path] = path
-        self.try_all_offsets: bool = try_all_offsets
         self.parse: bool = parse
         self._magic_matcher: Optional[MagicMatcher] = magic_matcher
         self._matcher: Optional[Matcher] = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,76 @@
+import contextlib
+import io
+import re
+import shlex
+from unittest import TestCase
+from zipfile import ZipFile
+
+from polyfile.__main__ import FormatOutput, main
+from polyfile.fileutils import Tempfile
+
+USAGE_CHOICES = re.compile(r"--format \{([^}]*)}")
+HELP_EXAMPLE = re.compile(r"^\s*polyfile INPUT_FILE (-\S+ \S+(?: -\S+ \S+)*)$", re.MULTILINE)
+
+
+def run_cli(*argv: str) -> str:
+    """Runs PolyFile's command line with the given arguments and returns what it wrote to STDOUT."""
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        main(["polyfile", "--quiet", *argv])
+    return output.getvalue()
+
+
+def cli_help() -> str:
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        with contextlib.suppress(SystemExit):
+            main(["polyfile", "--help"])
+    return output.getvalue()
+
+
+class FormatArgumentTests(TestCase):
+    """Tests that every output format the `--format` help advertises is one `--format` accepts.
+
+    These tests prevent a regression to the behavior reported in
+    https://github.com/trailofbits/polyfile/issues/3497, where `--format file` was the documented
+    default and had an implemented output branch, but was missing from the argparse choices and so
+    was rejected as an invalid choice; `json` was listed twice in the choices; and the example in
+    the help text passed the formats to `--filetype` instead of `--format`.
+    """
+
+    zip_file: bytes
+
+    @classmethod
+    def setUpClass(cls):
+        contents = io.BytesIO()
+        with ZipFile(contents, "w") as zf:
+            zf.writestr("hello.txt", "hello, PolyFile\n")
+        cls.zip_file = contents.getvalue()
+
+    def test_default_format_is_valid(self):
+        self.assertIn(FormatOutput.default_format, FormatOutput.valid_formats)
+
+    def test_every_format_is_accepted(self):
+        with Tempfile(self.zip_file, suffix=".zip") as path:
+            for output_format in FormatOutput.valid_formats:
+                with self.subTest(output_format=output_format):
+                    self.assertNotEqual(run_cli("--format", output_format, path), "")
+
+    def test_no_duplicate_choices(self):
+        choices = USAGE_CHOICES.search(cli_help())
+        self.assertIsNotNone(choices, "the usage line does not list the `--format` choices")
+        listed = choices.group(1).split(",")
+        self.assertEqual(sorted(listed), sorted(set(listed)))
+        self.assertEqual(sorted(listed), sorted(FormatOutput.valid_formats))
+
+    def test_omitted_format_matches_the_default(self):
+        with Tempfile(self.zip_file, suffix=".zip") as path:
+            self.assertEqual(run_cli(path), run_cli("--format", FormatOutput.default_format, path))
+
+    def test_help_example_runs(self):
+        example = HELP_EXAMPLE.search(cli_help())
+        self.assertIsNotNone(example, "the `--format` help no longer contains a runnable example")
+        with Tempfile(self.zip_file, suffix=".zip") as path:
+            output = run_cli(*shlex.split(example.group(1)), path)
+        self.assertIn("application/zip", output)
+        self.assertIn("\"b64contents\"", output)


### PR DESCRIPTION
Closes #3531
Closes #3497
Closes #3467
Closes #3465

Three issues that all edit `polyfile/__main__.py:59-181`, where the `--format` block, the `--html`
help and the commented-out `--try-all-offsets` flag sit in one contiguous region.

## Merge order

This PR branches from master at `fde96d4`. It touches `polyfile/__main__.py`, `polyfile/polyfile.py`
(`Matcher.__init__` and `Analyzer.__init__` only), `README.md`, `CLAUDE.md`, and adds
`tests/test_cli.py`.

- No open PR touches those files: #3572 is confined to `polyfile/zipmatcher.py` and #3573 to
  `polyfile/magic.py`, so this merges independently of both.
- #3531 records this as blocked on #3530, which edits `Matcher.match`. This PR changes only
  `Matcher.__init__`, 7 lines above, so either order works and the second one rebases cleanly.
- #3399 adds a new `--format` value to the block this restructures. It should branch from master
  after this merges. See the note below for the shape it should build on.

## #3497: three defects in `--format`

### 1. `--format file` was rejected

`file` is the documented default and has an implemented output branch, but `FormatOutput.valid_formats`
omitted it, so it never reached the argparse `choices`.

Before:

```console
$ polyfile --format file a.zip
polyfile: error: argument --format/-r: invalid choice: 'file'
    (choose from mime, html, json, sbud, explain, json)
$ echo $?
2
```

After:

```console
$ polyfile --format file a.zip
Zip archive data, made by v3.0 UNIX, extract using at least v1.0, last modified Sep 11 2026 ...
Zip archive, with extra data prepended
ZIP end of central directory record
```

### 2. `json` was listed twice

`choices` was built from `FormatOutput.valid_formats + ("json",)`, and `valid_formats` already
contained `"json"`. The duplicate showed up in the usage line and in every error message.

Before:

```console
$ polyfile --help | head -1
usage: polyfile [-h] [--format {mime,html,json,sbud,explain,json}]
```

After:

```console
$ polyfile --help | head -1
usage: polyfile [-h] [--format {file,mime,html,json,sbud,explain}]
```

Adding `file` to `valid_formats` and dropping the concatenation fixes both defects at once, which
is what the `+ ("json",)` was presumably meant to do.

### 3. The help example used `-f`, which is `--filetype`

`--format`'s short option is `-r`. The example did not fail loudly; it matched against filetypes
named `mime` and `json`.

Before:

```console
$ polyfile -f mime a.zip
Filetype argument(s) ['mime'] did not match any known definitions!
$ echo $?
1
```

After, running the example the help now prints:

```console
$ polyfile -r mime -r json a.zip
application/zip
application/zip
application/zip
{"MD5": "628b128aa8198f04afb455a152e18262", "SHA1": "6c949c5cdf0d836f13e7649f205f864be91aaffe", ...
```

## #3467: documentation describing code that was replaced

- `README.md` credited the PDF parser to Didier Stevens' forensic parser. `polyfile/pdfparser.py`
  was deleted in `88f915c` (2022-02-10); PDF handling runs on `pdfminer.six`, declared in
  `pyproject.toml`.
- The `--html` help said "for exploring the PDF". The flag takes any input PolyFile can match.
- `CLAUDE.md` documented registration as `@register_parser("application/pdf")` on a `parse_pdf`
  function. There is no `parse_pdf`, and the PDF parser registers a `_LazyPDFParser` instance in
  `polyfile/__init__.py` to defer the `pdfminer` import.

While reading `CLAUDE.md` I found two more statements that describe APIs which do not exist, both
now corrected:

- "Python matchers (classes extending `Matcher`)". They extend `MagicTest`; `Matcher` is the
  analysis driver. The "Adding a Custom Matcher" example built on that mistake and could not run.
- The "Adding a Custom Parser" example decorated a **class** with `@register_parser` and built a
  `Submatch` from keywords it does not accept. `register_parser` wraps anything that is not already
  a `Parser` instance in a `ParserFunctionWrapper`, so the decorated class is registered as the
  class object and parsing raises `TypeError: MyParser() takes no arguments`. Both replacement
  examples were executed against this branch before being committed.

Counts, measured on this branch rather than adjusted:

- `polyfile/kaitai/parsers/` holds 183 generated parsers, so that figure was right.
- `KAITAI_MIME_MAPPING` has 67 entries pointing at 44 distinct `.ksy` specifications, and
  `EXTRA_PARSERS` adds one more parser (`executable/mach_o_fat.ksy`) for `application/x-mach-binary`,
  a MIME type the mapping already covers. So 45 specifications are dispatched across 67 MIME types,
  not "44 mapped to MIME types".
- The "896 MIME types" claim in both files is still accurate: `MagicMatcher.parse(*MAGIC_DEFS)`
  yields 896, and the 902 that `polyfile --list` prints includes the six added by PolyFile's own
  Python matchers.

## #3465: remove the dead parameter

`Matcher.__init__` and `Analyzer.__init__` each took `try_all_offsets` and stored it. Nothing read
either attribute, and `Analyzer.matcher` constructed its `Matcher` without forwarding the value, so
even the plumbing was broken and a caller passing `try_all_offsets=True` got a silent no-op. Every
call site in `polyfile/`, `polymerge/` and `tests/` passes arguments by keyword, so dropping the
leading parameter moves nothing else; `grep -rn try_all_offsets` over the repository now returns
nothing. The commented-out `--try-all-offsets` flag is deleted with it.

The binwalk comparison in `README.md` and `CLAUDE.md` overstated what happens. What actually
recurses today:

- the ZIP parser, which matches every decompressed member
- the PDF parser, which matches every decoded stream
- `polyfile/structmatcher.py`, which re-matches every non-`Constant` `bytes` field of a parsed
  structure
- matchers that `search` for their magic at any offset, such as the relaxed ZIP matcher in
  `zipmatcher.py`, so a ZIP that does not start at byte offset zero is still found:

  ```console
  $ (head -c 512 /dev/urandom; cat a.zip) > prefixed.bin && polyfile --format file prefixed.bin
  Zip archive, with extra data prepended
  ZIP end of central directory record
  ```

Both documents now say that and link #3532, which is the unmilestoned home for a real all-offsets
scan, so this reads as a correction rather than a loss of intent. #3572 widens the first bullet from
the last archive to every concatenated archive; it had not merged when this was written, and the
wording holds either way.

## What the tests pin

`tests/test_cli.py` runs `polyfile.__main__.main` in process against a small ZIP built in
`setUpClass`, and adds 5 tests and 6 subtests in 0.7 s.

| Test | Fails without the fix |
| --- | --- |
| `test_default_format_is_valid` | `AssertionError: 'file' not found in ('mime', 'html', ...)` |
| `test_every_format_is_accepted` | one subtest per `valid_formats` entry; catches any listed format the dispatch cannot serve |
| `test_no_duplicate_choices` | the usage line lists `json` twice, and does not match `valid_formats` |
| `test_omitted_format_matches_the_default` | `SystemExit: 2` from argparse on `--format file` |
| `test_help_example_runs` | extracts the example from the `--format` help and runs it; `SystemExit: 1` while `-f` is `--filetype` |

Each was confirmed by restoring the defect one at a time and watching the test fail: reverting
defects 1 and 2 fails 3 of the 5 tests, and reverting defect 3 alone fails `test_help_example_runs`.

There is no test for the `try_all_offsets` removal. A test asserting that the constructor rejects
the keyword would pin the absence of a name and would stand in the way of #3532 implementing it for
real; the existing `Matcher` and `Analyzer` tests cover the constructors.

## Verification

- Blocking lint pass (`--select=E9,F63,F7,F82` over `polyfile polymerge tests build_backend.py
  compile_kaitai_parsers.py`): 0 findings.
- Complexity pass (`--max-complexity=10 --max-line-length=127`) over the changed files: byte for
  byte the same findings as master, with only line numbers shifted. Master does not pass this lint
  today (`main` has been complexity 58 since before this branch); this PR adds nothing to it.
- `uv run pytest tests --ignore=tests/test_corkami.py`: 320 passed, 1408 subtests passed in 18.8 s.
- `uvx pip-audit`: no known vulnerabilities found.
- No corpus differential: this PR changes no matching code. The only change under `polyfile/` that
  is not argparse text is the removal of two unread constructor parameters.

## Note for #3399

`--format` now derives its choices from `FormatOutput.valid_formats` alone, so adding an output
format means adding the value there and an `elif` branch to the dispatch in `main`. Two things to
build on rather than rework:

- `FormatOutput.default_format` must stay a member of `valid_formats`; `test_default_format_is_valid`
  enforces that, and it is the invariant that broke here.
- `needs_sbud` in `main` is the set of formats that require the full analysis pass
  (`{"html", "json", "sbud"}`). A format that emits SBuD without `b64contents` belongs in that set,
  or `sbud` is unbound when the dispatch reaches it. The `--no-contents` alternative in the issue
  needs no change to `FormatOutput` at all; it would be a flag read by `Analyzer.sbud`.
- `tests/test_cli.py::FormatArgumentTests::test_every_format_is_accepted` iterates `valid_formats`,
  so a new value gets a smoke test for free and must write something to STDOUT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
