### PR TITLE
Gate both soft magic passes on the file's own bytes

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -4336,9 +4336,9 @@ def detect_text_encoding(data: bytes) -> Optional[str]:
     This mirrors ``file_encoding`` in libmagic's ``src/encoding.c``: membership in a text
     encoding is decided by character class alone, with no statistical inference. Every byte in
     ``0xA0``-``0xFF`` is a printable ISO-8859 character, so a buffer of ASCII with a handful of
-    accented characters is text. libmagic classifies the buffer `_trim_trailing_nuls` prepares
-    rather than the file's own bytes, so text that a fixed record size or a block boundary padded
-    out with NULs still counts as text.
+    accented characters is text. ``file_encoding`` trims nothing itself, so a caller that mirrors
+    ``file_ascmagic`` hands it the buffer `_trim_trailing_nuls` prepares, and one that mirrors
+    ``file_buffer``'s soft magic pass gate hands it the file's own bytes.
 
     EBCDIC comes last because most EBCDIC buffers are also valid eight bit buffers, so testing for
     it any earlier would report ordinary ISO-8859 text as EBCDIC.
@@ -4349,7 +4349,6 @@ def detect_text_encoding(data: bytes) -> Optional[str]:
     Returns:
         The name of the encoding family, or None if `data` belongs to no text character class.
     """
-    data = _trim_trailing_nuls(data)
     if len(data) < 2:
         return None
     elif _only_contains(data, _ASCII_BYTES):
@@ -4595,7 +4594,9 @@ class PlainTextTest(MagicTest):
 
     def test(self, data: bytes, absolute_offset: int, parent_match: Optional[TestResult]) -> TestResult:
         content = data[absolute_offset:]
-        encoding = detect_text_encoding(content)
+        # this decides whether `file_ascmagic` reports text at all, and `file_ascmagic` classifies
+        # the trimmed buffer (`file/src/ascmagic.c:83-93`)
+        encoding = detect_text_encoding(_trim_trailing_nuls(content))
         if encoding is None:
             return FailedTest(self, offset=absolute_offset, parent=parent_match, message="the data do not appear to "
                                                                                          "be encoded in a text format")
@@ -5144,9 +5145,9 @@ class MagicMatcher:
         because the test is for one bit and not the other.
 
         Args:
-            looks_text: Whether `TextEncodingDescription.detect` recognized the buffer as text,
+            looks_text: Whether `detect_text_encoding` recognized the file's own bytes as text,
                 which is the ``looks_text`` ``file_buffer`` hands ``file_softmagic``
-                (``file/src/funcs.c:314-317`` and ``482``).
+                (``file/src/funcs.c:368-371`` and ``482``).
 
         Returns:
             The tests to run, in the order `MagicMatcher.match` runs them.
@@ -5155,6 +5156,28 @@ class MagicMatcher:
             return self.non_text_tests
         return [test for test in self.non_text_tests
                 if test.declared_test_type() != TestType.BINARY]
+
+    def text_pass_tests(self, looks_text: bool) -> Iterable[MagicTest]:
+        """The level 0 tests `MagicMatcher.match` runs over the decoded text buffer.
+
+        This is the other arm of the same condition `binary_pass_tests` reads: ``softmagic`` skips
+        an entry whose declared string flags are exactly ``STRING_TEXTTEST`` when the buffer does
+        not look like text (``file/src/softmagic.c:249-253``). ``file_ascmagic`` reaches this pass
+        on the strength of the trimmed buffer but passes ``file_buffer``'s answer straight through
+        (``file/src/ascmagic.c:71-100`` and ``161-162``), so the arm fires only for a buffer that
+        is text once its trailing NUL padding is gone and binary before that.
+
+        Args:
+            looks_text: Whether `detect_text_encoding` recognized the file's own bytes as text,
+                which is the ``text`` ``file_ascmagic_with_encoding`` hands ``file_softmagic``.
+
+        Returns:
+            The tests to run, in the order `MagicMatcher.match` runs them.
+        """
+        if looks_text:
+            return self.text_tests
+        return [test for test in self.text_tests
+                if test.declared_test_type() != TestType.TEXT]
 
     def match(self, to_match: Union[bytes, BinaryIO, str, Path, MatchContext]) -> Iterator[Match]:
         if isinstance(to_match, bytes):
@@ -5167,12 +5190,16 @@ class MagicMatcher:
             yield Match(matcher=self, context=to_match, results=EmptyFileTest().match(to_match))
             return
         text_encoding = TextEncodingDescription.detect(to_match.data)
+        # `file_buffer` gates both soft magic passes on the file's own bytes
+        # (`file/src/funcs.c:368-371`), while the description comes from the buffer
+        # `file_ascmagic` trims, so NUL-padded text is text to one and binary to the other
+        looks_text = detect_text_encoding(to_match.data) is not None
         yielded = False
         matched_on_the_files_bytes: Set[MagicTest] = set()
         # only the text pass carries the encoding description: `file_ascmagic` prints it, and
         # `file_buffer` reaches `file_ascmagic` only once binary soft magic has printed nothing
         # (`file/src/funcs.c:479-503`)
-        for test, m in self._run_tests(self.binary_pass_tests(text_encoding is not None),
+        for test, m in self._run_tests(self.binary_pass_tests(looks_text),
                                        to_match, None, "binary matching"):
             matched_on_the_files_bytes.add(test)
             yield m
@@ -5186,7 +5213,8 @@ class MagicMatcher:
             # this is a text file, so try all of the textual tests, against the buffer libmagic
             # hands them rather than against the file's bytes
             text_context = to_match.text_test_context(text_encoding.encoding)
-            text_tests = [test for test in self.text_tests if test not in matched_on_the_files_bytes]
+            text_tests = [test for test in self.text_pass_tests(looks_text)
+                          if test not in matched_on_the_files_bytes]
             # a match that carries the encoding description already reports it, and so does a
             # binary pass match, which is where `file_buffer` stops before `file_ascmagic`
             described = bool(matched_on_the_files_bytes)

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -449,6 +449,9 @@ class MagicTest(TestCase):
         fixed record size, a string table, or a block boundary leaves behind does not reach the
         character class check. Without the trim the NULs fail `_only_contains`, PolyFile reports
         no encoding, and `MagicMatcher.match` falls through to `application/octet-stream`.
+
+        `TextEncodingDescription.detect` is the `file_ascmagic` mirror that applies the trim;
+        `detect_text_encoding` is the `file_encoding` mirror and classifies what it is handed.
         """
         padded = (
             (b"\xde\xca\xff\xed" + b"\x00" * 4, "iso-8859-1"),
@@ -458,7 +461,9 @@ class MagicTest(TestCase):
         )
         for data, expected_encoding in padded:
             with self.subTest(data=data[:16]):
