### PR TITLE
Add --no-contents to omit the base64 input from SBuD output

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ TrID matching code is still shipped with PolyFile and can be invoked programmati
 
 PolyFile has several options for outputting its results, specified by its `--format` option. For computer-readable output, PolyFile has an extension of the [SBuD](https://github.com/corkami/sbud) JSON format described [in the documentation](docs/json_format.md). Prior to version 0.5.0 this was the default output format of PolyFile. However, now the default output format is to mimic the behavior of the `file` command. To maintain the original behavior, use the `--format sbud` option.
 
+The `json` and `sbud` formats include a `b64contents` key holding a base64 encoding of the entire input, so their output grows with the size of the file you analyze. Pass `--no-contents` to leave that key out; PolyFile then skips the encoding instead of computing it and throwing the result away. The key is omitted rather than emptied, so a consumer that needs the contents fails instead of reading the input as empty. The HTML hex viewer is built from the contents, so you cannot combine `--no-contents` with `--format html` or `--html`.
+
 ### libmagic Implementation
 
 PolyFile has a cleanroom implementation of [libmagic (used in the `file` command)](https://github.com/file/file).

--- a/docs/json_format.md
+++ b/docs/json_format.md
@@ -13,6 +13,7 @@ Notes, additions to SBuD, as well as any breaking changes are listed in C-style 
   "SHA1": "SHA1 hex string for the input file", 
   "SHA256": "SHA256 hex string for the input file", 
   "b64contents": "base64 encoded contents of the input file", 
+  /* the b64contents key is absent when PolyFile runs with --no-contents */
   "fileName": "The input filename, or 'STDIN' if the file was read from STDIN",
   "length": 1337, /* integer number of bytes in the file */
   "struc": [

--- a/polyfile/__main__.py
+++ b/polyfile/__main__.py
@@ -113,6 +113,20 @@ class ValidateOutput(argparse.Action):
         ValidateOutput.add_output(args, values)
 
 
+def reject_html_without_contents(parser: argparse.ArgumentParser, args: argparse.Namespace):
+    """Exits with an error when `--no-contents` is combined with an output format that needs them.
+
+    The hex viewer is built from the base64 encoding of the input that `--no-contents` omits, so the
+    combination cannot produce HTML. Argparse cannot express the conflict on its own, because both
+    `--format html` and `--html` append to the same list of output formats.
+    """
+    if args.no_contents and any(output_format.output_format == "html" for output_format in args.format):
+        parser.print_usage()
+        sys.stderr.write("polyfile: error: `--no-contents` cannot be combined with HTML output, because the hex "
+                         "viewer is built from the contents of the input\n")
+        exit(1)
+
+
 def main(argv=None):
     parser = argparse.ArgumentParser(description='A utility to recursively map the structure of a file.',
                                      formatter_class=argparse.RawTextHelpFormatter)
@@ -181,6 +195,17 @@ equivalent to `--format html --output HTML`"""))
 equivalent to `--format mime`"""))
     parser.add_argument('--only-match', '-m', action='store_true',
                         help='do not attempt to parse known filetypes; only match against file magic')
+    parser.add_argument('--no-contents', action='store_true',
+                        help=dedent("""omit the `b64contents` key from the `json` and `sbud` output
+
+That key holds a base64 encoding of the entire input, so it
+dominates the size of the output for all but the smallest files.
+Omitting it skips the encoding rather than discarding its result.
+
+The key is left out rather than emptied, so a consumer that needs
+the contents raises a `KeyError` instead of reading the input as
+empty. This option cannot be combined with HTML output, whose hex
+viewer is built from the contents."""))
     parser.add_argument('--require-match', action='store_true', help='if no matches are found, exit with code 127')
     parser.add_argument('--max-matches', type=int, default=None,
                         help='stop scanning after having found this many matches')
@@ -249,6 +274,8 @@ equivalent to `--format mime`"""))
     if not args.format:
         args.format.append(FormatOutput())
 
+    reject_html_without_contents(parser, args)
+
     if args.quiet:
         logger.setLevel(logging.CRITICAL)
     elif args.trace:
@@ -315,7 +342,7 @@ equivalent to `--format mime`"""))
                                 log.info(f"Found {args.max_matches} matches; stopping early")
                                 break
         if needs_sbud:
-            sbud = analyzer.sbud(matches=analyzer.matches_so_far)
+            sbud = analyzer.sbud(matches=analyzer.matches_so_far, include_contents=not args.no_contents)
 
             if args.require_match and not analyzer.matches_so_far:
                 log.info("No matches found, exiting")

