### PR TITLE
Give the sort key every string flag libmagic compares

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -423,17 +423,46 @@ STRING_FLAG_BITS: Tuple[Tuple[str, int], ...] = (
     ("compact_whitespace", 0x0001),
     ("optional_blanks", 0x0002),
     ("case_insensitive_lower", 0x0004),
+    ("case_insensitive", 0x0004),
     ("case_insensitive_upper", 0x0008),
     ("match_to_start", 0x0010),
     ("force_text", 0x0020),
+    ("force_binary", 0x0040),
+    ("limit_lines", 0x0800),
     ("trim", 0x2000),
     ("full_word_match", 0x4000),
 )
 """Each string modifier PolyFile records, with the ``str_flags`` bit libmagic sets for it.
 
-See ``file/src/file.h:414-432`` for the bit numbering and ``file/src/apprentice.c:1946-1980`` for
+See ``file/src/file.h:396-414`` for the bit numbering and ``file/src/apprentice.c:1953-2015`` for
 the modifier characters they come from.
+
+A bit appears more than once when PolyFile's types spell the same modifier differently: `c` is
+`StringType.case_insensitive_lower` but `RegexType.case_insensitive`. No type carries both names,
+and the lookup is a bitwise or, so a repeated bit is set once.
+
+``0x0800`` is ``BIT(11)``, which libmagic names twice because its meaning depends on the type that
+carries it: ``PSTRING_4_LE`` on a `pstring` and ``REGEX_LINE_COUNT`` on a `regex`. PolyFile spells
+the regular expression's half of that as `RegexType.limit_lines` and reads the Pascal string's half
+out of `PSTRING_LENGTH_BITS`, so the two never collide.
 """
+
+PSTRING_LENGTH_BITS: Dict[str, int] = {
+    "B": 0x0080,
+    "H": 0x0100,
+    "h": 0x0200,
+    "L": 0x0400,
+    "l": 0x0800,
+}
+"""The ``PSTRING_LEN`` bit each length modifier letter sets (``file/src/file.h:403-411``).
+
+Exactly one of them is always set, because libmagic seeds a ``pstring``'s ``str_flags`` with
+``PSTRING_1_LE`` before it reads any modifier (``file/src/apprentice.c:2337``) and each letter
+replaces whatever the seed or an earlier letter left.
+"""
+
+PSTRING_LENGTH_INCLUDES_ITSELF: int = 0x1000
+"""``BIT(12)``, the bit ``pstring/J`` sets (``file/src/file.h:412``)."""
 
 
 def libmagic_field(value: int, num_bytes: int) -> bytes:
@@ -2672,6 +2701,12 @@ class PascalStringType(DataType[StringTest]):
                 modifier = "l"
         else:
             raise ValueError("byte_length must be either 1, 2, or 4")
+        self.length_modifier: str = modifier
+        """The letter libmagic reads the length prefix's width and byte order from.
+
+        A key of `PSTRING_LENGTH_BITS`. A declaration that named no letter still has one here,
+        because libmagic's default is the same ``B`` an explicit letter would spell.
+        """
         if count_includes_length:
             modifier = f"{modifier}J"
         super().__init__(f"pstring/{modifier}{string_flags}")
@@ -2913,6 +2948,13 @@ class RegexType(DataType[MagicRegex]):
             force_text: bool = False,
             force_binary: bool = False
     ):
+        self.declared_length: Optional[int] = length
+        """The number the declaration wrote after ``regex``, or None if it wrote none.
+
+        This, not `length`, is libmagic's ``str_range``: the defaults `length` falls back to are
+        applied when the test runs rather than when it is parsed
+        (``file/src/softmagic.c:1411-1422``).
+        """
         if length is None:
             if limit_lines:
                 length = 8 * 1024 // 80  # libmagic assumes 80 bytes per line
