### PR TITLE
Store zero for a search that declares no range

### DIFF
--- a/polyfile/magic.py
+++ b/polyfile/magic.py
@@ -407,9 +407,6 @@ FLAG_OFFNEGATIVE: int = 0x80
 which of `MagicMatcher.match`'s two passes a test belongs to.
 """
 
-STRING_DEFAULT_RANGE: int = 100
-"""The ``str_range`` libmagic gives a ``search`` that declared none (``file/src/file.h:433``)."""
-
 REGEX_MAX: int = 8192
 """``FILE_REGEX_MAX``, the hard ceiling libmagic puts on a regular expression's search region.
 
@@ -3467,11 +3464,13 @@ class NumericDataType(DataType[NumericValue]):
 def libmagic_str_range(data_type: DataType) -> int:
     """The ``str_range`` libmagic stores for a string type.
 
-    It is the number the declaration wrote after the type name. A declaration that wrote none
-    leaves the field zero, because the range a `regex` or `search` falls back on is applied when
-    the test runs rather than when it is parsed (``file/src/softmagic.c:1411-1422``). The
-    `SearchType` line below is the one departure from that, which
-    https://github.com/trailofbits/polyfile/issues/3580 tracks.
+    It is the number the declaration wrote after the type name, and zero when it wrote none:
+    ``file/src/apprentice.c:2336`` zeroes the field, and only `parse_string_modifier` writes it
+    (``file/src/apprentice.c:1948``), which a declaration reaches only by carrying a ``/``. The
+    range a `regex` or `search` falls back on is applied when the test runs rather than when it
+    is parsed, and zero is what asks for it: a regular expression reads the fallback out of
+    ``FILE_REGEX_MAX`` (``file/src/softmagic.c:1411-1422``) and a search takes the loop bound
+    ``m->str_range == 0`` leaves unbounded (``file/src/softmagic.c:2357``).
 
     Args:
         data_type: The type a definition declared.
@@ -3481,10 +3480,7 @@ def libmagic_str_range(data_type: DataType) -> int:
     """
     if isinstance(data_type, RegexType):
         return data_type.declared_length or 0
-    string_range = getattr(data_type, "num_bytes", None) or 0
-    if isinstance(data_type, SearchType) and string_range == 0:
-        return STRING_DEFAULT_RANGE
-    return string_range
+    return getattr(data_type, "num_bytes", None) or 0
 
 
 def libmagic_str_flags(data_type: DataType) -> int:

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -2656,7 +2656,7 @@ class MatchOrderTest(TestCase):
 
 
 class StringFlagSortKeyTest(TestCase):
-    """Regression tests for the string modifier bits reported in issue #3568.
+    """Regression tests for the sort key fields reported in issues #3568 and #3580.
 
     `polyfile.magic.STRING_FLAG_BITS` mapped eight of the fifteen `str_flags` bits libmagic
     defines in `file/src/file.h:396-414`, and `libmagic_string_flags` read attribute names that
@@ -2665,12 +2665,15 @@ class StringFlagSortKeyTest(TestCase):
     `MagicTest.libmagic_sort_key`, which is how PolyFile reproduces the `memcmp` tie-break
     `apprentice_sort` applies to tests of equal strength (`file/src/apprentice.c:1132-1149`).
 
+    Issue #3580 is the other half of `str_range`: a `search` that declared no range was given the
+    100 of `STRING_DEFAULT_RANGE`, where libmagic leaves the field zero.
+
     Each definition below declares two tests of equal strength, with descriptions chosen so that
     ordering by description alone, or by the file and line order PolyFile falls back on, would
     give the opposite answer. Every expected order is the order `file -b -k` reports the two
     matches in, checked against libmagic 5.48 built from the `file` submodule over an input both
