### PR TITLE
Ship CHANGELOG.md in the distributions and record the process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ polyfile/trie_partial.gz
 .vscode/*
 polyfile/kaitai/kaitai-struct-compiler-*/
 
+# Release notes: CHANGELOG.md is the source, and a working file per release is not tracked
+/polyfile_*.md
+
 # Build artifacts
 /build/
 /dist/

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,8 @@ polyfile/kaitai/kaitai-struct-compiler-*/
 /dist/
 /*.egg-info/
 
+# Staged by build_backend.py from the CHANGELOG.md at the repository root
+/polyfile/CHANGELOG.md
+
 # uv resolves dependencies fresh across Python 3.10-3.14 in CI, so a lock file is not tracked
 uv.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ polyfile/
 ├── tests/                     # Test suite
 ├── docs/                      # Extension guide, JSON format spec
 ├── kaitai_struct_formats/     # Git submodule with KSY definitions
+├── CHANGELOG.md               # Release notes; the source of every GitHub release body
 ├── pyproject.toml             # Packaging metadata
 ├── build_backend.py           # In-tree PEP 517 backend; regenerates the Kaitai parsers
 ├── compile_kaitai_parsers.py  # Kaitai compilation and license audit
@@ -95,6 +96,29 @@ uvx twine check dist/*
 
 There is no `setup.py`. `pyproject.toml` selects `build_backend.py`, an in-tree PEP 517 backend
 that regenerates the Kaitai parsers for wheel, sdist and editable builds.
+
+### Release notes
+
+`CHANGELOG.md` at the repository root is the only place release notes are written, and every GitHub
+release body is extracted from it. A release adds a section to that file. Do not create a
+standalone `polyfile_#.#.#.md` working file; `polyfile_*.md` is gitignored.
+
+1. Add a `## [<version>] - <YYYY-MM-DD>` section at the top of `CHANGELOG.md`, in
+   [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format, and add the version's compare
+   link to the list at the end of the file. Use the `Added`, `Changed`, `Deprecated`, `Removed`,
+   `Fixed`, and `Security` headings, omit the ones with nothing under them, and mark an entry that
+   changes observable output, the command line, or the Python API with **Breaking**.
+2. Extract that section for the release body, so the two cannot disagree:
+
+```bash
+VERSION=0.6.0
+awk -v v="$VERSION" '/^## \[/{if(p)exit; if($0 ~ "^## \\["v"\\] "){p=1;next}} p' CHANGELOG.md \
+    | gh release create "v$VERSION" --draft --notes-file -
+```
+
+`MANIFEST.in` ships the root copy in the source distribution, and `build_backend.py` stages a copy
+into `polyfile/` so that the wheel carries it too. That staged `polyfile/CHANGELOG.md` is a build
+artifact: it is gitignored, and never edited by hand.
 
 ### Linting
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,7 @@
+include CHANGELOG.md
+# build_backend.py stages a copy inside the package so that the wheel carries it; the
+# source distribution needs only the one at the root.
+exclude polyfile/CHANGELOG.md
 include compile_kaitai_parsers.py
 include build_backend.py
 include CODEOWNERS

--- a/build_backend.py
+++ b/build_backend.py
@@ -2,7 +2,11 @@
 
 PolyFile's Kaitai Struct parsers are generated at build time, so a build has to run
 ``compile_kaitai_parsers.rebuild()`` before setuptools collects the files that go into a
-distribution. This module wraps :mod:`setuptools.build_meta` to do that, and nothing else.
+distribution. This module wraps :mod:`setuptools.build_meta` to do that, and to stage
+``CHANGELOG.md`` inside the ``polyfile`` package, which is the only way a wheel can carry a file
+that lives at the repository root. The source distribution takes the root copy through
+``MANIFEST.in``, so the two builds that produce an installable tree stage it and ``build_sdist``
+does not.
 
 Only the three hooks that produce a distribution regenerate the parsers. The metadata hooks and
 the ``get_requires_for_build_*`` hooks are re-exported unchanged, so tools that want nothing but
@@ -16,6 +20,7 @@ because importing it runs ``git submodule init`` and ``git submodule update`` wh
 format library is missing.
 """
 
+import shutil
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -35,6 +40,22 @@ GENERATED_MANIFEST: Path = PROJECT_ROOT / "polyfile" / "kaitai" / "parsers" / "m
 
 # A source distribution always carries a PKG-INFO at its root; a checkout never does.
 SDIST_MARKER: Path = PROJECT_ROOT / "PKG-INFO"
+
+# CHANGELOG.md sits at the repository root, which is where GitHub renders it and where
+# MANIFEST.in takes it from for the source distribution. A wheel carries only what lives inside
+# a package, so a copy is staged into polyfile/ and declared as package data in pyproject.toml.
+CHANGELOG: Path = PROJECT_ROOT / "CHANGELOG.md"
+PACKAGED_CHANGELOG: Path = PROJECT_ROOT / "polyfile" / "CHANGELOG.md"
+
+
+def _stage_changelog() -> None:
+    """Copies the changelog into the ``polyfile`` package so that a wheel carries it."""
+    if not CHANGELOG.is_file():
+        raise FileNotFoundError(
+            f"{CHANGELOG} is missing: it is the source of PolyFile's release notes, and every "
+            f"distribution ships it"
+        )
+    shutil.copyfile(CHANGELOG, PACKAGED_CHANGELOG)
 
 
 def _rebuild_parsers() -> None:
@@ -60,6 +81,7 @@ def build_wheel(
     metadata_directory: Optional[str] = None,
 ) -> str:
     _rebuild_parsers()
+    _stage_changelog()
     return _setuptools.build_wheel(wheel_directory, config_settings, metadata_directory)
 
 
@@ -69,6 +91,7 @@ def build_editable(
     metadata_directory: Optional[str] = None,
 ) -> str:
     _rebuild_parsers()
+    _stage_changelog()
     return _setuptools.build_editable(wheel_directory, config_settings, metadata_directory)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,6 @@ namespaces = false
 # still have to be declared here. polyfile/magic.py enumerates the installed magic_defs
 # directory, so an omission changes which file types PolyFile can detect.
 [tool.setuptools.package-data]
-polyfile = ["templates/*"]
+polyfile = ["templates/*", "CHANGELOG.md"]
 "polyfile.kaitai.parsers" = ["*.py", "manifest.json"]
 "polyfile.magic_defs" = ["*"]


### PR DESCRIPTION
Follow-on work for the changelog, split out from the direct commit `cebe966` that added
`CHANGELOG.md` and deleted `polyfile_0.6.0.md` (refs #3587). That commit deliberately touched
nothing but those two files; this is everything else the issue lists under "Follow-on, not part of
the direct commit".

## Merge order

No other pull requests are open, and nothing depends on this one. It sits on top of `cebe966` on
`master`. Merge it before publishing the v0.6.0 draft release if you want the published sdist and
wheel to carry the changelog; the draft's body already comes from `CHANGELOG.md` either way.

## What this changes

**The distributions carry `CHANGELOG.md`.** `MANIFEST.in` listed no documentation at all, so a PyPI
install had no in-tree record of what changed. `include CHANGELOG.md` covers the source
distribution. A wheel holds only what lives inside a package, so `build_backend.py` stages a copy
into `polyfile/` from the two hooks that produce an installable tree, `pyproject.toml` declares it
as package data, and `MANIFEST.in` excludes the staged copy so the source distribution carries the
root one alone. `build_sdist` does not stage, because the source distribution takes the root copy
through `MANIFEST.in`; the `exclude` is what keeps a developer's leftover staged copy out of it.

The staged `polyfile/CHANGELOG.md` is a build artifact: it is gitignored, and `_stage_changelog`
raises `FileNotFoundError` naming the path rather than building a distribution without it.

**`polyfile_*.md` is ignored.** `polyfile_0.5.6.md` has shown up as untracked since February, and
`polyfile_0.6.0.md` was committed by accident. A per-release working file is no longer part of the
process, so a leftover one no longer shows the tree as dirty. The file on disk is untouched.

**`CLAUDE.md` records the process** beside the existing build steps: a release adds a section to
`CHANGELOG.md` and extracts it for the release body, rather than creating a standalone file. The
extraction command in the doc is the one that produced the current v0.6.0 draft body.

## Verification

```
uv build
  sdist: polyfile-0.6.0/CHANGELOG.md           (33,818 bytes, identical to the source)
  wheel: polyfile/CHANGELOG.md                 (33,818 bytes, identical to the source)
  neither artifact carries the file twice

uvx twine check dist/*                          PASSED, PASSED
uv pip install -e .                             stages the copy; importlib.resources reads it back
flake8 (blocking pass, CI settings)             0
flake8 build_backend.py (advisory pass)         0
pytest tests --ignore=tests/test_corkami.py     368 passed, 1464 subtests passed
pytest tests/test_licensing.py                  3 passed, 189 subtests passed
```

`tests/test_licensing.py` reads `MANIFEST.in`, so it is called out separately: it parses only lines
beginning `exclude kaitai_struct_formats/`, and the new `exclude polyfile/CHANGELOG.md` does not
disturb it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017o8f2HYDiPKJ31Pj5YnJEC