@@ -2930,11 +2972,19 @@ class RegexType(DataType[MagicRegex]):
     def declaration(self) -> str:
         """Rebuilds the declaration this type was parsed from, which is also its name.
 
+        The name leaves out a length the declaration did not write, because a declared length is
+        libmagic's ``str_range`` and an undeclared one is not. `DataType.parse` interns a type
+        under this name, so rendering the fallback `length` here would give ``regex`` and
+        ``regex/8192`` one shared instance and one shared sort key.
+
         Returns:
             A string `DataType.parse` accepts and that spells every flag this type carries.
         """
         flags = "".join(letter for letter, attribute in self.FLAGS if getattr(self, attribute))
-        return f"regex/{self.length}{flags}"
+        length = "" if self.declared_length is None else str(self.declared_length)
+        if not length and not flags:
+            return "regex"
+        return f"regex/{length}{flags}"
 
     DOLLAR_PATTERN = re.compile(rb"(^|[^\\])\$", re.MULTILINE)
 
@@ -3414,6 +3464,64 @@ class NumericDataType(DataType[NumericValue]):
         )
 
 
+def libmagic_str_range(data_type: DataType) -> int:
+    """The ``str_range`` libmagic stores for a string type.
+
+    It is the number the declaration wrote after the type name. A declaration that wrote none
+    leaves the field zero, because the range a `regex` or `search` falls back on is applied when
+    the test runs rather than when it is parsed (``file/src/softmagic.c:1411-1422``). The
+    `SearchType` line below is the one departure from that, which
+    https://github.com/trailofbits/polyfile/issues/3580 tracks.
+
+    Args:
+        data_type: The type a definition declared.
+
+    Returns:
+        libmagic's ``m->str_range`` for this type.
+    """
+    if isinstance(data_type, RegexType):
+        return data_type.declared_length or 0
+    string_range = getattr(data_type, "num_bytes", None) or 0
+    if isinstance(data_type, SearchType) and string_range == 0:
+        return STRING_DEFAULT_RANGE
+    return string_range
+
+
+def libmagic_str_flags(data_type: DataType) -> int:
+    """The ``str_flags`` bits the modifier letters on `data_type` set.
+
+    Args:
+        data_type: The type a definition declared.
+
+    Returns:
+        The bits named in `STRING_FLAG_BITS` that this type's modifiers ask for.
+    """
+    flags = 0
+    for attribute, bit in STRING_FLAG_BITS:
+        if getattr(data_type, attribute, False):
+            flags |= bit
+    return flags
+
+
+def libmagic_pstring_flags(data_type: PascalStringType) -> int:
+    """The ``str_flags`` word libmagic gives a ``pstring``.
+
+    The length modifier letter picks one of ``PSTRING_LEN``'s bits and ``J`` adds another
+    (``file/src/apprentice.c:1980-2015``). The rest of the letters are the ordinary string
+    modifiers, which `PascalStringType` keeps in a `StringType` of its own.
+
+    Args:
+        data_type: The Pascal string type a definition declared.
+
+    Returns:
+        Every ``str_flags`` bit the declaration sets.
+    """
+    flags = PSTRING_LENGTH_BITS[data_type.length_modifier]
+    if data_type.count_includes_length:
+        flags |= PSTRING_LENGTH_INCLUDES_ITSELF
+    return flags | libmagic_str_flags(data_type.string_type)
+
+
 def libmagic_string_flags(data_type: DataType) -> bytes:
     """The ``str_range`` and ``str_flags`` word libmagic gives a string type.
 
@@ -3425,14 +3533,11 @@ def libmagic_string_flags(data_type: DataType) -> bytes:
     """
     if not isinstance(data_type, (StringType, PascalStringType, RegexType, UTF16Type)):
         return bytes(8)