--- a/polyfile/html.py
+++ b/polyfile/html.py
@@ -73,7 +73,29 @@ def undescribed_regions(matches, length):
     return regions
 
 
+def encoded_contents(file_path, sbud):
+    """Returns the base64 encoding of the input that the hex viewer is built from.
+
+    Args:
+        file_path: the path of the analyzed file, used to report which input is missing.
+        sbud: the SBuD object describing that file.
+
+    Returns:
+        The value of the object's ``b64contents`` key.
+
+    Raises:
+        ValueError: if the object has no ``b64contents`` key, which is what
+            ``Analyzer.sbud(include_contents=False)`` produces.
+    """
+    if 'b64contents' not in sbud:
+        raise ValueError(f"cannot render a hex viewer for {file_path!r}: the SBuD object has no 'b64contents' key. "
+                         "Build it with Analyzer.sbud(include_contents=True), which is the default.")
+    return sbud['b64contents']
+
+
 def generate(file_path, sbud):
+    encoded = encoded_contents(file_path, sbud)
+
     global TEMPLATE, jinja2
     if jinja2 is None:
         # Load jinja2 lazily so that importing this module does not require it
@@ -170,7 +192,7 @@ def generate(file_path, sbud):
 
         return TEMPLATE.render(
             filename=os.path.split(file_path)[-1],
-            encoded=sbud['b64contents'],
+            encoded=encoded,
             matches=matches,
             input_file=input_file,
             input_bytes=input_bytes,

--- a/polyfile/polyfile.py
+++ b/polyfile/polyfile.py
@@ -377,25 +377,43 @@ class Analyzer:
         else:
             yield from self._magic_matches
 
-    def sbud(self, matches: Optional[Iterable[Match]] = None) -> Dict[str, Any]:
+    def sbud(self, matches: Optional[Iterable[Match]] = None, include_contents: bool = True) -> Dict[str, Any]:
+        """Builds the SBuD object that describes this file.
+
+        Args:
+            matches: the matches to record. Defaults to running the analysis with
+                :meth:`Analyzer.matches`.
+            include_contents: whether to base64 encode the whole input into the ``b64contents`` key.
+                Pass ``False`` to skip the encoding, which omits the key rather than emitting an
+                empty one, so a caller that needs the contents fails with a ``KeyError`` instead of
+                reading the input as empty.
+
+        Returns:
+            The SBuD object, ready to serialize as JSON.
+        """
         if matches is None:
             matches = self.matches()
         md5 = hashlib.md5()
         sha1 = hashlib.sha1()
         sha256 = hashlib.sha256()
+        b64contents: Optional[str] = None
         with open(self.path, 'rb') as hash_file:
             data = hash_file.read()
             md5.update(data)
             sha1.update(data)
             sha256.update(data)
-            b64contents = base64.b64encode(data)
+            if include_contents:
+                b64contents = base64.b64encode(data).decode('utf-8')
             file_length = len(data)
             del data
-        return {
+        sbud: Dict[str, Any] = {
             'MD5': md5.hexdigest(),
             'SHA1': sha1.hexdigest(),
             'SHA256': sha256.hexdigest(),
-            'b64contents': b64contents.decode('utf-8'),
+        }
+        if b64contents is not None:
+            sbud['b64contents'] = b64contents
+        sbud.update({
             'fileName': self.path,
             'length': file_length,
             'versions': {
@@ -404,4 +422,5 @@ class Analyzer:
             'struc': [
                 match.to_obj() for match in matches
             ]
-        }
+        })
+        return sbud

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,10 @@
+import base64
 import contextlib
 import io
+import json
 import re
 import shlex
+from typing import Tuple
 from unittest import TestCase
 from zipfile import ZipFile
 
@@ -10,6 +13,16 @@ from polyfile.fileutils import Tempfile
 
 USAGE_CHOICES = re.compile(r"--format \{([^}]*)}")
 HELP_EXAMPLE = re.compile(r"^\s*polyfile INPUT_FILE (-\S+ \S+(?: -\S+ \S+)*)$", re.MULTILINE)
+# some `struc` values are the `repr` of a matcher object, whose address differs between runs
+OBJECT_ADDRESS = re.compile(r"0x[0-9a-f]+")
+
+
+def zip_file() -> bytes:
+    """Builds the small ZIP archive that these tests hand to the command line."""
+    contents = io.BytesIO()
+    with ZipFile(contents, "w") as zf:
+        zf.writestr("hello.txt", "hello, PolyFile\n")
+    return contents.getvalue()
 
 
 def run_cli(*argv: str) -> str:
@@ -18,6 +31,17 @@ def run_cli(*argv: str) -> str:
     with contextlib.redirect_stdout(output):
         main(["polyfile", "--quiet", *argv])
     return output.getvalue()
+
+
+def run_cli_until_exit(*argv: str) -> Tuple[int, str]:
+    """Runs PolyFile's command line and returns its exit code and what it wrote to STDERR."""
+    errors = io.StringIO()
+    with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(errors):
+        try:
+            main(["polyfile", "--quiet", *argv])
+        except SystemExit as exiting:
+            return exiting.code, errors.getvalue()
+    return 0, errors.getvalue()
 
 
 def cli_help() -> str:
@@ -42,10 +66,7 @@ class FormatArgumentTests(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        contents = io.BytesIO()
-        with ZipFile(contents, "w") as zf:
-            zf.writestr("hello.txt", "hello, PolyFile\n")
-        cls.zip_file = contents.getvalue()
+        cls.zip_file = zip_file()
 
     def test_default_format_is_valid(self):
         self.assertIn(FormatOutput.default_format, FormatOutput.valid_formats)
@@ -74,3 +95,65 @@ class FormatArgumentTests(TestCase):
             output = run_cli(*shlex.split(example.group(1)), path)
         self.assertIn("application/zip", output)
         self.assertIn("\"b64contents\"", output)
+
+
+class NoContentsTests(TestCase):
+    """Tests for `--no-contents`, which drops the base64 encoding of the input from SBuD output.
+
+    These tests cover the request in https://github.com/trailofbits/polyfile/issues/3399. The
+    `b64contents` key scales with the size of the input, so it dominates the JSON output, and a
+    consumer that does not need the contents has no way to ask PolyFile not to produce them.
+    """
+
+    zip_file: bytes
+
+    @classmethod
+    def setUpClass(cls):
+        cls.zip_file = zip_file()
+
+    def analyze(self, *argv: str) -> dict:
+        with Tempfile(self.zip_file, suffix=".zip") as path:
+            return json.loads(run_cli(*argv, path))
+
+    def test_the_default_output_still_carries_the_contents(self):
+        self.assertEqual(base64.b64encode(self.zip_file).decode("utf-8"),
+                         self.analyze("--format", "json")["b64contents"])
+
+    def test_the_key_is_omitted_rather_than_emptied(self):
+        self.assertNotIn("b64contents", self.analyze("--format", "json", "--no-contents"))
+
+    def test_the_sbud_format_honors_the_flag(self):
+        self.assertNotIn("b64contents", self.analyze("--format", "sbud", "--no-contents"))
+
+    def test_nothing_else_about_the_output_changes(self):
+        with Tempfile(self.zip_file, suffix=".zip") as path:
+            with_contents = json.loads(OBJECT_ADDRESS.sub("0x0", run_cli("--format", "json", path)))
+            without = json.loads(OBJECT_ADDRESS.sub("0x0", run_cli("--format", "json", "--no-contents", path)))
+        del with_contents["b64contents"]
+        self.assertEqual(with_contents, without)
+
+    def test_html_output_refuses_the_flag(self):
+        """`polyfile/html.py` builds the hex viewer out of `b64contents`.
+
+        Without this check the run reached `html.generate` and failed there, so the message the
+        user saw depended on which output format happened to come first.
+        """
+        for argv in (("--format", "html"), ("--html", "-")):
+            with self.subTest(argv=argv):
+                with Tempfile(self.zip_file, suffix=".zip") as path:
+                    code, errors = run_cli_until_exit(*argv, "--no-contents", path)
+                self.assertEqual(1, code)
+                self.assertIn("`--no-contents` cannot be combined with HTML output", errors)
+
+    def test_html_output_is_refused_even_alongside_a_format_that_allows_it(self):
+        with Tempfile(self.zip_file, suffix=".zip") as path:
+            code, errors = run_cli_until_exit("--format", "json", "--format", "html", "--no-contents", path)
+        self.assertEqual(1, code)
+        self.assertIn("`--no-contents` cannot be combined with HTML output", errors)
+
+    def test_formats_that_carry_no_contents_are_unaffected(self):
+        with Tempfile(self.zip_file, suffix=".zip") as path:
+            for output_format in ("file", "mime", "explain"):
+                with self.subTest(output_format=output_format):
+                    self.assertEqual(run_cli("--format", output_format, path),
+                                     run_cli("--format", output_format, "--no-contents", path))

--- a/tests/unit/test_html.py
+++ b/tests/unit/test_html.py
@@ -19,17 +19,19 @@ def match(offset, size, sub_els=()):
     }
 
 
-def sbud(contents, struc):
-    return {
+def sbud(contents, struc, include_contents=True):
+    obj = {
         'MD5': '',
         'SHA1': '',
         'SHA256': '',
-        'b64contents': base64.b64encode(contents).decode('utf-8'),
         'fileName': 'test.bin',
         'length': len(contents),
         'versions': [],
         'struc': struc
     }
+    if include_contents:
+        obj['b64contents'] = base64.b64encode(contents).decode('utf-8')
+    return obj
 
 
 class UndescribedRegionTests(TestCase):
@@ -78,9 +80,9 @@ class UndescribedRegionTests(TestCase):
 class GeneratedHtmlTests(TestCase):
     """Test that the generated hex viewer carries the data it needs to mark undescribed bytes."""
 
-    def render(self, contents, struc):
+    def render(self, contents, struc, include_contents=True):
         with Tempfile(contents) as file_path:
-            return generate(file_path, sbud(contents, struc))
+            return generate(file_path, sbud(contents, struc, include_contents))
 
     def emitted_regions(self, html):
         emitted = re.search(r'const UNDESCRIBED_REGIONS = (\[.*?]);', html)
@@ -120,3 +122,19 @@ class GeneratedHtmlTests(TestCase):
         self.assertIn(".toggleClass('undescribed'", html)
         self.assertIn('.undescribed {', html)
         self.assertIn('repeating-linear-gradient', html)
+
+    def test_the_contents_reach_the_viewer(self):
+        contents = bytes(range(16))
+        html = self.render(contents, [match(0, 16)])
+        self.assertIn(base64.b64encode(contents).decode('utf-8'), html)
+
+    def test_an_sbud_without_contents_is_refused(self):
+        """`--no-contents` omits `b64contents`, which the hex viewer is built from.
+
+        This is a regression test for trailofbits/polyfile#3399. Without the check, rendering an
+        SBuD object that carries no contents raised a bare `KeyError: 'b64contents'` from deep
+        inside `generate`.
+        """
+        with self.assertRaises(ValueError) as refused:
+            self.render(bytes(16), [match(0, 16)], include_contents=False)
+        self.assertIn("no 'b64contents' key", str(refused.exception))

--- a/tests/unit/test_sbud.py
+++ b/tests/unit/test_sbud.py
@@ -1,0 +1,47 @@
+import base64
+from unittest import TestCase
+from unittest.mock import patch
+
+from polyfile.fileutils import Tempfile
+from polyfile.polyfile import Analyzer
+
+CONTENTS = b"hello, PolyFile\n"
+
+
+def sbud(include_contents: bool = True):
+    """Builds an SBuD object for a small file, without running the analysis."""
+    with Tempfile(CONTENTS) as path:
+        return Analyzer(path).sbud(matches=[], include_contents=include_contents)
+
+
+class ContentsTests(TestCase):
+    """Tests for the `include_contents` argument of `Analyzer.sbud`.
+
+    These tests cover the request in https://github.com/trailofbits/polyfile/issues/3399, where
+    the `b64contents` key holds a base64 encoding of the whole input and so dominates the size of
+    the JSON output for all but the smallest files.
+    """
+
+    def test_the_contents_are_included_by_default(self):
+        self.assertEqual(base64.b64encode(CONTENTS).decode("utf-8"), sbud()["b64contents"])
+
+    def test_omitting_the_contents_omits_the_key(self):
+        self.assertNotIn("b64contents", sbud(include_contents=False))
+
+    def test_omitting_the_contents_changes_nothing_else(self):
+        with Tempfile(CONTENTS) as path:
+            analyzer = Analyzer(path)
+            with_contents = analyzer.sbud(matches=[])
+            without = analyzer.sbud(matches=[], include_contents=False)
+        del with_contents["b64contents"]
+        self.assertEqual(with_contents, without)
+
+    def test_omitting_the_contents_skips_the_encoding(self):
+        """The issue asks for the encoding to be skipped, not computed and then discarded.
+
+        Patching `base64.b64encode` to raise is the only way to tell the two apart from the
+        outside: an implementation that encodes the input and then filters the key out of the
+        finished object passes every other test in this class but raises here.
+        """
+        with patch("polyfile.polyfile.base64.b64encode", side_effect=AssertionError("encoded anyway")):
+            self.assertNotIn("b64contents", sbud(include_contents=False))


### PR DESCRIPTION
Closes #3399

A `--no-contents` flag that omits the `b64contents` key from the `json` and `sbud` output, and an
`include_contents` argument on `Analyzer.sbud` that skips the base64 encoding rather than computing
it and discarding the result. The default output is unchanged.

## Merge order

This PR branches from master at `3f4e003`, which already includes #3574, so it builds on the
`FormatOutput.valid_formats` restructuring rather than conflicting with it. It touches
`polyfile/polyfile.py` (`Analyzer.sbud` only), `polyfile/__main__.py`, `polyfile/html.py`,
`README.md`, `docs/json_format.md`, `tests/test_cli.py`, `tests/unit/test_html.py`, and adds
`tests/unit/test_sbud.py`.

- No other PR is open. The two issues still open in v0.6.0 besides the release itself, #3568 and
  #3575, are both confined to `polyfile/magic.py`, so this merges independently of either.
- Nothing downstream needs to rebase onto this.
- This is the last issue in milestone v0.6.0 apart from #3568, #3575, and cutting the release
  (#3533).

## The shape, and the shapes not chosen

The issue offers several shapes for both halves of the question and does not settle on one. Since
this is a design decision you may want to redirect, here is what was considered.

**How to trigger it.** The issue offers a new format value (`json-nob64`) or a flag
(`--no-contents`). This PR adds the flag.

A flag is orthogonal: it applies to `json` and `sbud` alike. A `json-nob64` format value would need
an `sbud-nob64` sibling to be consistent, and a third value if another SBuD-shaped format is ever
added. It also avoids the coupling #3574 introduced, where a new SBuD-shaped format value has to be
added to both `FormatOutput.valid_formats` and the `needs_sbud` set, and `sbud` is unbound at
dispatch if the second is forgotten. `needs_sbud` is unchanged by this PR.

**What to do with the key.** The issue offers omitting it, setting it to `null` or the empty string,
or setting it to the base64 of the string `"null"`. This PR omits it.

The issue anticipates the objection: Python callers write `d['b64contents']` rather than
`d.get('b64contents')`, so a missing key raises a `KeyError`. That is the argument for omitting it.
A caller that needs the contents should fail loudly rather than read an empty string or the four
bytes `null` and treat either as the file. The default is unchanged, so only a caller that passed
the flag can reach the missing key, and `--no-contents` is not a flag anything passes by accident.

## What it does

`Analyzer.sbud` takes `include_contents: bool = True`. When it is `False` the `base64.b64encode`
call is not made at all — the issue asks for this specifically, so the CPU and memory are not spent
on a result that is about to be dropped — and the key is left out of the returned object.

`polyfile/html.py` builds the hex viewer out of `b64contents`: `hexdump.js` opens with
`const rawBytes = atob("{{ encoded }}");`. The viewer genuinely needs the bytes, and there is no
useful degraded viewer to fall back to, so `--no-contents` is refused when any output format is
`html`:

```console
$ polyfile --format html --no-contents big.zip
usage: polyfile [-h] [--format {file,mime,html,json,sbud,explain}] ...
polyfile: error: `--no-contents` cannot be combined with HTML output, because the hex viewer is built from the contents of the input
$ echo $?
1
```

The check runs after the output formats are collected, so it catches `--html PATH` and
`--format json --format html` as well, and it runs before any analysis rather than failing several
seconds in. `html.generate` also raises a `ValueError` naming the input and the fix, in place of the
bare `KeyError: 'b64contents'` it used to raise from inside the `TEMPLATE.render` call, so the
programmatic API fails the same way the CLI does.

Passing `--no-contents` with only non-SBuD formats (`file`, `mime`, `explain`) is a silent no-op.

## Before and after

`big.txt` is 4,194,325 bytes of generated text. Before, with the first 200 bytes of a 5,592,965-byte
line shown:

```console
$ polyfile --quiet --format json big.txt
{"MD5": "33d27fe94279af5d3040e434f5ac7fe1", "SHA1": "5ce2abecdc9a993242d618aa8d1b4e1b419dd7d1", "SHA256": "6b6c0991836b758de571134ec81ddd9e61e8a1711bc8cd625ffd46b1ebeae2bf", "b64contents": "Z3B2c3hva2tobmhoIGZ6IGogZ2JwcWd0bnp4ZyBt[... 5,592,428 more bytes ...]
```

After, in full:

```console
$ polyfile --quiet --format json --no-contents big.txt
{"MD5": "33d27fe94279af5d3040e434f5ac7fe1", "SHA1": "5ce2abecdc9a993242d618aa8d1b4e1b419dd7d1", "SHA256": "6b6c0991836b758de571134ec81ddd9e61e8a1711bc8cd625ffd46b1ebeae2bf", "fileName": "big.txt", "length": 4194325, "versions": {"polyfile": "0.5.6"}, "struc": [{"relative_offset": 0, "offset": 0, "size": 4194325, "type": "text/plain", "name": "text/plain", "value": "", "subEls": [], "extension": "txt"}]}
```

## What it saves

Two 4.0 MiB inputs, each run five times, best wall clock and highest peak RSS reported. The text
file has no PolyFile parser, so its `struc` is small and the output is almost entirely
`b64contents`; the ZIP is parsed recursively, so its `struc` carries the data too and the key is a
smaller share of the whole.

| Input | Output size | Peak RSS | Wall clock |
| --- | --- | --- | --- |
| 4.0 MiB `text/plain`, default | 5,592,965 bytes | 144.6 MiB | 3.705 s |
| 4.0 MiB `text/plain`, `--no-contents` | **510 bytes** | 141.5 MiB | 3.484 s |
| 4.0 MiB ZIP, default | 25,936,881 bytes | 202.3 MiB | 1.113 s |
| 4.0 MiB ZIP, `--no-contents` | **20,344,294 bytes** | 197.5 MiB | 1.096 s |

The output shrinks by 4/3 of the input size, which is the whole of the JSON in the text case
(10,967x smaller) and 21.6% of it in the ZIP case. Peak memory drops by 3.1 MiB and 4.8 MiB.

The CPU saving the issue asks for is real but small: `base64.b64encode` on 4 MiB costs 3.2 ms, and
the wall clock difference above is within run-to-run noise. The size of the output is the
justification for the feature, not the encoding time.

## Tests

`tests/unit/test_sbud.py` pins the `Analyzer.sbud` contract:

- the contents are included by default, and equal `base64.b64encode` of the file;
- `include_contents=False` omits the key rather than emptying it;
- nothing else about the object changes;
- the encoding is skipped rather than computed and discarded. Patching
  `polyfile.polyfile.base64.b64encode` to raise is the only way to tell the two apart from outside
  the function: an implementation that encodes the input and then filters the key out of the
  finished object passes the other three tests and fails this one.

`tests/test_cli.py` adds `NoContentsTests`: the default output still carries the contents, `json`
and `sbud` both honor the flag, nothing else in the JSON changes, `file`/`mime`/`explain` output is
byte-identical with and without the flag, and HTML output exits 1 with the message above for
`--format html`, `--html -`, and `--format json --format html` together. The existing
`FormatArgumentTests` fixture moved to a module-level `zip_file()` that both classes share; nothing
it asserts changed.

`tests/unit/test_html.py` keeps its `sbud` fixture and gives it an `include_contents` argument, so
the existing tests are untouched. Two tests are added: the encoded contents reach the rendered page,
and an object without them is refused with a `ValueError` naming the key.

Each test was checked against a broken implementation:

| Break | Tests that fail |
| --- | --- |
| encode, then drop the key from the finished object | `test_omitting_the_contents_skips_the_encoding` |
| always write the key | 2 in `test_sbud.py`, 3 in `test_cli.py` |
| remove the CLI check for HTML output | 3 in `test_cli.py` (2 as subtests) |
| remove the `html.generate` check | `test_an_sbud_without_contents_is_refused`, with the old `KeyError` at `polyfile/html.py:173` |

## Verification

- Blocking lint (`--select=E9,F63,F7,F82`): 0 findings.
- Complexity lint (`--max-complexity=10 --max-line-length=127`): output is byte-identical to
  master's. `main` and `html.generate` are both already far over the complexity limit, so the new
  validation lives in `reject_html_without_contents` and `encoded_contents` rather than adding a
  branch to either.
- `uv run pytest tests --ignore=tests/test_corkami.py`: 346 passed, 1437 subtests passed, up from
  333 and 1432 on master.
- `uvx pip-audit`: no known vulnerabilities.
- Every format run with and without the flag, plus `--html PATH`, multiple `--format` arguments,
  `--output` to files, and STDIN.
- **No corpus differential.** This changes no matcher, no magic definition, and no parser; the only
  behavior that moves is which keys the SBuD object carries, so the 88 `file/tests/*.testfile`
  stems cannot distinguish this branch from master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