-                self.assertEqual(expected_encoding, polyfile.magic.detect_text_encoding(data))
+                description = polyfile.magic.TextEncodingDescription.detect(data)
+                self.assertIsNotNone(description)
+                self.assertEqual(expected_encoding, description.encoding)
                 mimetypes = {
                     mimetype
                     for match in MagicMatcher.DEFAULT_INSTANCE.match(data)
@@ -488,10 +493,14 @@ class MagicTest(TestCase):
         which belongs to no text character class, so `file` reports `data` for `abc\\0` and
         `ASCII text` for `abc\\0\\0`. Trimming without the adjustment reports text for both.
         """
-        self.assertIsNone(polyfile.magic.detect_text_encoding(b"abc\x00"))
-        self.assertIsNone(polyfile.magic.detect_text_encoding(b"The quick brown fox.\n"
-                                                              + b"\x00" * 491))
-        self.assertEqual("ascii", polyfile.magic.detect_text_encoding(b"abc\x00\x00"))
+        detect = polyfile.magic.TextEncodingDescription.detect
+        self.assertIsNone(detect(b"abc\x00"))
+        self.assertIsNone(detect(b"The quick brown fox.\n" + b"\x00" * 491))
+        self.assertEqual("ascii", detect(b"abc\x00\x00").encoding)
+        self.assertEqual({"data"},
+                         {str(m) for m in MagicMatcher.DEFAULT_INSTANCE.match(b"abc\x00")})
+        self.assertEqual({"ASCII text, with no line terminators"},
+                         {str(m) for m in MagicMatcher.DEFAULT_INSTANCE.match(b"abc\x00\x00")})
 
     def test_the_odd_byte_adjustment_keeps_the_last_utf_16le_character(self):
         """Tests that UTF-16LE text does not lose its last character to the NUL trim.

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -3274,6 +3274,50 @@ class PassGateTest(TestCase):
             with self.subTest(data=data):
                 self.assertEqual({"both flags"}, self.messages(definition, data))
 
+    def test_a_binary_flagged_entry_runs_against_nul_padded_text(self):
+        """Tests that the gate classifies the file's own bytes rather than the trimmed buffer.
+
+        This is a regression test for trailofbits/polyfile#3575. `file_buffer` calls
+        `file_encoding` on the buffer it was handed (`file/src/funcs.c:368-371`), and only
+        `file_ascmagic` trims the trailing NULs, so text padded out to a record boundary is
+        binary to the gate and text to the description. Gating on the trimmed buffer drops the
+        entry, and PolyFile reported `ASCII text, with no line terminators` where `file` reports
+        `binary only`.
+
+        The second case pins the other half: the description still comes from the trimmed buffer,
+        so dropping the trim to make the first case pass reports `data` here.
+        """
+        definition = "0\tsearch/40/b\t=ABC\tbinary only\n"
+        self.assertEqual({"binary only"}, self.messages(definition, b"ABC\x00\x00"))
+        self.assertEqual({"ASCII text, with no line terminators"},
+                         self.messages(definition, b"XYZ\x00\x00"))
+        self.assertNotIn("binary only", self.messages(definition, b"ABC and then some text\n"))
+
+    def test_a_nul_padded_winamp_preset_is_not_plain_text(self):
+        """Tests the shipped definition that first reported trailofbits/polyfile#3575.
+
+        `magic_defs/msdos:1966` is `0 string/b Nullsoft\\ AVS\\ Preset\\ `, and the presets
+        themselves are ASCII followed by NUL padding, so the gate decided the whole class of file.
+        """
+        data = b"Nullsoft AVS Preset 0.2\n" + b"\x00" * 8
+        self.assertEqual({"Winamp plug in"},
+                         {str(m) for m in MagicMatcher.DEFAULT_INSTANCE.match(data)})
+
+    def test_a_text_flagged_entry_skips_nul_padded_text(self):
+        """Tests the other arm of the same gate, for trailofbits/polyfile#3575.
+
+        `file_ascmagic` reaches the text pass on the strength of the trimmed buffer but hands
+        `file_softmagic` the answer `file_buffer` computed from the untrimmed one
+        (`file/src/ascmagic.c:71-100` and `161-162`), so a `t`-only entry is skipped for exactly
+        the buffers a `b`-only entry now runs against. PolyFile ran the entry and reported
+        `text only, ASCII text, with no line terminators`.
+        """
+        definition = "0\tstring/t\tABC\ttext only\n"
+        self.assertEqual({"ASCII text, with no line terminators"},
+                         self.messages(definition, b"ABC\x00\x00"))
+        self.assertEqual({"text only, ASCII text, with no line terminators"},
+                         self.messages(definition, b"ABC"))
+
     def test_a_script_reports_only_libmagics_variant(self):
         """Tests that `file/tests/cmd1.testfile` no longer reports a binary variant.
 


### PR DESCRIPTION
Closes #3575

## Merge order

This PR and #3568's (the `b` flag's other defect, in `STRING_FLAG_BITS` and `libmagic_string_flags`)
are the two open v0.6.0 code items. They touch `polyfile/magic.py` about 1,700 lines apart and do
not overlap: this one owns the pass gate, `detect_text_encoding`, and `TextEncodingDescription`,
and #3568 owns the sort key. Merge either first; the second rebases cleanly. #3533 (cut the v0.6.0
release) comes after both.

## Reproducer

`polyfile/magic_defs/msdos:1966` is `0 string/b Nullsoft\ AVS\ Preset\ `, and the presets are ASCII
followed by NUL padding:

```console
$ printf 'Nullsoft AVS Preset 0.2\n\0\0\0\0\0\0\0\0' > avs.bin
$ TZ=UTC ./file/src/file -b -m file/magic/magic.mgc avs.bin
Winamp plug in
```

Before:

```pycon
>>> from polyfile.magic import MagicMatcher
>>> sorted({str(m) for m in MagicMatcher.DEFAULT_INSTANCE.match(
...     b"Nullsoft AVS Preset 0.2\n" + b"\x00" * 8)})
['ASCII text']
```

After:

```pycon
>>> sorted({str(m) for m in MagicMatcher.DEFAULT_INSTANCE.match(
...     b"Nullsoft AVS Preset 0.2\n" + b"\x00" * 8)})
['Winamp plug in']
```

Minimal form, `0 search/40/b =ABC HITZ` over `b"ABC"` plus 0 to 3 trailing NULs. `file` reports
`ASCII text, with no line terminators`, `HITZ`, `HITZ`, `HITZ`. Before: `ASCII text, with no line
terminators`, `HITZ`, `ASCII text, with no line terminators`, `HITZ`. After: it agrees with `file`
on all four.

## What the fix does

`file_buffer` calls `file_encoding` on the buffer it was handed (`file/src/funcs.c:368-371`) and
threads that one `looks_text` answer through both `file_softmagic` calls. `file_ascmagic` trims the
trailing NULs and classifies again for the description it prints (`file/src/ascmagic.c:83-96`), but
it passes `file_buffer`'s answer straight through to the text pass (`file/src/ascmagic.c:161-162`).
So the two classifications disagree for a buffer that is text once its padding is gone, and
`file/src/softmagic.c:249-253` reads the untrimmed one.

#3540 taught `TextEncodingDescription.detect` to trim, correctly, and put the trim inside
`detect_text_encoding` as well. `MagicMatcher.match` derived the pass gate from that same call, so
the gate saw the trimmed classification.

The separation follows libmagic's own: one PolyFile function per libmagic function.
`detect_text_encoding` documents itself as mirroring `file_encoding`, and `file_encoding` trims
nothing, so the trim moves out of it and into the two callers that mirror `file_ascmagic` —
`TextEncodingDescription.detect`, which already applied it and now applies it once instead of
twice, and `PlainTextTest.test`. `MagicMatcher.match` then gets the gate from
`detect_text_encoding(to_match.data)`, exactly as `file_buffer` gets it from `file_encoding`. The
alternative, a `trim_nuls` parameter on `detect_text_encoding`, leaves the function's default
behavior at odds with the libmagic function its docstring names, and every caller would have to
know which value it wants anyway.

`_trim_trailing_nuls` itself is untouched.

## The `t` flag has the same defect

`softmagic`'s skip has two arms: a `b`-only entry is skipped when the buffer looks like text, and a
`t`-only entry is skipped when it does not. PolyFile implemented only the first. The second arm is
reachable only when `file_ascmagic` enters the text pass on the strength of the trimmed buffer
while `file_buffer` called the untrimmed one binary — that is, only for NUL-padded text, the same
inputs this issue is about. Before #3540 the two classifications could never disagree, so the arm
was unreachable rather than missing; #3540 made it reachable. It is the same defect from the other
side, so this PR fixes it too, in `MagicMatcher.text_pass_tests`.

With `0 string/t ABC text only` over `b"ABC\x00\x00"`, `file` reports `ASCII text, with no line
terminators` and PolyFile reported `text only, ASCII text, with no line terminators`. It now agrees.

## What the tests pin

Three new tests in `PassGateTest`, and two existing #3506 tests moved onto
`TextEncodingDescription.detect`, the entry point that still applies the trim.

- `test_a_binary_flagged_entry_runs_against_nul_padded_text` fails with the gate on the trimmed
  classification. Its second assertion, that `b"XYZ\x00\x00"` still reports `ASCII text, with no
  line terminators`, fails if the trim is dropped rather than moved.
- `test_a_text_flagged_entry_skips_nul_padded_text` pins the `t` arm, and brackets the same way.
- `test_a_nul_padded_winamp_preset_is_not_plain_text` pins the shipped definition.
- `test_an_even_buffer_that_trims_odd_keeps_a_nul` gains end-to-end assertions: `data` for
  `abc\0` and `ASCII text, with no line terminators` for `abc\0\0`, which is what `file -b` reports.

Verified by breaking the fix both ways. With the gate reverted to the trimmed classification, the
three new tests fail and nothing else does. With the trim removed from both `file_ascmagic` mirrors,
eight tests fail, including the second assertion of each new gate test.

Every expected string is what `file -b` reports for the same definition and input, checked against
libmagic 5.48 built from the `file` submodule.

## Verification

- `flake8 --select=E9,F63,F7,F82`: 0 findings. The complexity pass reports the same findings as
  `master`, at shifted line numbers, and none in the changed functions.
- `pytest tests --ignore=tests/test_corkami.py`: 336 passed, 1,432 subtests passed.
- `pytest tests/test_corkami.py`: 906 passed, 1 skipped, unchanged. `card.bin` still reports
  `text/plain` and `ISO-8859 text, with no line terminators`.
- `pip-audit`: no known vulnerabilities.
- Corpus differential over all 88 `file/tests` stems, comparing full match sets between `master`
  and this branch with the same normalization `corpus_result_matches` applies: 88 passing before,
  88 after, 0 regressions, and 0 stems whose match set changed at all. 163 declarations across 27
  files carry `b`, so the gate change alters which tests run for a meaningful slice of the
  definitions; no corpus verdict moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