-    string_range = getattr(data_type, "num_bytes", None) or 0
-    if isinstance(data_type, SearchType) and string_range == 0:
-        string_range = STRING_DEFAULT_RANGE
-    flags = 0
-    for attribute, bit in STRING_FLAG_BITS:
-        if getattr(data_type, attribute, False):
-            flags |= bit
-    return libmagic_field(string_range, 4) + libmagic_field(flags, 4)
+    if isinstance(data_type, PascalStringType):
+        flags = libmagic_pstring_flags(data_type)
+    else:
+        flags = libmagic_str_flags(data_type)
+    return libmagic_field(libmagic_str_range(data_type), 4) + libmagic_field(flags, 4)
 
 
 def libmagic_string_value(constant: StringTest) -> bytes:

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -2646,6 +2646,196 @@ class MatchOrderTest(TestCase):
                          f"the match order differs between hash seeds:\n{detail}")
 
 
+class StringFlagSortKeyTest(TestCase):
+    """Regression tests for the string modifier bits reported in issue #3568.
+
+    `polyfile.magic.STRING_FLAG_BITS` mapped eight of the fifteen `str_flags` bits libmagic
+    defines in `file/src/file.h:396-414`, and `libmagic_string_flags` read attribute names that
+    `RegexType` and `PascalStringType` do not carry. A `b`, an `l`, a regular expression's range,
+    and every Pascal string modifier were therefore absent from
+    `MagicTest.libmagic_sort_key`, which is how PolyFile reproduces the `memcmp` tie-break
+    `apprentice_sort` applies to tests of equal strength (`file/src/apprentice.c:1132-1149`).
+
+    Each definition below declares two tests of equal strength, with descriptions chosen so that
+    ordering by description alone, or by the file and line order PolyFile falls back on, would
+    give the opposite answer. Every expected order is the order `file -b -k` reports the two
+    matches in, checked against libmagic 5.48 built from the `file` submodule over an input both
+    tests match: `b"ABCD\x00\xff\xfe"` for a string, `b"ABCD\n"` for a regular expression, and a
+    zeroed length prefix of the declared width for a Pascal string.
+    """
+
+    @staticmethod
+    def order(first: str, second: str, value: str) -> List[str]:
+        """The order PolyFile runs two equally strong tests of the given types in.
+
+        Args:
+            first: The type declaration of the test written on the first line.
+            second: The type declaration of the test written on the second line.
+            value: The value both tests look for.
+
+        Returns:
+            The description of each test, strongest first.
+        """
+        definition = f"0\t{first}\t{value}\tZZZ-first\n0\t{second}\t{value}\tAAA-second\n"
+        with TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "flag_sort_key"
+            path.write_text(definition)
+            return [str(test.message) for test in MagicMatcher.parse(path)]
+
+    def assert_second_sorts_first(self, first: str, second: str, value: str = "ABCD"):
+        """Asserts that the flag `second` carries lifts it above `first`.
+
+        Args:
+            first: The type declaration of the unflagged test, written on the first line.
+            second: The type declaration of the flagged test, written on the second line.
+            value: The value both tests look for.
+        """
+        self.assertEqual(["AAA-second", "ZZZ-first"], self.order(first, second, value),
+                         f"{second} does not sort ahead of {first}")
+
+    def test_an_already_mapped_flag_is_the_control(self):
+        """`T` and `f` were mapped all along, so they order the same before and after the fix.
+
+        They isolate the flag as the cause: the pairs differ only in a modifier, so a pair whose
+        bit the table holds ordering correctly while a pair whose bit it omits does not rules out
+        anything else about the two definitions.
+        """
+        self.assert_second_sorts_first("string", "string/T")
+        self.assert_second_sorts_first("string", "string/f")
+
+    def test_the_binary_test_flag_is_part_of_the_key(self):
+        """`b` is `STRING_BINTEST`, `BIT(6)` (`file/src/file.h:402`), which the table omitted.
+
+        Both tests here run in the binary pass, because libmagic assumes a `string` is binary
+        unless it says otherwise (`file/src/apprentice.c:1271-1276`), so the pass assignment
+        cannot account for the order.
+        """
+        self.assert_second_sorts_first("string", "string/b", value="ABCD")
+
+    def test_a_regular_expressions_range_is_part_of_the_key(self):
+        """`RegexType` spells the range `length`, so reading `num_bytes` left every regex at zero.
+
+        `file -b -k` reports `AAA-200` before `ZZZ-100` for the first pair: the range is
+        libmagic's `str_range`, and 200 compares greater than 100.
+        """
+        self.assert_second_sorts_first("regex/100", "regex/200")
+
+    def test_an_undeclared_range_is_not_the_range_a_regex_falls_back_on(self):
+        """A declaration that writes no range leaves `str_range` zero.
+
+        `RegexType.length` reports the 8 KiB a regular expression falls back on, but libmagic
+        applies that when the test runs rather than when it is parsed
+        (`file/src/softmagic.c:1411-1422`), so `regex/8192` outranks a bare `regex`.
+        """
+        self.assert_second_sorts_first("regex", "regex/8192")
+
+    def test_the_line_count_flag_is_part_of_the_key(self):
+        """`l` on a regex is `REGEX_LINE_COUNT`, `BIT(11)` (`file/src/file.h:409`).
+
+        libmagic names `BIT(11)` twice because its meaning depends on the type that carries it,
+        `PSTRING_4_LE` on a `pstring` and `REGEX_LINE_COUNT` on a `regex`, and PolyFile reaches
+        it through `RegexType.limit_lines` here.
+        """
+        self.assert_second_sorts_first("regex/5", "regex/5l")
+
+    def test_a_case_insensitive_regex_carries_the_ignore_case_bit(self):
+        """`RegexType` spells `c` as `case_insensitive`, not `case_insensitive_lower`.
+
+        The table held only the `StringType` spelling, so `c` on a regular expression contributed
+        nothing to the key.
+        """
+        self.assert_second_sorts_first("regex/5", "regex/5c")
+
+    def test_a_pascal_strings_length_modifier_is_part_of_the_key(self):
+        """`PascalStringType` carries none of the attribute names the table held.
+
+        Every `pstring` therefore had `str_flags` zero. The width of the length prefix already
+        separates two Pascal strings by strength, so each pair here declares the same width and
+        differs only in byte order: `h` is `PSTRING_2_LE` and `H` is `PSTRING_2_BE`, `l` is
+        `PSTRING_4_LE` and `L` is `PSTRING_4_BE` (`file/src/file.h:405-409`).
+        """
+        for width, (first, second) in ((2, ("pstring/H", "pstring/h")),
+                                       (4, ("pstring/L", "pstring/l"))):
+            with self.subTest(byte_length=width):
+                self.assert_second_sorts_first(first, second, value="x")
+
+    def test_a_length_prefix_that_counts_itself_is_part_of_the_key(self):
+        """`J` is `PSTRING_LENGTH_INCLUDES_ITSELF`, `BIT(12)` (`file/src/file.h:412`)."""
+        self.assert_second_sorts_first("pstring/B", "pstring/BJ", value="x")
+
+    def test_a_pascal_string_carries_the_ordinary_string_modifiers(self):
+        """The letters a `pstring` shares with a `string` set the same bits they set there.
+
+        `PascalStringType` keeps them in a `StringType` of its own, which is where
+        `libmagic_pstring_flags` reads them from.
+        """
+        for second in ("pstring/BT", "pstring/Bc"):
+            with self.subTest(declaration=second):
+                self.assert_second_sorts_first("pstring/B", second, value="x")
+
+    def test_an_undeclared_length_prefix_sorts_as_the_one_byte_prefix_it_is(self):
+        """A bare `pstring` and a `pstring/B` are one entry as far as libmagic is concerned.
+
+        libmagic seeds a Pascal string's `str_flags` with `PSTRING_1_LE` before it reads any
+        modifier (`file/src/apprentice.c:2337`), so the two declarations compile to identical
+        `struct magic` bytes. `file -m` warns `Duplicate magic entry` for the pair and leaves them
+        in the order they were read, which is what PolyFile falls back on for a tie.
+        """
+        self.assertEqual(["ZZZ-first", "AAA-second"], self.order("pstring", "pstring/B", "x"))
+
+    FLAG_WORDS: Tuple[Tuple[str, int, int], ...] = (
+        ("string", 0, 0x0000),
+        ("string/b", 0, 0x0040),
+        ("string/t", 0, 0x0020),
+        ("string/Tf", 0, 0x6000),
+        ("search/100", 100, 0x0000),
+        ("search/100/s", 100, 0x0010),
+        ("regex", 0, 0x0000),
+        ("regex/100", 100, 0x0000),
+        ("regex/50l", 50, 0x0800),
+        ("regex/50c", 50, 0x0004),
+        ("regex/50b", 50, 0x0040),
+        ("pstring", 0, 0x0080),
+        ("pstring/B", 0, 0x0080),
+        ("pstring/H", 0, 0x0100),
+        ("pstring/h", 0, 0x0200),
+        ("pstring/L", 0, 0x0400),
+        ("pstring/l", 0, 0x0800),
+        ("pstring/BJ", 0, 0x1080),
+        ("pstring/BT", 0, 0x2080),
+    )
+    """The `str_range` and `str_flags` libmagic gives each declaration, from `file/src/file.h`."""
+
+    def test_the_flag_word_holds_libmagics_bit_numbering(self):
+        """Tests the eight bytes `MagicTest.libmagic_sort_key` compares for a string type.
+
+        The ordering tests above prove that the right bits reach the key; this pins which bits
+        they are, so a pair that happens to order correctly under a wrong pair of values cannot
+        hide a mis-numbered table.
+        """
+        for declaration, string_range, flags in self.FLAG_WORDS:
+            with self.subTest(declaration=declaration):
+                expected = struct.pack("<II", string_range, flags)
+                data_type = DataType.parse(declaration)
+                self.assertEqual(expected, polyfile.magic.libmagic_string_flags(data_type))
+
+    def test_a_shipped_binary_string_sorts_ahead_of_its_equals(self):
+        """Tests the fix against a definition file rather than a synthetic pair.
+
+        `magic_defs/games` declares `0 string/b bnry` beside two unflagged four-byte strings of
+        the same strength. `file -m polyfile/magic_defs/games -l` lists the flagged one first;
+        PolyFile listed it last, because it sorted as though it carried no flag at all.
+        """
+        games = next(path for path in MAGIC_DEFS if path.name == "games")
+        order = [str(test.message).strip() for test in MagicMatcher.parse(games)]
+        flagged = "GTA Item Placement data (IPL), used in GTA SA/IV,"
+        unflagged = ("Syzygy DTZ tablebase", "Syzygy WDL tablebase")
+        for description in (flagged, *unflagged):
+            self.assertIn(description, order, "magic_defs/games no longer declares this test")
+        for description in unflagged:
+            self.assertLess(order.index(flagged), order.index(description))
+
+
 class MatchJoinTest(TestCase):
     """Tests for the joined description reported in issue #3491.
 


### PR DESCRIPTION
Closes #3568

## Merge order

This PR and #3578 (the `b` flag's other defect, the binary-pass gate) are the two open v0.6.0 code
items. They touch `polyfile/magic.py` about 1,700 lines apart and do not overlap: #3578 owns the
pass gate, `detect_text_encoding`, and `TextEncodingDescription`, and this one owns
`STRING_FLAG_BITS`, `libmagic_string_flags`, and the two data types those read. Merge either
first; the second rebases cleanly. #3533 (cut the v0.6.0 release) comes after both.

## Reproducer

Each pair declares two tests of equal strength that both match the same input, with descriptions
chosen so that ordering by description alone, or by the file and line order PolyFile falls back on,
would give the opposite answer. That isolates the flag as the cause. The expected order is what
`file -b -k` prints, from libmagic 5.48 built from the `file` submodule.

| definitions | input | `file -b -k` | before | after |
| --- | --- | --- | --- | --- |
| `0 string ABCD ZZZ-plain` / `0 string/b ABCD AAA-flagged` | `ABCD\0\xff\xfe` | `AAA-flagged`, `ZZZ-plain` | `ZZZ-plain`, `AAA-flagged` | `AAA-flagged`, `ZZZ-plain` |
| `0 regex/100 ABCD ZZZ-100` / `0 regex/200 ABCD AAA-200` | `ABCD\n` | `AAA-200`, `ZZZ-100` | `ZZZ-100`, `AAA-200` | `AAA-200`, `ZZZ-100` |
| `0 regex/5 ABCD ZZZ-plain` / `0 regex/5l ABCD AAA-flagged` | `ABCD\n` | `AAA-flagged`, `ZZZ-plain` | `ZZZ-plain`, `AAA-flagged` | `AAA-flagged`, `ZZZ-plain` |
| `0 regex/5 ABCD ZZZ-plain` / `0 regex/5c ABCD AAA-flagged` | `ABCD\n` | `AAA-flagged`, `ZZZ-plain` | `ZZZ-plain`, `AAA-flagged` | `AAA-flagged`, `ZZZ-plain` |
| `0 pstring/L x ZZZ-BE` / `0 pstring/l x AAA-LE` | `\0\0\0\0ab\xff` | `AAA-LE`, `ZZZ-BE` | `ZZZ-BE`, `AAA-LE` | `AAA-LE`, `ZZZ-BE` |

The control is the same shape with `T`, a bit the table already held: both tools put the flagged
test first before and after this change, which rules out anything about the pairs other than the
flag.

The one shipped definition file whose order this visibly corrects is `magic_defs/games`.
`0 string/b bnry` at line 485 ties in strength with the two four-byte strings at lines 361 and 363.
`file -m polyfile/magic_defs/games -l` lists the flagged one first; PolyFile listed it last.

## What the fix does

`MagicTest.libmagic_sort_key` reproduces the `memcmp` tie-break `apprentice_sort` applies to tests
of equal strength (`file/src/apprentice.c:1132-1149`), field by field. Two of those fields are
`str_range` and `str_flags`, and `libmagic_string_flags` built both.

`STRING_FLAG_BITS` mapped `BIT(0)`-`BIT(5)`, `BIT(13)` and `BIT(14)` of the fifteen bits
`file/src/file.h:396-414` defines. It now also holds:

- `BIT(6)`, `STRING_BINTEST`, the `b` modifier, which 163 declarations across 27 files set.
- `BIT(11)`, `REGEX_LINE_COUNT`, the `l` modifier on a regular expression, which 40 declarations
  across 8 files set.

`BIT(7)`-`BIT(12)`, the `PSTRING_*` family, do not belong in that table, because they are not one
boolean each: `SET_LENGTH` replaces whichever of them is set rather than adding to it
(`file/src/apprentice.c:1981`). They come from `PSTRING_LENGTH_BITS` instead, keyed by the length
modifier letter, plus `PSTRING_LENGTH_INCLUDES_ITSELF` for `J`.

### `BIT(11)` under two names

`file/src/file.h` defines `BIT(11)` twice, as `PSTRING_4_LE` and as `REGEX_LINE_COUNT`, because a
magic entry is one type or the other and the namespaces never meet. PolyFile keeps them apart the
same way rather than reaching for one attribute that serves both: the regular expression's half is
`RegexType.limit_lines` in `STRING_FLAG_BITS`, and the Pascal string's half is the `l` entry of
`PSTRING_LENGTH_BITS`, which only `libmagic_pstring_flags` reads. A `pstring` has no `limit_lines`
attribute and a `regex` is never looked up in `PSTRING_LENGTH_BITS`, so neither table can reach the
other's type.

### The attribute names

`libmagic_string_flags` read three names that some types spell differently, so `getattr` silently
returned nothing:

- It read `num_bytes` for the range, which `RegexType` spells `length`, so **every** regex had
  `str_range` zero.
- It read `case_insensitive_lower`, which `RegexType` spells `case_insensitive`, so `c` on a
  regular expression contributed nothing.
- `PascalStringType` carries none of those names, so **every** `pstring` had `str_flags` zero.

A bit may now appear twice in `STRING_FLAG_BITS`, once per spelling. No type carries both names,
and the lookup is a bitwise or, so a repeated bit is set once.

### A declared length is not a default one

`RegexType.length` reports the 8 KiB a regular expression falls back on, but libmagic applies that
when the test runs rather than when it is parsed (`file/src/softmagic.c:1411-1422`), so a bare
`regex` has `str_range` zero where `regex/8192` has 8192. `RegexType` now records
`declared_length` beside `length`, and `RegexType.declaration` leaves an undeclared length out of
the name: `DataType.parse` interns a type under its name, so rendering the fallback would have
given `regex` and `regex/8192` one shared instance and one shared sort key.

The mirror image holds for `pstring`. libmagic seeds a Pascal string's `str_flags` with
`PSTRING_1_LE` before it reads any modifier (`file/src/apprentice.c:2337`), so `pstring` and
`pstring/B` compile to identical entries — `file -m` reports them as a `Duplicate magic entry`.
PolyFile already interned both under `pstring/B`, which is the right answer, and
`test_an_undeclared_length_prefix_sorts_as_the_one_byte_prefix_it_is` pins it.

## What the tests pin

`StringFlagSortKeyTest` in `tests/test_magic.py`, 12 methods. Each ordering test parses a
two-line definition and asserts the order `MagicMatcher` runs the tests in, against the order
`file -b -k` reports the two matches in. Every newly mapped bit has at least one case: `BIT(6)`
as `string` against `string/b`; `BIT(8)` against `BIT(9)` and `BIT(10)` against `BIT(11)` as
same-width Pascal string pairs that differ only in byte order, which is the only way two `pstring`
length bits can tie in strength; `BIT(12)` as `pstring/B` against `pstring/BJ`, which also pins
`BIT(7)` as the bit the `B` in both carries; and `BIT(11)` again as `regex/5` against `regex/5l`.
`test_the_flag_word_holds_libmagics_bit_numbering` then pins the exact eight bytes for 19
declarations, so a pair that happens to order correctly under a wrong pair of values cannot hide a
mis-numbered table. `test_a_shipped_binary_string_sorts_ahead_of_its_equals`
runs the same check over `magic_defs/games` rather than a synthetic definition.

Reverting `polyfile/magic.py` to master fails 7 of the 12 methods outright and 17 subtests across
3 more. The two methods left clean are the two controls: the already-mapped `T` and `f` bits, and
the `pstring` against `pstring/B` tie. Each of the three attribute-name bugs is covered on its own,
so fixing the table without fixing the lookups still fails.

## Verification

- `uv run pytest tests --ignore=tests/test_corkami.py`: 345 passed, 1,455 subtests passed. 333
  passed on master, so the 12 new methods are the difference.
- `uv run pytest tests/test_corkami.py`: 906 passed, 1 skipped, unchanged.
- Corpus differential over all 88 `file/tests` stems, comparing the full ordered match list and
  the `-k` join, master against this branch: **0 stems change**.
- Order differential over the shipped definitions: 1,232 of the 3,877 level 0 tests move, and the
  set of tests is identical, so nothing was gained or lost.
- Parity differential against `file -m <definition> -l`, which lists each definition file's level 0
  tests in the order libmagic sorted them, compared by line number: 328 of 344 definition files
  agreed before, 329 after. `magic_defs/games` is the file that changed, and no file regressed.
- `uv run flake8 polyfile polymerge tests build_backend.py compile_kaitai_parsers.py
  --exclude polyfile/kaitai/parsers --count --select=E9,F63,F7,F82 --show-source --statistics`: 0.
- `uv run flake8 ... --max-complexity=10 --max-line-length=127` reports the same findings for
  `polyfile/magic.py` before and after, and none for `tests/test_magic.py`.
- `uvx pip-audit`: no known vulnerabilities.

## A related defect, filed separately

#3580: a `search` that declares no range gets `STRING_DEFAULT_RANGE` in the sort key, where
libmagic leaves the field zero. It is one line of the same function but was not in this issue's
scope, since changing it reorders 27 of the shipped level 0 tests. `libmagic_str_range` names the
issue where the departure is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