-    tests match: `b"ABCD\x00\xff\xfe"` for a string, `b"ABCD\n"` for a regular expression, and a
-    zeroed length prefix of the declared width for a Pascal string.
+    tests match: `b"ABCD\x00\xff\xfe"` for a string, `b"ABCD\n"` for a regular expression or a
+    search, and a zeroed length prefix of the declared width for a Pascal string.
     """
 
     @staticmethod
@@ -2738,6 +2741,31 @@ class StringFlagSortKeyTest(TestCase):
         """
         self.assert_second_sorts_first("regex", "regex/8192")
 
+    def test_an_undeclared_search_range_is_not_the_range_a_search_falls_back_on(self):
+        """A `search` that declares no range leaves `str_range` zero, as a bare `regex` does.
+
+        libmagic zeroes the field (`file/src/apprentice.c:2336`) and only `parse_string_modifier`
+        writes it (`file/src/apprentice.c:1948`), which a declaration reaches only by carrying a
+        `/`. The `STRING_DEFAULT_RANGE` of 100 that `string_modifier_check` names beside its
+        warning never reaches a live entry, because the function returns before it unless
+        `MAGIC_CHECK` is set. Zero is not "search nothing" either: it is what asks the search loop
+        to run the whole buffer (`file/src/softmagic.c:2357`), which is why a bare `search` finds
+        a value 300 bytes in where `search/100` does not.
+        """
+        self.assert_second_sorts_first("search", "search/100")
+
+    def test_a_declared_search_range_outranks_an_undeclared_one_either_way_round(self):
+        """`search/1` sorts ahead of a bare `search` whichever of the two lines declares it.
+
+        One line order on its own cannot tell a stored 0 from a stored 100, because a pair that
+        ties falls back to the order the lines were read in and the bare declaration is written
+        first. Reading the pair both ways can: 1 outranks 0, so the declared range has to win from
+        either line, and the second direction rules out a fix that only inverts the line order.
+        `file -b -k` reports `search/1` first both ways round.
+        """
+        self.assert_second_sorts_first("search", "search/1")
+        self.assertEqual(["ZZZ-first", "AAA-second"], self.order("search/1", "search", "ABCD"))
+
     def test_the_line_count_flag_is_part_of_the_key(self):
         """`l` on a regex is `REGEX_LINE_COUNT`, `BIT(11)` (`file/src/file.h:409`).
 
@@ -2797,6 +2825,7 @@ class StringFlagSortKeyTest(TestCase):
         ("string/b", 0, 0x0040),
         ("string/t", 0, 0x0020),
         ("string/Tf", 0, 0x6000),
+        ("search", 0, 0x0000),
         ("search/100", 100, 0x0000),
         ("search/100/s", 100, 0x0010),
         ("regex", 0, 0x0000),
@@ -2843,6 +2872,24 @@ class StringFlagSortKeyTest(TestCase):
             self.assertIn(description, order, "magic_defs/games no longer declares this test")
         for description in unflagged:
             self.assertLess(order.index(flagged), order.index(description))
+
+    def test_a_shipped_bare_search_sorts_behind_its_equals(self):
+        """Tests the range against shipped definitions rather than a synthetic pair.
+
+        `magic_defs/bioinformatics:113` searches for `##fileformat=VCFv` and declares no range,
+        and `magic_defs/sgml:162` searches for a KDE cookie header with a range of 1. Both are
+        strength 47 and both run in the text pass, so the range is all that separates them.
+        `file -m <both definitions> -l` lists the declared range first, and PolyFile listed it
+        last, because a bare `search` sorted as though it had declared 100.
+        """
+        paths = [path for path in MAGIC_DEFS if path.name in ("bioinformatics", "sgml")]
+        self.assertEqual(2, len(paths), "magic_defs no longer ships both definitions")
+        order = [str(test.message) for test in MagicMatcher.parse(*paths)]
+        declared = "Konqueror cookie text"
+        undeclared = "Variant Call Format (VCF)"
+        for description in (declared, undeclared):
+            self.assertIn(description, order, "the definitions no longer declare this test")
+        self.assertLess(order.index(declared), order.index(undeclared))
 
 
 class MatchJoinTest(TestCase):


### PR DESCRIPTION
Closes #3580

## Merge order

This is the last open code item on the v0.6.0 milestone apart from #3583 (issue #3581, the
non-deterministic JSON output). The two touch different files, so merge either first and the
second rebases cleanly. Once both land, the only milestone item left is #3533, cutting the
release. This PR builds on #3582, which split `libmagic_str_range` out of
`libmagic_string_flags`, so it needs that merged first, and it is.

## What libmagic actually stores

The issue asked for the stored value to be established rather than assumed, because the comment on
it read a bare `search`'s runtime behavior as evidence of a non-zero range. Two independent
observations say the stored value is **zero**, and the runtime behavior does not conflict with
that.

**The compiled entry.** `file -C` writes a `struct magic` per entry, and `str_range` is the
`uint32` at byte 24 of the record:

```console
$ printf '0\tsearch\tABC\tfound-bare\n' > bare.magic
$ printf '0\tsearch/100\tABC\tfound-100\n' > r100.magic
$ ./file/src/file -C -m bare.magic; ./file/src/file -C -m r100.magic
$ python3 -c 'import struct
for n in ("bare.magic.mgc", "r100.magic.mgc"):
    rec = open(n, "rb").read()[432:864]
    print(n, "type", rec[6], "str_range", struct.unpack("<I", rec[24:28])[0])'
bare.magic.mgc type 20 str_range 0
r100.magic.mgc type 20 str_range 100
```

**Zero is not "search nothing".** The comment on the issue read `file`'s matching a bare `search`
at a non-zero offset as proof that the 100 had been applied. It is not: the search loop is
`for (idx = 0; m->str_range == 0 || idx < m->str_range; idx++)`
(`file/src/softmagic.c:2357`), so zero asks for the whole buffer rather than for nothing. A bare
`search` therefore reaches **further** than `search/100`, not less far:

```console
$ python3 -c "open('far.bin','wb').write(b'x'*300 + b'ABC' + b'yy\n')"
$ ./file/src/file -b -m bare.magic far.bin
found-bare, ASCII text, with very long lines (305)
$ ./file/src/file -b -m r100.magic far.bin
ASCII text, with very long lines (305)
```

That agrees with the parse path: `file/src/apprentice.c:2336` zeroes `str_range`, and only
`parse_string_modifier` writes it (`file/src/apprentice.c:1948`), which a declaration reaches only
by carrying a `/`. The `STRING_DEFAULT_RANGE` of 100 that `string_modifier_check` names
(`file/src/apprentice.c:1769-1776`) is behind an early `return 0` that fires unless `MAGIC_CHECK`
is set, so it never reaches a live entry.

**The ordering agrees.** `apprentice_sort` settles a tie in strength with a `memcmp` over the
whole `struct magic` (`file/src/apprentice.c:1132-1149`), and a larger `str_range` sorts first. A
declared range therefore outranks an undeclared one whichever line writes it, which a stored 100
could not produce for `search/1`:

```console
$ printf 'ABCD\n' > in.bin
$ printf '0\tsearch\tABCD\tZZZ-first\n0\tsearch/1\tABCD\tAAA-second\n' > a.magic
$ ./file/src/file -b -k -m a.magic in.bin
AAA-second\012- ZZZ-first, ASCII text
$ printf '0\tsearch/1\tABCD\tZZZ-first\n0\tsearch\tABCD\tAAA-second\n' > b.magic
$ ./file/src/file -b -k -m b.magic in.bin
ZZZ-first\012- AAA-second, ASCII text
```

## Reproducer

The pair from the issue comment, with descriptions chosen so that ordering by description alone,
or by the line order PolyFile falls back on for a tie, would give the opposite answer.

```
0	search		ABC	ZZZ-bare
0	search/100	ABC	AAA-explicit
```

| | order |
| --- | --- |
| `file -b -k` | `AAA-explicit\012- ZZZ-bare, ASCII text` |
| before | `['ZZZ-bare', 'AAA-explicit']` |
| after | `['AAA-explicit', 'ZZZ-bare']` |

Before the fix both declarations produced the same eight bytes, `6400000000000000`, so the pair
tied and fell back to line order. After it the bare declaration produces `0000000000000000`.

## What the fix does

`libmagic_str_range` gave a `SearchType` with no declared range `STRING_DEFAULT_RANGE`. It now
returns the declared number for every string type and zero when the declaration wrote none, which
is what the compiled entry holds. `SearchType` already records an undeclared range as
`num_bytes = None` and `SearchType.declaration` already leaves the number out of the type's name,
so `search` and `search/100` were already distinct interned types; unlike the `regex` case in
#3582 there was no effective-versus-declared length to separate, only the wrong constant. The now
unused `STRING_DEFAULT_RANGE` goes with it, and the docstring records where the 100 lives in
libmagic and why it never reaches an entry.

Match time is unchanged: `SearchType.repetitions` still reports `None` for an undeclared range,
which is PolyFile's spelling of the unbounded loop bound at `file/src/softmagic.c:2357`.

## What the tests pin

Three methods and one subtest in `StringFlagSortKeyTest` (`tests/test_magic.py`):

- `test_an_undeclared_search_range_is_not_the_range_a_search_falls_back_on` is the reproducer:
  `search` against `search/100`.
- `test_a_declared_search_range_outranks_an_undeclared_one_either_way_round` reads `search`
  against `search/1` from both line orders. One line order alone cannot tell a stored 0 from a
  stored 100, because the buggy pair ties and the tie falls back to line order; 1 outranks 0 but
  loses to 100, so the declared range has to win from either line.
- `test_a_shipped_bare_search_sorts_behind_its_equals` runs the check over shipped definitions
  rather than a synthetic pair. `magic_defs/bioinformatics:113` searches for `##fileformat=VCFv`
  with no range and `magic_defs/sgml:162` searches for a KDE cookie header with a range of 1.
  Both are strength 47 and both run in the text pass, and `file -m <both> -l` lists the declared
  range first.
- `FLAG_WORDS` gains `("search", 0, 0x0000)`, so the stored value is pinned as well as the order.

Reverting `polyfile/magic.py` to master fails all three methods and that subtest.

## Verification

- Every reordered pair checked against the reference binary. The fix moves 22 level 0 tests
  within the text pass and **none** within the binary pass, and the pass assignment of all 3,874
  level 0 tests is unchanged. Of the 20 adjacent pairs it swaps, 19 are same-pass and therefore
  adjudicable; `file -m <the two definition files> -l` puts the declared range ahead of the bare
  one in **all 19**, which is the new order. The twentieth pair
  (`bioinformatics:113` against `tex:49`) spans the binary and text passes, so libmagic never
  compares the two at match time.
- Corpus differential over all 88 `file/tests` stems, comparing the full ordered match list and
  the `-k` join, master against this branch: **0 stems change**, so no stem's strongest match
  moves.
- Parity differential against `file -m <definition> -l`, which lists each definition file's level
  0 tests in the order libmagic sorted them: **329 of 344 before, 329 after**, and no file
  regressed. The reordering this fixes is between definition files, which a per-file comparison
  cannot see.
- `uv run pytest tests --ignore=tests/test_corkami.py`: 364 passed, 1,461 subtests passed. 361 and
  1,460 on master, so the three new methods and the new subtest are the difference.
- `uv run pytest tests/test_corkami.py`: 906 passed, 1 skipped, unchanged.
- `uv run flake8 polyfile polymerge tests build_backend.py compile_kaitai_parsers.py
  --exclude polyfile/kaitai/parsers --count --select=E9,F63,F7,F82 --show-source --statistics`: 0.
- `uv run flake8 ... --max-complexity=10 --max-line-length=127` reports the same findings for
  `polyfile/magic.py` before and after, and none for `tests/test_magic.py`.
- `uvx pip-audit`: no known vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
